### PR TITLE
feat(dropdown-group)!: add options groups to dropdown single and multi select

### DIFF
--- a/packages/react-ui-components/src/stories/Components/MultiSelectDropdown.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/MultiSelectDropdown.stories.tsx
@@ -40,7 +40,7 @@ export default {
 			control: { type: 'text' }
 		},
 		selectedOptions: {
-			control: { type: 'array' }
+			control: { type: 'object' }
 		}
 	},
 	parameters: {
@@ -86,9 +86,51 @@ Default.args = {
 			label: 'Option 8'
 		}
 	},
-	selectedOptions: ['option2', 'option3'],
+	selectedOptions: { option2: true, option3: true },
 	label: 'Options',
 	icon: EIconName.Layer,
+	searchable: true,
+	selectionClearable: true
+};
+
+export const Groups = MultiSelectDropdownTemplate.bind({});
+Groups.args = {
+	options: {
+		'UTC-12': {
+			value: 'UTC-12',
+			label: '(UTC-12) Anywhere on Earth',
+			group: 'System Timezone - Default'
+		},
+		'UTC-01': {
+			value: 'UTC-01',
+			label: '(UTC-01) Azores Time',
+			group: 'Other timezones'
+		},
+		'UTC-05': {
+			value: 'UTC-05',
+			label: '(UTC-05) Ecuador Time',
+			group: 'Other timezones'
+		},
+		'UTC-11': {
+			value: 'UTC-11',
+			label: '(UTC-11) Samoa Standard Time',
+			group: 'Other timezones'
+		},
+		'eUTC-10': {
+			value: 'UTC-10',
+			label: '(UTC-10) Cook Islands Standard Time',
+			group: 'Other timezones'
+		},
+		'UTC-09': {
+			value: 'UTC-09',
+			label: '(UTC-09) Hawaii-Aleutian Standarc Time',
+			group: 'Other timezones'
+		}
+	},
+	selectedOptions: { 'UTC-12': true, 'UTC-05': true },
+	label: 'Timezone',
+	placeholder: 'Select a timezone',
+	icon: EIconName.Time,
 	searchable: true,
 	selectionClearable: true
 };

--- a/packages/react-ui-components/src/stories/Components/SingleSelectDropdown.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/SingleSelectDropdown.stories.tsx
@@ -88,3 +88,44 @@ Default.args = {
 	placeholder: 'Select an option',
 	icon: EIconName.Layer
 };
+
+export const Groups = SingleSelectDropdownTemplate.bind({});
+Groups.args = {
+	options: {
+		'UTC-12': {
+			value: 'UTC-12',
+			label: '(UTC-12) Anywhere on Earth',
+			group: 'System Timezone - Default'
+		},
+		'UTC-01': {
+			value: 'UTC-01',
+			label: '(UTC-01) Azores Time',
+			group: 'Other timezones'
+		},
+		'UTC-05': {
+			value: 'UTC-05',
+			label: '(UTC-05) Ecuador Time',
+			group: 'Other timezones'
+		},
+		'UTC-11': {
+			value: 'UTC-11',
+			label: '(UTC-11) Samoa Standard Time',
+			group: 'Other timezones'
+		},
+		'eUTC-10': {
+			value: 'UTC-10',
+			label: '(UTC-10) Cook Islands Standard Time',
+			group: 'Other timezones'
+		},
+		'UTC-09': {
+			value: 'UTC-09',
+			label: '(UTC-09) Hawaii-Aleutian Standarc Time',
+			group: 'Other timezones'
+		}
+	},
+	selectedOption: 'UTC-12',
+	label: 'Timezone',
+	placeholder: 'Select a timezone',
+	icon: EIconName.Time,
+	searchable: true
+};

--- a/packages/ui-components/src/components/dropdown-group/dropdown-group.config.ts
+++ b/packages/ui-components/src/components/dropdown-group/dropdown-group.config.ts
@@ -1,0 +1,2 @@
+export const NO_GROUP_NAME = 'Other';
+export const EMPTY_GROUP_NAME = 'undefined';

