### PR TITLE
feat(svg-icon): enable public assets url configuration

### DIFF
--- a/packages/ui-components/src/components/svg-icon/readme.md
+++ b/packages/ui-components/src/components/svg-icon/readme.md
@@ -88,6 +88,7 @@ export const SvgIconExample: React.FC = () => (
 
 | Property            | Attribute      | Description                                                                                                                 | Type                 | Default     |
 | ------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------- | -------------------- | ----------- |
+| `assetsUrl`         | `assets-url`   | (required) Url where assets are public served                                                                               | `string`             | `'/'`       |
 | `customClass`       | `custom-class` | (optional) Additional classes to apply for custom CSS. If multiple classes are provided they should be separated by spaces. | `string \| string[]` | `''`        |
 | `customColor`       | `custom-color` | (optional) Icon custom color                                                                                                | `string`             | `''`        |
 | `name` _(required)_ | `name`         | (required) Icon symbol name                                                                                                 | `string`             | `undefined` |

--- a/packages/ui-components/src/components/svg-icon/svg-icon.tsx
+++ b/packages/ui-components/src/components/svg-icon/svg-icon.tsx
@@ -13,6 +13,9 @@ export class KvSvgIcon {
 	/** (required) Icon symbol name */
 	@Prop({ reflect: true }) name!: string;
 
+	/** (required) Url where assets are public served */
+	@Prop({ reflect: true }) assetsUrl: string = '/';
+
 	/**
 	 * (optional) Additional classes to apply for custom CSS. If multiple classes are
 	 * provided they should be separated by spaces.
@@ -34,7 +37,7 @@ export class KvSvgIcon {
 					}}
 					style={{ fill: this.customColor }}
 				>
-					<use href={`svg-symbols.svg#${this.name}`}></use>
+					<use href={`${this.assetsUrl}svg-symbols.svg#${this.name}`}></use>
 				</svg>
 			</Host>
 		);

--- a/packages/ui-components/src/components/svg-icon/test/__snapshots__/svg-icon.spec.tsx.snap
+++ b/packages/ui-components/src/components/svg-icon/test/__snapshots__/svg-icon.spec.tsx.snap
@@ -1,30 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Svg Icon (unit tests) when has custom classes should match the snapshot 1`] = `
-<kv-svg-icon custom-class="icon-full-size rotate-90" custom-color="" name="kv-logo-kelvin">
+<kv-svg-icon assets-url="/" custom-class="icon-full-size rotate-90" custom-color="" name="kv-logo-kelvin">
   <mock:shadow-root>
     <svg class="icon-full-size rotate-90 svg-icon" part="icon" xmlns="http://www.w3.org/2000/svg">
-      <use href="svg-symbols.svg#kv-logo-kelvin"></use>
+      <use href="/svg-symbols.svg#kv-logo-kelvin"></use>
     </svg>
   </mock:shadow-root>
 </kv-svg-icon>
 `;
 
 exports[`Svg Icon (unit tests) when has custom color should match the snapshot 1`] = `
-<kv-svg-icon custom-class="" custom-color="#05a357" name="kv-logo-kelvin">
+<kv-svg-icon assets-url="/" custom-class="" custom-color="#05a357" name="kv-logo-kelvin">
   <mock:shadow-root>
     <svg class="svg-icon" part="icon" xmlns="http://www.w3.org/2000/svg" style="fill: #05a357;">
-      <use href="svg-symbols.svg#kv-logo-kelvin"></use>
+      <use href="/svg-symbols.svg#kv-logo-kelvin"></use>
     </svg>
   </mock:shadow-root>
 </kv-svg-icon>
 `;
 
 exports[`Svg Icon (unit tests) when uses default props should match the snapshot 1`] = `
-<kv-svg-icon custom-class="" custom-color="" name="kv-logo-kelvin">
+<kv-svg-icon assets-url="/" custom-class="" custom-color="" name="kv-logo-kelvin">
   <mock:shadow-root>
     <svg class="svg-icon" part="icon" xmlns="http://www.w3.org/2000/svg">
-      <use href="svg-symbols.svg#kv-logo-kelvin"></use>
+      <use href="/svg-symbols.svg#kv-logo-kelvin"></use>
     </svg>
   </mock:shadow-root>
 </kv-svg-icon>

--- a/packages/ui-components/src/components/svg-icon/test/svg-icon.e2e.ts
+++ b/packages/ui-components/src/components/svg-icon/test/svg-icon.e2e.ts
@@ -18,7 +18,7 @@ describe('Svg Icon (end-to-end)', () => {
 		it('should render the <use> to symbol', async () => {
 			const useComponent = await page.find('kv-svg-icon >>> use');
 			expect(useComponent).toBeTruthy();
-			expect(useComponent.getAttribute('href').toLocaleLowerCase()).toBe('svg-symbols.svg#kv-logo-kelvin');
+			expect(useComponent.getAttribute('href').toLocaleLowerCase()).toBe('/svg-symbols.svg#kv-logo-kelvin');
 		});
 	});
 


### PR DESCRIPTION
#### Description
Currently, the links to the SVG icons are relative to the page, which implies the SVG icons file to be served on every relative page where it's running.
This PR enables this public assets URL to be configured via prop and also defaults it to be absolute.