### PR TITLE
fix(dropdown): fix check for click outside fuction

### DIFF
--- a/packages/ui-components/src/components/dropdown/dropdown.tsx
+++ b/packages/ui-components/src/components/dropdown/dropdown.tsx
@@ -38,11 +38,10 @@ export class KvDropdown implements IDropdown, IDropdownEvents {
 	@Element() el: HTMLKvDropdownElement;
 
 	@Listen('click', { target: 'window' })
-	checkForClickOutside(ev: { path: HTMLElement[] }) {
-		if (ev.path.some(element => element === this.el)) {
+	checkForClickOutside(ev: { target: Node }) {
+		if (this.el.contains(ev.target)) {
 			return;
 		}
-
 		this.isOpen = false;
 		this.openStateChange.emit(this.isOpen);
 	}


### PR DESCRIPTION
When clicking outside this dropdown wouldn't close, I was trying to figure out the problem and realized that the console was giving this error.
![2022-08-11-164133_503x199_scrot](https://user-images.githubusercontent.com/44007026/184176541-0efe7d47-0a1f-419f-aa52-19ce5d24d5a3.png)

Digging deeper, I figured out that this error was actually the dropdown problem. So I made some modifications to the function, and it seems to be working. My only doubt  is the type of the target (it was suggested by VSCode).