--- a/packages/ui-components/src/components/dropdown-group/dropdown-group.helper.ts
+++ b/packages/ui-components/src/components/dropdown-group/dropdown-group.helper.ts
@@ -1,0 +1,17 @@
+import { groupBy, isEmpty } from 'lodash-es';
+import { EMPTY_GROUP_NAME, NO_GROUP_NAME } from './dropdown-group.config';
+
+export const buildDropdownGroups = <T extends { group?: string }>(options: Record<string, T>): Record<string, T[]> => {
+	/**
+	 * Note: All options that do not contain a `group` filed will be aggregated on an `undefined` (EMPTY_GROUP_NAME) group name.
+	 */
+	return groupBy(Object.values(options), 'group');
+};
+
+export const buildDropdownGroupLabel = (groupName: string): string => {
+	if (isEmpty(groupName) || groupName === EMPTY_GROUP_NAME) {
+		return NO_GROUP_NAME;
+	}
+
+	return groupName;
+};

--- a/packages/ui-components/src/components/dropdown-group/dropdown-group.scss
+++ b/packages/ui-components/src/components/dropdown-group/dropdown-group.scss
@@ -1,0 +1,27 @@
+@import '../../assets/styles/globals';
+
+:host {
+	/**
+	 * @prop --dropdown-group-item-height: Dropdown group item height.
+	 * @prop --dropdown-group-item-background-color: Dropdown group item background color.
+	 * @prop --dropdown-group-item-label-color: Dropdown group item label color.
+	 */
+
+	--dropdown-group-item-height: 32px;
+	--dropdown-group-item-background-color: kv-color('neutral-7');
+	--dropdown-group-item-label-color: kv-color('neutral-2');
+}
+
+.group {
+	.label {
+		@include kv-font-label-small-uppercase-regular;
+		height: var(--dropdown-group-item-height);
+		padding: 0 $spacing-4x;
+		display: flex;
+		align-items: center;
+		user-select: none;
+		cursor: default;
+		background-color: var(--dropdown-group-item-background-color);
+		color: var(--dropdown-group-item-label-color);
+	}
+}

--- a/packages/ui-components/src/components/dropdown-group/dropdown-group.tsx
+++ b/packages/ui-components/src/components/dropdown-group/dropdown-group.tsx
@@ -1,0 +1,29 @@
+import { Component, Host, h, Prop } from '@stencil/core';
+import { buildDropdownGroupLabel } from './dropdown-group.helper';
+import { IDropdownGroup } from './dropdown-group.types';
+
+/**
+ * @part group-container - The group element container.
+ */
+@Component({
+	tag: 'kv-dropdown-group',
+	styleUrl: 'dropdown-group.scss',
+	shadow: true
+})
+export class KvDropdownGroup implements IDropdownGroup {
+	/** @inheritdoc */
+	@Prop({ reflect: true }) label?: string;
+
+	render() {
+		return (
+			<Host>
+				<div class="group" part="group-container">
+					<div class="label">{buildDropdownGroupLabel(this.label)}</div>
+					<div class="items">
+						<slot></slot>
+					</div>
+				</div>
+			</Host>
+		);
+	}
+}

--- a/packages/ui-components/src/components/dropdown-group/dropdown-group.types.ts
+++ b/packages/ui-components/src/components/dropdown-group/dropdown-group.types.ts
@@ -1,0 +1,4 @@
+export interface IDropdownGroup {
+	/** (optional) The text to display on the dropdown group label */
+	label?: string;
+}

