### PR TITLE
fix(dropdown): Add fallbackPlacements

### DIFF
--- a/packages/ui-components/src/components/dropdown/dropdown.tsx
+++ b/packages/ui-components/src/components/dropdown/dropdown.tsx
@@ -66,7 +66,7 @@ export class KvDropdown implements IDropdown, IDropdownEvents {
 						offset(8),
 						flip({
 							padding: 15,
-							fallbackPlacements: ['top']
+							fallbackPlacements: ['top-end', 'bottom-end', 'top-start', 'bottom-start']
 						})
 					]
 				}).then(({ x, y }) => {


### PR DESCRIPTION
When the dropdown selector doesn't have space to expand to the right, it will expand to the right.
![2022-08-12-165548_315x439_scrot](https://user-images.githubusercontent.com/44007026/184401951-a87c55b2-0302-4728-9ab5-37e5a61f4acc.png)

When it doesn't have space to the left, it will expand to the right.
![2022-08-12-171205_380x572_scrot](https://user-images.githubusercontent.com/44007026/184402173-ba884467-3726-416a-ad0c-ef70a0be7bf3.png)

The same happens if the selector doesn't have space at the bottom.

![2022-08-12-173237_283x448_scrot](https://user-images.githubusercontent.com/44007026/184403382-e7468364-57e7-41d1-b68b-d55e1aad0417.png)

![2022-08-12-173123_210x386_scrot](https://user-images.githubusercontent.com/44007026/184403212-0b990fcc-4734-491c-b3ab-b5e7d4f3ca9f.png)
f.png)

