### PR TITLE
fix(tooltip): check if child is null before `removeEventListeners` [KMAPS-532]

### DIFF
--- a/packages/ui-components/src/components/tooltip/tooltip.tsx
+++ b/packages/ui-components/src/components/tooltip/tooltip.tsx
@@ -114,7 +114,9 @@ export class KvTooltip implements ITooltip {
 
 	disconnectedCallback() {
 		const child = this.getContentElement();
-		this.unlistenToEvents(child);
+		if (child) {
+			this.unlistenToEvents(child);
+		}
 	}
 
 	render() {


### PR DESCRIPTION
`child` should be inferred as `HTMLElement | null` because `private getContentElement = (): HTMLElement | null`

![image](https://user-images.githubusercontent.com/19409687/193868445-9f28f9c7-2acd-4563-a51e-30ec17a199aa.png)