### PR TITLE
fix(switch-button): refactor component props and state

### DIFF
--- a/packages/react-ui-components/src/stories/Components/SwitchButton.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/SwitchButton.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentStory } from '@storybook/react';
 import React from 'react';
-import { ESwitchButtonState, ESwitchButtonSize, KvSwitchButton } from '../../components';
+import { ESwitchButtonSize, KvSwitchButton } from '../../components';
 
 // Required to have the correct TagName in the code sample
 KvSwitchButton.displayName = 'KvSwitchButton';
@@ -9,10 +9,6 @@ export default {
 	title: 'Components/Buttons/Switch',
 	component: 'kv-switch-button',
 	argTypes: {
-		state: {
-			control: { type: 'select' },
-			options: Object.values(ESwitchButtonState)
-		},
 		size: {
 			control: { type: 'select' },
 			options: Object.values(ESwitchButtonSize)
@@ -28,7 +24,7 @@ const SwitchButtonTemplate: ComponentStory<typeof KvSwitchButton> = args => <KvS
 export const DefaultState = SwitchButtonTemplate.bind(this);
 DefaultState.args = {
 	label: 'Switch',
-	state: ESwitchButtonState.OFF,
-	size: ESwitchButtonSize.Large,
-	disabled: false
+	checked: false,
+	disabled: false,
+	size: ESwitchButtonSize.Large
 };

--- a/packages/ui-components/src/components/switch-button/readme.md
+++ b/packages/ui-components/src/components/switch-button/readme.md
@@ -86,17 +86,17 @@ export class SwichButtonExample {
 
 | Property   | Attribute  | Description                                 | Type                                                 | Default                   |
 | ---------- | ---------- | ------------------------------------------- | ---------------------------------------------------- | ------------------------- |
+| `checked`  | `checked`  | (optional) If `true` the button is ON       | `boolean`                                            | `false`                   |
 | `disabled` | `disabled` | (optional) If `true` the button is disabled | `boolean`                                            | `false`                   |
 | `label`    | `label`    | (optional) Button's label                   | `string`                                             | `''`                      |
 | `size`     | `size`     | (optional) Button's size                    | `ESwitchButtonSize.Large \| ESwitchButtonSize.Small` | `ESwitchButtonSize.Large` |
-| `state`    | `state`    | (optional) If `ON` the button is ON         | `ESwitchButtonState.OFF \| ESwitchButtonState.ON`    | `ESwitchButtonState.OFF`  |
 
 
 ## Events
 
-| Event               | Description                         | Type                                                           |
-| ------------------- | ----------------------------------- | -------------------------------------------------------------- |
-| `switchStateChange` | Emitted when switch's state changes | `CustomEvent<ESwitchButtonState.OFF \| ESwitchButtonState.ON>` |
+| Event          | Description                         | Type                   |
+| -------------- | ----------------------------------- | ---------------------- |
+| `switchChange` | Emitted when switch's state changes | `CustomEvent<boolean>` |
 
 
 ## Shadow Parts

--- a/packages/ui-components/src/components/switch-button/switch-button.scss
+++ b/packages/ui-components/src/components/switch-button/switch-button.scss
@@ -14,11 +14,11 @@ $sqr-sizes: (
 	'large': 16px
 );
 $sqr-paddings-x: (
-	'small': 2.3px,
+	'small': 2.5px,
 	'large': 2px
 );
 $sqr-paddings-y: (
-	'small': 2.7px,
+	'small': 2.5px,
 	'large': 2px
 );
 $icon-sizes: (
@@ -109,11 +109,11 @@ $icon-sizes: (
 		}
 	}
 
-	&--lg {
+	&--large {
 		@include button-theme('large');
 	}
 
-	&--sm {
+	&--small {
 		@include button-theme('small');
 	}
 }
@@ -130,6 +130,6 @@ $icon-sizes: (
 	font-size: 0;
 
 	kv-svg-icon {
-		--icon-color: var(--off-background-color);
+		--icon-color: #{var(--off-background-color)};
 	}
 }

--- a/packages/ui-components/src/components/switch-button/switch-button.tsx
+++ b/packages/ui-components/src/components/switch-button/switch-button.tsx
@@ -1,5 +1,5 @@
 import { Component, Event, EventEmitter, Host, Prop, State, Watch, h } from '@stencil/core';
-import { ESwitchButtonSize, ESwitchButtonState } from './switch-button.types';
+import { ESwitchButtonSize } from './switch-button.types';
 import throttle from 'lodash/throttle';
 
 /**
@@ -24,43 +24,26 @@ export class KvSwitchButton {
 
 	/** (optional) If `true` the button is disabled */
 	@Prop({ reflect: true }) disabled: boolean = false;
-
-	/** Watch `disabled` property for changes and update `isDisabled` accordingly */
-	@Watch('disabled')
-	disabledHandler(newValue: boolean) {
-		this.isDisabled = newValue === true;
-	}
-
-	/** (optional) If `ON` the button is ON */
-	@Prop({ reflect: true, mutable: true }) state: ESwitchButtonState = ESwitchButtonState.OFF;
+	/** (optional) If `true` the button is ON */
+	@Prop({ reflect: true, mutable: true }) checked: boolean = false;
 	/** (optional) Button's size */
 	@Prop() size: ESwitchButtonSize = ESwitchButtonSize.Large;
 
-	/** Watch `state` property for changes and update `isOn` accordingly */
-	@Watch('state')
-	stateHandler(newValue: ESwitchButtonState) {
-		this.isOn = newValue === ESwitchButtonState.ON;
-	}
-
 	/** Whether the label exist and it's not empty */
 	@State() hasLabel: boolean = this.label != null && this.label !== '';
-	/** Whether the state is ON or `true` */
-	@State() isOn: boolean = this.state === ESwitchButtonState.ON;
-	/** Whether the state is ON or `true` */
-	@State() isDisabled: boolean = this.disabled === true;
 
 	/** Emitted when switch's state changes */
-	@Event() switchStateChange: EventEmitter<ESwitchButtonState>;
+	@Event() switchChange: EventEmitter<boolean>;
 
 	private onSwitchClick: () => void;
 
 	private onStateChange() {
-		if (this.isDisabled) {
+		if (this.disabled) {
 			return;
 		}
 
-		this.state = this.isOn ? ESwitchButtonState.OFF : ESwitchButtonState.ON;
-		this.switchStateChange.emit(this.state);
+		this.checked = !this.checked;
+		this.switchChange.emit(this.checked);
 	}
 
 	connectedCallback() {
@@ -68,7 +51,7 @@ export class KvSwitchButton {
 	}
 
 	render() {
-		const iconName = this.isDisabled ? 'kv-lock' : 'kv-done-all';
+		const iconName = this.disabled ? 'kv-lock' : 'kv-done-all';
 
 		return (
 			<Host>
@@ -78,10 +61,9 @@ export class KvSwitchButton {
 						<div
 							class={{
 								'switch-button': true,
-								'switch-button--disabled': this.isDisabled,
-								'switch-button--on': this.isOn,
-								'switch-button--lg': this.size === ESwitchButtonSize.Large,
-								'switch-button--sm': this.size === ESwitchButtonSize.Small
+								'switch-button--disabled': this.disabled,
+								'switch-button--on': this.checked,
+								[`switch-button--${this.size}`]: true
 							}}
 							part="button"
 							onClick={this.onSwitchClick}

--- a/packages/ui-components/src/components/switch-button/switch-button.types.tsx
+++ b/packages/ui-components/src/components/switch-button/switch-button.types.tsx
@@ -1,9 +1,4 @@
-export enum ESwitchButtonState {
-	ON = 'on',
-	OFF = 'off'
-}
-
 export enum ESwitchButtonSize {
-	Small = 'sm',
-	Large = 'lg'
+	Small = 'small',
+	Large = 'large'
 }

--- a/packages/ui-components/src/components/switch-button/test/__snapshots__/switch-button.spec.tsx.snap
+++ b/packages/ui-components/src/components/switch-button/test/__snapshots__/switch-button.spec.tsx.snap
@@ -1,48 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Switch Button (unit tests) when has a label should match the snapshot 1`] = `
-<kv-switch-button label="Switch" state="off">
+<kv-switch-button label="Switch">
   <mock:shadow-root>
     <div class="switch-button-container">
       <span class="label">
         Switch
       </span>
       <div class="switch-button-content">
-        <div class="switch-button switch-button--lg" part="button">
+        <div class="switch-button switch-button--large" part="button">
           <div class="icon-square" part="icon-square">
             <kv-svg-icon name="kv-done-all" part="icon-svg"></kv-svg-icon>
-          </div>
-        </div>
-      </div>
-    </div>
-  </mock:shadow-root>
-</kv-switch-button>
-`;
-
-exports[`Switch Button (unit tests) when is ON should match the snapshot 1`] = `
-<kv-switch-button state="on">
-  <mock:shadow-root>
-    <div class="switch-button-container">
-      <div class="switch-button-content">
-        <div class="switch-button switch-button--lg switch-button--on" part="button">
-          <div class="icon-square" part="icon-square">
-            <kv-svg-icon name="kv-done-all" part="icon-svg"></kv-svg-icon>
-          </div>
-        </div>
-      </div>
-    </div>
-  </mock:shadow-root>
-</kv-switch-button>
-`;
-
-exports[`Switch Button (unit tests) when is disabled should match the snapshot 1`] = `
-<kv-switch-button disabled="" state="off">
-  <mock:shadow-root>
-    <div class="switch-button-container">
-      <div class="switch-button-content">
-        <div class="switch-button switch-button--disabled switch-button--lg" part="button">
-          <div class="icon-square" part="icon-square">
-            <kv-svg-icon name="kv-lock" part="icon-svg"></kv-svg-icon>
           </div>
         </div>
       </div>
@@ -52,11 +20,11 @@ exports[`Switch Button (unit tests) when is disabled should match the snapshot 1
 `;
 
 exports[`Switch Button (unit tests) when uses default props should match the snapshot 1`] = `
-<kv-switch-button state="off">
+<kv-switch-button>
   <mock:shadow-root>
     <div class="switch-button-container">
       <div class="switch-button-content">
-        <div class="switch-button switch-button--lg" part="button">
+        <div class="switch-button switch-button--large" part="button">
           <div class="icon-square" part="icon-square">
             <kv-svg-icon name="kv-done-all" part="icon-svg"></kv-svg-icon>
           </div>

--- a/packages/ui-components/src/components/switch-button/test/switch-button.e2e.ts
+++ b/packages/ui-components/src/components/switch-button/test/switch-button.e2e.ts
@@ -1,7 +1,5 @@
 import { E2EElement, E2EPage, EventSpy, newE2EPage } from '@stencil/core/testing';
 
-import { ESwitchButtonState } from '../switch-button.types';
-
 describe('Switch Button (end-to-end)', () => {
 	let page: E2EPage;
 
@@ -17,12 +15,12 @@ describe('Switch Button (end-to-end)', () => {
 		});
 
 		describe('and user clicks on the button', () => {
-			let spyStateChangeEvent: EventSpy;
+			let spyChangeEvent: EventSpy;
 			let switchButtonElement: E2EElement;
 
 			beforeEach(async () => {
 				switchButtonElement = await page.find('kv-switch-button');
-				spyStateChangeEvent = await switchButtonElement.spyOnEvent('switchStateChange');
+				spyChangeEvent = await switchButtonElement.spyOnEvent('switchChange');
 
 				const buttonElement = await page.find('kv-switch-button >>> .switch-button');
 				await buttonElement.click();
@@ -30,13 +28,12 @@ describe('Switch Button (end-to-end)', () => {
 				await page.waitForTimeout(300);
 			});
 
-			it('should change `state` to `ON`', async () => {
-				expect(switchButtonElement).toHaveAttribute('state');
-				expect(switchButtonElement).toEqualAttribute('state', ESwitchButtonState.ON);
+			it('should change `checked` to true', async () => {
+				expect(switchButtonElement).toHaveAttribute('checked');
 			});
 
-			it('should emit `true` state', () => {
-				expect(spyStateChangeEvent).toHaveReceivedEventDetail(ESwitchButtonState.ON);
+			it('should emit switchChange event with true', () => {
+				expect(spyChangeEvent).toHaveReceivedEventDetail(true);
 			});
 		});
 	});
@@ -61,12 +58,12 @@ describe('Switch Button (end-to-end)', () => {
 		});
 
 		describe('and user clicks on the button', () => {
-			let spyStateChangeEvent: EventSpy;
+			let spyChangeEvent: EventSpy;
 			let switchButtonElement: E2EElement;
 
 			beforeEach(async () => {
 				switchButtonElement = await page.find('kv-switch-button');
-				spyStateChangeEvent = await switchButtonElement.spyOnEvent('switchStateChange');
+				spyChangeEvent = await switchButtonElement.spyOnEvent('switchChange');
 
 				const buttonElement = await page.find('kv-switch-button >>> .switch-button');
 				await buttonElement.click();
@@ -74,12 +71,12 @@ describe('Switch Button (end-to-end)', () => {
 				await page.waitForTimeout(300);
 			});
 
-			it('should not change `state` to `ON`', async () => {
-				expect(switchButtonElement).toEqualAttribute('state', ESwitchButtonState.OFF);
+			it('should not change `checked` to true', async () => {
+				expect(switchButtonElement).not.toHaveAttribute('checked');
 			});
 
-			it('should not emit `true` state', () => {
-				expect(spyStateChangeEvent).not.toHaveReceivedEvent();
+			it('should not emit switchChange event', () => {
+				expect(spyChangeEvent).not.toHaveReceivedEvent();
 			});
 		});
 	});
@@ -87,16 +84,16 @@ describe('Switch Button (end-to-end)', () => {
 	describe('when is ON', () => {
 		beforeEach(async () => {
 			page = await newE2EPage();
-			await page.setContent('<kv-switch-button state="on"></kv-switch-button>');
+			await page.setContent('<kv-switch-button checked></kv-switch-button>');
 		});
 
 		describe('and user clicks on the switch', () => {
-			let spyStateChangeEvent: EventSpy;
+			let spyChangeEvent: EventSpy;
 			let switchButtonElement: E2EElement;
 
 			beforeEach(async () => {
 				switchButtonElement = await page.find('kv-switch-button');
-				spyStateChangeEvent = await switchButtonElement.spyOnEvent('switchStateChange');
+				spyChangeEvent = await switchButtonElement.spyOnEvent('switchChange');
 
 				const buttonElement = await page.find('kv-switch-button >>> .switch-button');
 				await buttonElement.click();
@@ -104,13 +101,12 @@ describe('Switch Button (end-to-end)', () => {
 				await page.waitForTimeout(300);
 			});
 
-			it('should change `state` to `OFF`', async () => {
-				expect(switchButtonElement).toHaveAttribute('state');
-				expect(switchButtonElement).toEqualAttribute('state', ESwitchButtonState.OFF);
+			it('should change `checked` to false', async () => {
+				expect(switchButtonElement).not.toHaveAttribute('checked');
 			});
 
-			it('should emit `OFF` state', () => {
-				expect(spyStateChangeEvent).toHaveReceivedEventDetail(ESwitchButtonState.OFF);
+			it('should emit switchChange event with false', () => {
+				expect(spyChangeEvent).toHaveReceivedEventDetail(false);
 			});
 		});
 	});

--- a/packages/ui-components/src/components/switch-button/test/switch-button.spec.tsx
+++ b/packages/ui-components/src/components/switch-button/test/switch-button.spec.tsx
@@ -1,7 +1,7 @@
 import { SpecPage } from '@stencil/core/internal';
 import { KvSwitchButton } from '../switch-button';
 import { newSpecPage } from '@stencil/core/testing';
-import { ESwitchButtonState } from '../switch-button.types';
+import { ESwitchButtonSize } from '../switch-button.types';
 
 describe('Switch Button (unit tests)', () => {
 	let page: SpecPage;
@@ -20,8 +20,20 @@ describe('Switch Button (unit tests)', () => {
 			expect(page.root).toMatchSnapshot();
 		});
 
-		it('should initialize `isOn` with false', () => {
-			expect(component.isOn).toBe(false);
+		it('should initialize `checked` with false', () => {
+			expect(component.checked).toBe(false);
+		});
+
+		it('should initialize `disabled` with false', () => {
+			expect(component.disabled).toBe(false);
+		});
+
+		it('should initialize `size` with large', () => {
+			expect(component.size).toBe(ESwitchButtonSize.Large);
+		});
+
+		it('should initialize `label` with empty string', () => {
+			expect(component.label).toBe('');
 		});
 
 		it('should initialize `hasLabel` with false', () => {
@@ -53,62 +65,6 @@ describe('Switch Button (unit tests)', () => {
 
 			it('should change `hasLabel` to false', () => {
 				expect(component.hasLabel).toBe(false);
-			});
-		});
-	});
-
-	describe('when is disabled', () => {
-		beforeEach(async () => {
-			page = await newSpecPage({
-				components: [KvSwitchButton],
-				html: `<kv-switch-button disabled></kv-switch-button>`
-			});
-			component = page.rootInstance;
-		});
-
-		it('should match the snapshot', () => {
-			expect(page.root).toMatchSnapshot();
-		});
-
-		it('should initialize `isDisabled` with true', () => {
-			expect(component.isDisabled).toBe(true);
-		});
-
-		describe('and its enabled', () => {
-			beforeEach(() => {
-				page.root.removeAttribute('disabled');
-			});
-
-			it('should change `isDisabled` to false', () => {
-				expect(component.isDisabled).toBe(false);
-			});
-		});
-	});
-
-	describe('when is ON', () => {
-		beforeEach(async () => {
-			page = await newSpecPage({
-				components: [KvSwitchButton],
-				html: `<kv-switch-button state="on"></kv-switch-button>`
-			});
-			component = page.rootInstance;
-		});
-
-		it('should match the snapshot', () => {
-			expect(page.root).toMatchSnapshot();
-		});
-
-		it('should initialize `isOn` with true', () => {
-			expect(component.isOn).toBe(true);
-		});
-
-		describe('and its turned OFF', () => {
-			beforeEach(() => {
-				page.root.setAttribute('state', ESwitchButtonState.OFF);
-			});
-
-			it('should change `isOn` to false', () => {
-				expect(component.isOn).toBe(false);
 			});
 		});
 	});


### PR DESCRIPTION
#### Description

This PR removes redundant states from the switch button component, such as the `isDisabled` as `isON` states.

It also renames the `state` string prop to a `checked` boolean prop in order to be easier to set from the parent component. 