### PR TITLE
fix(text-field): remove placeholder 0 on type numeric on hover or focus

### DIFF
--- a/packages/react-ui-components/src/stories/Components/TextField.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/TextField.stories.tsx
@@ -12,6 +12,8 @@ export default {
 		required: { control: { type: 'boolean' } },
 		loading: { control: { type: 'boolean' } },
 		helpText: { control: { type: 'array' } },
+		min: { control: { type: 'number' } },
+		max: { control: { type: 'number' } },
 		state: {
 			control: { type: 'radio' },
 			options: Object.values(EValidationState)
@@ -85,17 +87,17 @@ MaxMinLength.args = {
 };
 
 export const MaxMinValue = TextFieldTemplate.bind({});
-MaxMinLength.args = {
+MaxMinValue.args = {
 	...Default.args,
 	type: EInputFieldType.Number,
 	label: 'Required Text Field',
 	required: true,
-	min: 5,
+	min: 0,
 	max: 10
 };
 
 export const Step = TextFieldTemplate.bind({});
-MaxMinLength.args = {
+Step.args = {
 	...Default.args,
 	type: EInputFieldType.Number,
 	label: 'Required Text Field',

--- a/packages/ui-components/src/components/text-field/text-field.config.ts
+++ b/packages/ui-components/src/components/text-field/text-field.config.ts
@@ -4,7 +4,9 @@ import { ITooltip } from '../tooltip/tooltip.types';
 
 export const NUMERIC_TEXT_INPUT_MASK_CONFIG: Inputmask.Options = {
 	alias: 'numeric',
-	rightAlign: false
+	rightAlign: false,
+	showMaskOnHover: false,
+	showMaskOnFocus: false
 };
 
 export const DEFAULT_TEXT_TOOLTIP_CONFIG: Partial<ITooltip> = {


### PR DESCRIPTION
Removes placeholder added by the input mask and fixed some stories that had misused templates