--- a/packages/ui-components/src/components/dropdown-group/readme.md
+++ b/packages/ui-components/src/components/dropdown-group/readme.md
@@ -1,0 +1,70 @@
+# *<kv-dropdown-group>*
+
+<!-- Auto Generated Below -->
+
+
+## Usage
+
+### Angular
+
+```html
+<kv-dropdown-group label="Default Timezone"> </kv-dropdown-group>
+```
+
+
+### React
+
+```tsx
+import React from 'react';
+import { KvDropdownGroup } from '@kelvininc/react-ui-components';
+
+export const KvDropdownGroupExample: React.FC = props => (
+	<>
+		<KvDropdownGroup label="Default Timezone"></KvDropdownGroup>
+	</>
+);
+```
+
+
+
+## Properties
+
+| Property | Attribute | Description                                                | Type     | Default     |
+| -------- | --------- | ---------------------------------------------------------- | -------- | ----------- |
+| `label`  | `label`   | (optional) The text to display on the dropdown group label | `string` | `undefined` |
+
+
+## Shadow Parts
+
+| Part                | Description                  |
+| ------------------- | ---------------------------- |
+| `"group-container"` | The group element container. |
+
+
+## CSS Custom Properties
+
+| Name                                     | Description                           |
+| ---------------------------------------- | ------------------------------------- |
+| `--dropdown-group-item-background-color` | Dropdown group item background color. |
+| `--dropdown-group-item-height`           | Dropdown group item height.           |
+| `--dropdown-group-item-label-color`      | Dropdown group item label color.      |
+
+
+## Dependencies
+
+### Used by
+
+ - [kv-multi-select-dropdown](../multi-select-dropdown)
+ - [kv-single-select-dropdown](../single-select-dropdown)
+
+### Graph
+```mermaid
+graph TD;
+  kv-multi-select-dropdown --> kv-dropdown-group
+  kv-single-select-dropdown --> kv-dropdown-group
+  style kv-dropdown-group fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+

--- a/packages/ui-components/src/components/dropdown-group/usage/angular.md
+++ b/packages/ui-components/src/components/dropdown-group/usage/angular.md
@@ -1,0 +1,3 @@
+```html
+<kv-dropdown-group label="Default Timezone"> </kv-dropdown-group>
+```

--- a/packages/ui-components/src/components/dropdown-group/usage/react.md
+++ b/packages/ui-components/src/components/dropdown-group/usage/react.md
@@ -1,0 +1,10 @@
+```tsx
+import React from 'react';
+import { KvDropdownGroup } from '@kelvininc/react-ui-components';
+
+export const KvDropdownGroupExample: React.FC = props => (
+	<>
+		<KvDropdownGroup label="Default Timezone"></KvDropdownGroup>
+	</>
+);
+```

--- a/packages/ui-components/src/components/multi-select-dropdown/multi-select-dropdown.helper.ts
+++ b/packages/ui-components/src/components/multi-select-dropdown/multi-select-dropdown.helper.ts
@@ -1,0 +1,28 @@
+import { isNil } from 'lodash-es';
+import { IMultiSelectDropdownOption } from './multi-select-dropdown.types';
+
+export const getSelectedOptionsCount = (options: { [key: string]: IMultiSelectDropdownOption }, selectedOptions: { [key: string]: boolean }): string[] => {
+	return Object.keys(selectedOptions).reduce((accumulator, selectOption) => {
+		if (isNil(options[selectOption])) {
+			return accumulator;
+		}
+
+		if (selectedOptions[selectOption]) {
+			accumulator.push(selectOption);
+		}
+
+		return accumulator;
+	}, []);
+};
+
+export const getDropdownDisplayValue = (options: { [key: string]: IMultiSelectDropdownOption }, selectedOptions: { [key: string]: boolean }): string => {
+	return getSelectedOptionsCount(options, selectedOptions).reduce((acc, optionKey, currentIndex, selectedOptionsArray) => {
+		if (isNil(options[optionKey])) {
+			if (currentIndex === selectedOptionsArray.length - 1) {
+				acc = acc.slice(0, acc.length - 2);
+			}
+			return acc;
+		}
+		return `${acc + options[optionKey]?.label + (currentIndex !== selectedOptionsArray.length - 1 ? ', ' : '')}`;
+	}, '');
+};

--- a/packages/ui-components/src/components/multi-select-dropdown/multi-select-dropdown.scss
+++ b/packages/ui-components/src/components/multi-select-dropdown/multi-select-dropdown.scss
@@ -14,6 +14,10 @@
 		&[disabled] {
 			pointer-events: none;
 		}
+
+		kv-dropdown-group:not(:last-child)::part(group-container) {
+			margin-bottom: $spacing-2x;
+		}
 	}
 
 	kv-select {

--- a/packages/ui-components/src/components/multi-select-dropdown/multi-select-dropdown.types.ts
+++ b/packages/ui-components/src/components/multi-select-dropdown/multi-select-dropdown.types.ts
@@ -6,6 +6,7 @@ export interface IMultiSelectDropdownOption {
 	label: string;
 	value: string;
 	disabled?: boolean;
+	group?: string;
 }
 
 export interface IMultiSelectDropdownOptions {
@@ -43,13 +44,13 @@ export interface IMultiSelectDropdown {
 	noDataAvailableLabel?: string;
 	/** (optional) The object with the dropdown options */
 	options?: IMultiSelectDropdownOptions;
-	/** (optional) The array of selected options */
-	selectedOptions?: string[] | number[];
+	/** (optional) The object with indexed by the dropdown labels and its selected value */
+	selectedOptions?: { [key: string]: boolean };
 }
 
 export interface IMultiSelectDropdownEvents {
 	/** Emitted when the selected options change */
-	optionsSelected: EventEmitter<string[] | number[]>;
+	optionsSelected: EventEmitter<{ [key: string]: boolean }>;
 	/** Emitted when the search term changes */
 	searchChange: EventEmitter<string>;
 	/** Emitted when the selection is cleared */

--- a/packages/ui-components/src/components/multi-select-dropdown/readme.md
+++ b/packages/ui-components/src/components/multi-select-dropdown/readme.md
@@ -47,33 +47,33 @@ export const KvMultiSelectDropdownExample: React.FC = (props) => (
 
 ## Properties
 
-| Property               | Attribute                 | Description                                                   | Type                                                                          | Default                                   |
-| ---------------------- | ------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------- |
-| `clearSelectionLabel`  | `clear-selection-label`   | (optional) The clear search action text                       | `string`                                                                      | `undefined`                               |
-| `disabled`             | `disabled`                | (optional) If `true` the dropdown is disabled                 | `boolean`                                                                     | `undefined`                               |
-| `displayValue`         | `display-value`           | (optional) The text to display on the dropdown                | `string`                                                                      | `undefined`                               |
-| `errorState`           | `error-state`             | (required) The error state for the dropdown                   | `EValidationState.Invalid \| EValidationState.None \| EValidationState.Valid` | `undefined`                               |
-| `helpText`             | `help-text`               | (optional) The text to display as help text                   | `string \| string[]`                                                          | `[]`                                      |
-| `icon`                 | `icon`                    | (optional) The icon to display on the dropdown                | `EIconName \| EOtherIconName`                                                 | `undefined`                               |
-| `isOpen`               | `is-open`                 | (optional) If `true` the dropdown is opened                   | `boolean`                                                                     | `undefined`                               |
-| `label`                | `label`                   | (optional) The text to display on the dropdown label          | `string`                                                                      | `undefined`                               |
-| `loading`              | `loading`                 | (optional) If `true` the dropdown is loading                  | `boolean`                                                                     | `false`                                   |
-| `noDataAvailableLabel` | `no-data-available-label` | (required) The text to display when there are no options      | `string`                                                                      | `MULTI_SELECT_DROPDOWN_NO_DATA_AVAILABLE` |
-| `options`              | --                        | (optional) The object with the dropdown options               | `{ [key: string]: IMultiSelectDropdownOption; }`                              | `undefined`                               |
-| `placeholder`          | `placeholder`             | (required) The text to display as the dropdown placeholder    | `string`                                                                      | `undefined`                               |
-| `required`             | `required`                | (optional) If `true` dropdown requires a value to be selected | `boolean`                                                                     | `undefined`                               |
-| `searchable`           | `searchable`              | (optional) If `true` the dropdown is searchable               | `boolean`                                                                     | `undefined`                               |
-| `selectedOptions`      | --                        | (optional) The array of selected options                      | `string[]`                                                                    | `[]`                                      |
-| `selectionClearable`   | `selection-clearable`     | (optional) If `true` dropdown items can be cleared            | `boolean`                                                                     | `undefined`                               |
+| Property               | Attribute                 | Description                                                                      | Type                                                                          | Default                                   |
+| ---------------------- | ------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------- |
+| `clearSelectionLabel`  | `clear-selection-label`   | (optional) The clear search action text                                          | `string`                                                                      | `undefined`                               |
+| `disabled`             | `disabled`                | (optional) If `true` the dropdown is disabled                                    | `boolean`                                                                     | `undefined`                               |
+| `displayValue`         | `display-value`           | (optional) The text to display on the dropdown                                   | `string`                                                                      | `undefined`                               |
+| `errorState`           | `error-state`             | (required) The error state for the dropdown                                      | `EValidationState.Invalid \| EValidationState.None \| EValidationState.Valid` | `undefined`                               |
+| `helpText`             | `help-text`               | (optional) The text to display as help text                                      | `string \| string[]`                                                          | `[]`                                      |
+| `icon`                 | `icon`                    | (optional) The icon to display on the dropdown                                   | `EIconName \| EOtherIconName`                                                 | `undefined`                               |
+| `isOpen`               | `is-open`                 | (optional) If `true` the dropdown is opened                                      | `boolean`                                                                     | `undefined`                               |
+| `label`                | `label`                   | (optional) The text to display on the dropdown label                             | `string`                                                                      | `undefined`                               |
+| `loading`              | `loading`                 | (optional) If `true` the dropdown is loading                                     | `boolean`                                                                     | `false`                                   |
+| `noDataAvailableLabel` | `no-data-available-label` | (required) The text to display when there are no options                         | `string`                                                                      | `MULTI_SELECT_DROPDOWN_NO_DATA_AVAILABLE` |
+| `options`              | --                        | (optional) The object with the dropdown options                                  | `{ [key: string]: IMultiSelectDropdownOption; }`                              | `undefined`                               |
+| `placeholder`          | `placeholder`             | (required) The text to display as the dropdown placeholder                       | `string`                                                                      | `undefined`                               |
+| `required`             | `required`                | (optional) If `true` dropdown requires a value to be selected                    | `boolean`                                                                     | `undefined`                               |
+| `searchable`           | `searchable`              | (optional) If `true` the dropdown is searchable                                  | `boolean`                                                                     | `undefined`                               |
+| `selectedOptions`      | --                        | (optional) The object with indexed by the dropdown labels and its selected value | `{ [key: string]: boolean; }`                                                 | `{}`                                      |
+| `selectionClearable`   | `selection-clearable`     | (optional) If `true` dropdown items can be cleared                               | `boolean`                                                                     | `undefined`                               |
 
 
 ## Events
 
-| Event              | Description                              | Type                    |
-| ------------------ | ---------------------------------------- | ----------------------- |
-| `optionsSelected`  | Emitted when the selected options change | `CustomEvent<string[]>` |
-| `searchChange`     | Emitted when the search term changes     | `CustomEvent<string>`   |
-| `selectionCleared` | Emitted when the selection is cleared    | `CustomEvent<void>`     |
+| Event              | Description                              | Type                                       |
+| ------------------ | ---------------------------------------- | ------------------------------------------ |
+| `optionsSelected`  | Emitted when the selected options change | `CustomEvent<{ [key: string]: boolean; }>` |
+| `searchChange`     | Emitted when the search term changes     | `CustomEvent<string>`                      |
+| `selectionCleared` | Emitted when the selection is cleared    | `CustomEvent<void>`                        |
 
 
 ## CSS Custom Properties
@@ -87,16 +87,19 @@ export const KvMultiSelectDropdownExample: React.FC = (props) => (
 
 ### Depends on
 
+- [kv-dropdown-group](../dropdown-group)
+- [kv-select-option](../select-option)
 - [kv-dropdown](../dropdown)
 - [kv-select](../select)
-- [kv-select-option](../select-option)
 
 ### Graph
 ```mermaid
 graph TD;
