### PR TITLE
fix(range): add offset to the input value

### DIFF
--- a/packages/ui-components/src/components/range/range.helper.ts
+++ b/packages/ui-components/src/components/range/range.helper.ts
@@ -2,8 +2,16 @@ export const getInputPercentageFromValue = (inputValue: number, min: number, max
 	return (100 * (inputValue - min)) / (max - min);
 };
 
-export const getOffset = (percentage: number) => {
+export const getInputOffset = (percentage: number) => {
 	const offSet = -0.25;
+	const halfDistance = percentage - 50;
+
+	return halfDistance * offSet;
+};
+
+export const getValueOffset = (percentage: number, value: number) => {
+	const valueLength = value.toString().length;
+	const offSet = -0.15 * valueLength;
 	const halfDistance = percentage - 50;
 
 	return halfDistance * offSet;

--- a/packages/ui-components/src/components/range/range.tsx
+++ b/packages/ui-components/src/components/range/range.tsx
@@ -1,6 +1,6 @@
 import { Component, Host, h, Prop, Element, EventEmitter, Event } from '@stencil/core';
 import { IRange, IRangeEvents } from './range.types';
-import { getInputPercentageFromValue, getOffset } from './range.helper';
+import { getInputOffset, getInputPercentageFromValue, getValueOffset } from './range.helper';
 
 @Component({
 	tag: 'kv-range',
@@ -40,12 +40,13 @@ export class KvRange implements IRange, IRangeEvents {
 
 		const inputValue = this.getInputValue(rangeInputValue);
 		const percentage = getInputPercentageFromValue(inputValue, this.min, this.max);
-		const offSet = getOffset(percentage);
+		const inputOffSet = getInputOffset(percentage);
+		const valueOffset = getValueOffset(percentage, inputValue);
 
 		selector.style.left = percentage + '%';
-		selector.style.marginLeft = offSet + 'px';
+		selector.style.marginLeft = valueOffset + 'px';
 
-		rangeInputValue.style.background = `linear-gradient(90deg, var(--slider-background-filled) calc(${percentage}% + ${offSet}px), var(--slider-background-empty) calc(${percentage}% + ${offSet}px))`;
+		rangeInputValue.style.background = `linear-gradient(90deg, var(--slider-background-filled) calc(${percentage}% + ${inputOffSet}px), var(--slider-background-empty) calc(${percentage}% + ${inputOffSet}px))`;
 	};
 
 	private onInputChange = () => {


### PR DESCRIPTION
![Screenshot 2022-09-14 at 12 15 11](https://user-images.githubusercontent.com/37366547/190139613-bcf08b3b-63a1-4ad2-a275-3c15fc011f0d.png)
![Screenshot 2022-09-14 at 12 15 24](https://user-images.githubusercontent.com/37366547/190139617-081c9bb3-f3a5-4efa-a2f4-90e1968d4ffd.png)

This PR changes the value of the offset applied to the number on top of the range slider. 

This is particularly needed when the range is used inside a modal and the width of the slider is almost the same width of the modal. If the number displayed has at least 4 characters, the number will overflow the space available.

Another approach to consider would be adding a flag to enable/disable this offset but i will leave this question open to the review.  