### PR TITLE
fix(kv-link): fix anchor tag styling

### DIFF
--- a/packages/ui-components/src/components/link/link.scss
+++ b/packages/ui-components/src/components/link/link.scss
@@ -7,6 +7,7 @@
 
 		.label {
 			@include kv-font-h5-semibold();
+			text-decoration: none;
 			color: kv-color('text');
 			cursor: pointer;
 


### PR DESCRIPTION
removes the default anchor tag underline and only shows it when hovering