### PR TITLE
chore(package.json): fix react dependency notation

### DIFF
--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -77,8 +77,8 @@
 		"typescript": "^4.5.5"
 	},
 	"peerDependencies": {
-		"react": ">=^17.0.2",
-		"react-dom": ">=^17.0.2"
+		"react": ">=17.0.2",
+		"react-dom": ">=17.0.2"
 	},
 	"jest": {
 		"preset": "ts-jest",


### PR DESCRIPTION
#### Description

Currently when adding the react `@kelvininc/react-ui-components` dependency to a project we get the error:
```
code EINVALIDTAGNAME
Invalid tag name ">=^17.0.2": Tags may not have any characters that encodeURIComponent encodes.
````

This PR fixes it by fixing the dependency notation.