+  kv-multi-select-dropdown --> kv-dropdown-group
+  kv-multi-select-dropdown --> kv-select-option
   kv-multi-select-dropdown --> kv-dropdown
   kv-multi-select-dropdown --> kv-select
-  kv-multi-select-dropdown --> kv-select-option
+  kv-select-option --> kv-icon
   kv-dropdown --> kv-text-field
   kv-dropdown --> kv-icon
   kv-text-field --> kv-form-label
@@ -106,7 +109,6 @@ graph TD;
   kv-select --> kv-search
   kv-search --> kv-text-field
   kv-search --> kv-icon
-  kv-select-option --> kv-icon
   style kv-multi-select-dropdown fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/ui-components/src/components/select-option/readme.md
+++ b/packages/ui-components/src/components/select-option/readme.md
@@ -61,15 +61,15 @@ export const KvSelectOptionExample: React.FC = () => (
 
 ## CSS Custom Properties
 
-| Name                                        | Description                                        |
-| ------------------------------------------- | -------------------------------------------------- |
-| `--dropdown-item-background-color`          | Dropdown list item background color.               |
-| `--dropdown-item-background-color-hover`    | Dropdown list item background color when hovered.  |
-| `--dropdown-item-background-color-selected` | Dropdown list item background color when selected. |
-| `--dropdown-item-height`                    | Dropdown list item height.                         |
-| `--dropdown-item-label-color`               | Dropdown list item label color.                    |
-| `--dropdown-item-label-color-selected`      | Dropdown list item label color when selected.      |
-| `--dropdown-item-transition-duration`       | Dropdown list item transition time.                |
+| Name                                        | Description                                   |
+| ------------------------------------------- | --------------------------------------------- |
+| `--dropdown-item-background-color`          | Select option background color.               |
+| `--dropdown-item-background-color-hover`    | Select option background color when hovered.  |
+| `--dropdown-item-background-color-selected` | Select option background color when selected. |
+| `--dropdown-item-height`                    | Select option height.                         |
+| `--dropdown-item-label-color`               | Select option label color.                    |
+| `--dropdown-item-label-color-selected`      | Select option label color when selected.      |
+| `--dropdown-item-transition-duration`       | Select option transition time.                |
 
 
 ## Dependencies

--- a/packages/ui-components/src/components/select-option/select-option.scss
+++ b/packages/ui-components/src/components/select-option/select-option.scss
@@ -2,13 +2,13 @@
 
 :host {
 	/**
-	 * @prop --dropdown-item-height: Dropdown list item height.
-	 * @prop --dropdown-item-transition-duration: Dropdown list item transition time.
-	 * @prop --dropdown-item-background-color: Dropdown list item background color.
-	 * @prop --dropdown-item-background-color-selected: Dropdown list item background color when selected.
-	 * @prop --dropdown-item-background-color-hover: Dropdown list item background color when hovered.
-	 * @prop --dropdown-item-label-color: Dropdown list item label color.
-	 * @prop --dropdown-item-label-color-selected: Dropdown list item label color when selected.
+	 * @prop --dropdown-item-height: Select option height.
+	 * @prop --dropdown-item-transition-duration: Select option transition time.
+	 * @prop --dropdown-item-background-color: Select option background color.
+	 * @prop --dropdown-item-background-color-selected: Select option background color when selected.
+	 * @prop --dropdown-item-background-color-hover: Select option background color when hovered.
+	 * @prop --dropdown-item-label-color: Select option label color.
+	 * @prop --dropdown-item-label-color-selected: Select option label color when selected.
 	 */
 
 	--dropdown-item-height: 32px;
@@ -34,9 +34,7 @@
 		.item-label {
 			@include kv-font-span-regular;
 			transition: font-weight var(--dropdown-item-transition-duration) linear;
-			margin-left: $spacing-2x;
 			color: var(--dropdown-item-label-color);
-
 			white-space: nowrap;
 			text-overflow: ellipsis;
 			overflow: hidden;
@@ -63,6 +61,7 @@
 
 		kv-icon {
 			display: inline-flex;
+			margin-right: $spacing-2x;
 		}
 	}
 }

--- a/packages/ui-components/src/components/select/readme.md
+++ b/packages/ui-components/src/components/select/readme.md
@@ -72,6 +72,15 @@ export const KvSelectExample: React.FC = () => (
 | `searchChange`   | Emitted when the user interacts with the search text field | `CustomEvent<string>` |
 
 
+## CSS Custom Properties
+
+| Name                        | Description              |
+| --------------------------- | ------------------------ |
+| `--select-background-color` | Select background color. |
+| `--select-border-color`     | Select border color.     |
+| `--select-max-height`       | Select maximum height.   |
+
+
 ## Dependencies
 
 ### Used by

--- a/packages/ui-components/src/components/select/select.scss
+++ b/packages/ui-components/src/components/select/select.scss
@@ -2,9 +2,9 @@
 
 :host {
 	/**
-	 * @prop --select-max-height: Dropdown list maximum height.
-	 * @prop --select-background-color: Dropdown list background color.
-	 * @prop --select-border-color: Dropdown list border color.
+	 * @prop --select-max-height: Select maximum height.
+	 * @prop --select-background-color: Select background color.
+	 * @prop --select-border-color: Select border color.
 	 */
 
 	--select-max-height: auto;

--- a/packages/ui-components/src/components/single-select-dropdown/readme.md
+++ b/packages/ui-components/src/components/single-select-dropdown/readme.md
@@ -80,16 +80,19 @@ export const KvSingleSelectDropdownExample: React.FC = (props) => (
 
 ### Depends on
 
+- [kv-dropdown-group](../dropdown-group)
+- [kv-select-option](../select-option)
 - [kv-dropdown](../dropdown)
 - [kv-select](../select)
-- [kv-select-option](../select-option)
 
 ### Graph
 ```mermaid
 graph TD;
+  kv-single-select-dropdown --> kv-dropdown-group
+  kv-single-select-dropdown --> kv-select-option
   kv-single-select-dropdown --> kv-dropdown
   kv-single-select-dropdown --> kv-select
-  kv-single-select-dropdown --> kv-select-option
+  kv-select-option --> kv-icon
   kv-dropdown --> kv-text-field
   kv-dropdown --> kv-icon
   kv-text-field --> kv-form-label
@@ -99,7 +102,6 @@ graph TD;
   kv-select --> kv-search
   kv-search --> kv-text-field
   kv-search --> kv-icon
-  kv-select-option --> kv-icon
   style kv-single-select-dropdown fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/ui-components/src/components/single-select-dropdown/single-select-dropdown.scss
+++ b/packages/ui-components/src/components/single-select-dropdown/single-select-dropdown.scss
@@ -14,6 +14,10 @@
 		&[disabled] {
 			pointer-events: none;
 		}
+
+		kv-dropdown-group:not(:last-child)::part(group-container) {
+			margin-bottom: $spacing-2x;
+		}
 	}
 
 	kv-select {

--- a/packages/ui-components/src/components/single-select-dropdown/single-select-dropdown.tsx
+++ b/packages/ui-components/src/components/single-select-dropdown/single-select-dropdown.tsx
@@ -2,8 +2,9 @@ import { Component, Host, h, Prop, Event, EventEmitter, Watch, State } from '@st
 import { isEmpty, isNil } from 'lodash-es';
 import { EIconName, EOtherIconName } from '../icon/icon.types';
 import { EValidationState } from '../text-field/text-field.types';
-import { ISingleSelectDropdown, ISingleSelectDropdownOptions, ISingleSelectDropdownEvents } from './single-select-dropdown.types';
+import { ISingleSelectDropdown, ISingleSelectDropdownOption, ISingleSelectDropdownOptions, ISingleSelectDropdownEvents } from './single-select-dropdown.types';
 import { SINGLE_SELECT_DROPDOWN_NO_DATA_AVAILABLE } from './single-select-dropdown.config';
+import { buildDropdownGroups } from '../dropdown-group/dropdown-group.helper';
 
 @Component({
 	tag: 'kv-single-select-dropdown',
@@ -114,7 +115,32 @@ export class KvSingleSelectDropdown implements ISingleSelectDropdown, ISingleSel
 		}
 	}
 
+	private renderGroups = (groupNames: string[], groups: Record<string, ISingleSelectDropdownOption[]>) => {
+		return groupNames.map(groupName => (
+			<kv-dropdown-group key={groupName} label={groupName}>
+				{this.renderOptions(groups[groupName])}
+			</kv-dropdown-group>
+		));
+	};
+
+	private renderOptions = (options: ISingleSelectDropdownOption[]) => {
+		return options.map(option => (
+			<kv-select-option
+				key={option.label}
+				label={option.label}
+				value={option.value}
+				disabled={option.disabled}
+				selected={option.value === this._selectedOption}
+				onItemSelected={this.selectOption}
+			/>
+		));
+	};
+
 	render() {
+		const groups = buildDropdownGroups(this.options);
+		const groupNames = Object.keys(groups);
+		const hasGroups = groupNames.length > 1;
+
 		return (
 			<Host>
 				<kv-dropdown
@@ -132,15 +158,7 @@ export class KvSingleSelectDropdown implements ISingleSelectDropdown, ISingleSel
 				>
 					<kv-select searchValue={this._searchValue} searchable={this.searchable} onSearchChange={this.onSearchChange}>
 						{isEmpty(this.options) && <kv-select-option class="no-data" label={this.noDataAvailableLabel} value={null} />}
-						{Object.values(this.options).map(option => (
-							<kv-select-option
-								label={option.label}
-								value={option.value}
-								disabled={option.disabled}
-								selected={option.value === this._selectedOption}
-								onItemSelected={this.selectOption}
-							/>
-						))}
+						{hasGroups ? this.renderGroups(groupNames, groups) : this.renderOptions(Object.values(this.options))}
 					</kv-select>
 				</kv-dropdown>
 			</Host>

--- a/packages/ui-components/src/components/single-select-dropdown/single-select-dropdown.types.ts
+++ b/packages/ui-components/src/components/single-select-dropdown/single-select-dropdown.types.ts
@@ -6,6 +6,7 @@ export interface ISingleSelectDropdownOption {
 	label: string;
 	value: string;
 	disabled?: boolean;
+	group?: string;
 }
 
 export interface ISingleSelectDropdownOptions {


### PR DESCRIPTION
Now dropdown options can be grouped by a name.

**Screenshots**
<img width="800" alt="Screenshot 2022-08-10 at 10 43 43" src="https://user-images.githubusercontent.com/17494742/183872652-523a6e92-5e86-4219-9a36-c291c22391e8.png">
<img width="800" alt="Screenshot 2022-08-10 at 10 43 38" src="https://user-images.githubusercontent.com/17494742/183872667-9119bdf4-65ff-4f6b-b931-394c54e3321b.png">
