### PR TITLE
fix(icon): remove timestamp from copied SVG of symbols [KMAPS-385]

### DIFF
--- a/packages/angular-ui-components/.scripts/copy-assets.js
+++ b/packages/angular-ui-components/.scripts/copy-assets.js
@@ -28,8 +28,7 @@ function getFileChecksum(path) {
 }
 
 getFileChecksum(SYMBOLS_FILE_PATH).then((hash) => {
-	const [timestamp] = new Date().toISOString().split(".");
-	const file = `symbols.${timestamp}.${hash}.svg`;
+	const file = `symbols.${hash}.svg`;
 	const destination = `${ASSETS_DIR}/${file}`;
 
 	fse.copySync(SYMBOLS_FILE_PATH, destination, { overwrite: true }, (err) => {

--- a/packages/angular-ui-components/README.md
+++ b/packages/angular-ui-components/README.md
@@ -111,7 +111,7 @@ In addition, you can customize the theme by changing some CSS properties.
 
 ## Caching
 
-By default, the `KvIcon` and `KvIllustration` components require an SVG file with all the `kv-icons` available. The default file is `svg-symbols.svg` which is provided after installing this dependency. For caching purposes, it is also provided a `symbols.${timestamp}.${checksum}.svg` file after installation. If you are caching those SVGs in your project you should provide the latter to the library configuration in your `app.component.ts`.
+By default, the `KvIcon` and `KvIllustration` components require an SVG file with all the `kv-icons` available. The default file is `svg-symbols.svg` which is provided after installing this dependency. For caching purposes, it is also provided a `symbols.${checksum}.svg` file after installation. If you are caching those SVGs in your project you should provide the latter to the library configuration in your `app.component.ts`.
 
 ```typescript
 
@@ -122,7 +122,7 @@ export class AppComponent {
 	(...)
 
 	constructor() {
-		initialize({ symbolsFileName: 'symbols.2022-08-29T16:00:49.6e51ea0e37926eff2f3ef11e64be70fa.svg' });
+		initialize({ symbolsFileName: 'symbols.6e51ea0e37926eff2f3ef11e64be70fa.svg' });
 	}
 }
 ```

--- a/packages/react-ui-components/.scripts/copy-icons.js
+++ b/packages/react-ui-components/.scripts/copy-icons.js
@@ -28,8 +28,7 @@ function getFileChecksum(path) {
 }
 
 getFileChecksum(SYMBOLS_FILE_PATH).then(hash => {
-	const [timestamp] = new Date().toISOString().split('.');
-	const file = `symbols.${timestamp}.${hash}.svg`;
+	const file = `symbols.${hash}.svg`;
 	const destination = `${PUBLIC_DIR}/${file}`;
 
 	fse.copySync(SYMBOLS_FILE_PATH, destination, { overwrite: true }, err => {

--- a/packages/react-ui-components/README.md
+++ b/packages/react-ui-components/README.md
@@ -76,7 +76,7 @@ In addition, you can customize the theme by changing some CSS properties.
 
 ## Caching
 
-By default, the `KvIcon` and `KvIllustration` components require an SVG file with all the `kv-icons` available. The default file is `svg-symbols.svg` which is provided after installing this dependency. For caching purposes, it is also provided a `symbols.${timestamp}.${checksum}.svg` file after installation. If you are caching those SVGs in your project you should use the latter.
+By default, the `KvIcon` and `KvIllustration` components require an SVG file with all the `kv-icons` available. The default file is `svg-symbols.svg` which is provided after installing this dependency. For caching purposes, it is also provided a `symbols.${checksum}.svg` file after installation. If you are caching those SVGs in your project you should use the latter.
 
 ```tsx
 
@@ -84,7 +84,7 @@ import { initialize } from '@kelvininc/react-ui-components';
 
 (...)
 
-initialize({ symbolsFileName: 'symbols.2022-08-29T16:00:49.6e51ea0e37926eff2f3ef11e64be70fa.svg' });
+initialize({ symbolsFileName: 'symbols.6e51ea0e37926eff2f3ef11e64be70fa.svg' });
 
 ```
 


### PR DESCRIPTION
Even thought the timestamp was added with the best intentions of being able to see the most recent file on top when listing the public directory, that does not work because every time we deploy we get a new file and our users have to reload the file because its name changed.
