### PR TITLE
fix: remove overflow from tab navigation

### DIFF
--- a/packages/ui-components/src/components/tab-list/tab-list.scss
+++ b/packages/ui-components/src/components/tab-list/tab-list.scss
@@ -13,7 +13,6 @@ $tab-height: 34px;
 
 	position: relative;
 	height: $tab-height;
-	overflow-x: auto;
 	display: flex;
 	background-color: var(--tab-list-bg-color);
 


### PR DESCRIPTION
This overflow property was adding an scrollbar that was not possible to remove in maps