### PR TITLE
test(switch-button): add missing watchers tests

### DIFF
--- a/packages/ui-components/src/components/switch-button/test/switch-button.e2e.ts
+++ b/packages/ui-components/src/components/switch-button/test/switch-button.e2e.ts
@@ -26,6 +26,8 @@ describe('Switch Button (end-to-end)', () => {
 
 				const buttonElement = await page.find('kv-switch-button >>> .switch-button');
 				await buttonElement.click()
+
+				await page.waitForTimeout(300)
 			})
 
 			it('should change `state` to `ON`', async () => {
@@ -65,8 +67,11 @@ describe('Switch Button (end-to-end)', () => {
 			beforeEach(async () => {
 				switchButtonElement = await page.find('kv-switch-button')
 				spyStateChangeEvent = await switchButtonElement.spyOnEvent('switchStateChange');
+
 				const buttonElement = await page.find('kv-switch-button >>> .switch-button');
 				await buttonElement.click()
+
+				await page.waitForTimeout(300)
 			})
 
 			it('should not change `state` to `ON`', async () => {
@@ -95,6 +100,8 @@ describe('Switch Button (end-to-end)', () => {
 
 				const buttonElement = await page.find('kv-switch-button >>> .switch-button');
 				await buttonElement.click()
+
+				await page.waitForTimeout(300)
 			})
 
 			it('should change `state` to `OFF`', async () => {

--- a/packages/ui-components/src/components/switch-button/test/switch-button.spec.tsx
+++ b/packages/ui-components/src/components/switch-button/test/switch-button.spec.tsx
@@ -1,6 +1,7 @@
 import { SpecPage } from '@stencil/core/internal';
 import { KvSwitchButton } from '../switch-button';
 import { newSpecPage } from '@stencil/core/testing';
+import { ESwitchButtonState } from '../switch-button.types';
 
 describe('Switch Button (unit tests)', () => {
 	let page: SpecPage;
@@ -44,6 +45,16 @@ describe('Switch Button (unit tests)', () => {
 		it('should initialize `hasLabel` with true', () => {
 			expect(component.hasLabel).toBe(true)
 		});
+
+		describe('and the label is removed', () => {
+			beforeEach(() => {
+				page.root.setAttribute('label', '');
+			});
+
+			it('should change `hasLabel` to false', () => {
+				expect(component.hasLabel).toBe(false)
+			});
+		})
 	})
 
 	describe('when is disabled', () => {
@@ -58,6 +69,20 @@ describe('Switch Button (unit tests)', () => {
 		it('should match the snapshot', () => {
 			expect(page.root).toMatchSnapshot();
 		});
+
+		it('should initialize `isDisabled` with true', () => {
+			expect(component.isDisabled).toBe(true)
+		});
+
+		describe('and it\s enabled', () => {
+			beforeEach(() => {
+				page.root.removeAttribute('disabled');
+			});
+
+			it('should change `isDisabled` to false', () => {
+				expect(component.isDisabled).toBe(false)
+			});
+		})
 	});
 
 	describe('when is ON', () => {
@@ -76,5 +101,15 @@ describe('Switch Button (unit tests)', () => {
 		it('should initialize `isOn` with true', () => {
 			expect(component.isOn).toBe(true)
 		});
+
+		describe('and it\s turned OFF', () => {
+			beforeEach(() => {
+				page.root.setAttribute('state', ESwitchButtonState.OFF);
+			});
+
+			it('should change `isOn` to false', () => {
+				expect(component.isOn).toBe(false)
+			});
+		})
 	});
 });

--- a/packages/ui-components/stencil.config.ts
+++ b/packages/ui-components/stencil.config.ts
@@ -53,7 +53,7 @@ export const config: Config = {
 		moduleNameMapper: {
 			'^lodash-es$': 'lodash'
 		},
-		testRegex: "(\.(test|spec))\.(tsx?|jsx?)$",
+		testRegex: "(\.(test|spec|e2e))\.(tsx?|jsx?)$",
 		collectCoverage: true,
 		moduleFileExtensions: [
 			"ts",


### PR DESCRIPTION
### Description

Add missing watchers tests to the `kv-switch-button` component to improve coverage.