### PR TITLE
chore: extract node setup to custom gh action

### DIFF
--- a/.github/actions/node-setup/action.yml
+++ b/.github/actions/node-setup/action.yml
@@ -1,0 +1,25 @@
+name: Setup Node.js Project
+description: Configures Node.js, fetches dependencies, and manages caching.
+
+inputs:
+    node-version:
+        required: true
+        description: Node.js version to set up
+
+runs:
+    using: "composite"
+    steps:
+        - name: Setup Node.js
+          uses: actions/setup-node@v3
+          with:
+              node-version: ${{ inputs.node-version }}
+
+        - name: Restore cache
+          uses: actions/cache@v3
+          with:
+              path: "**/node_modules"
+              key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
+        - name: Install dependencies
+          shell: bash
+          run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,48 +11,30 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-22.04]
-                node: [14]
+                node: [14.x]
 
         name: Continuous Integration (${{ matrix.os }} / Node.js ${{ matrix.node }})
         runs-on: ${{ matrix.os }}
 
         steps:
-            - name: Checkout 🛎
-              uses: actions/checkout@master
+            - name: ☁️ Checkout repository
+              uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
 
-            - name: Setup node env 🏗
-              uses: actions/setup-node@v2.1.5
+            - name: 🟩 Setup Node.js ${{ matrix.node }}
+              uses: ./.github/actions/node-setup
               with:
                   node-version: ${{ matrix.node }}
-                  check-latest: true
 
-            - name: Cache node_modules 📦
-              uses: actions/cache@v2
-              env:
-                  cache-name: cache-node-modules
-              with:
-                  # npm cache files are stored in `~/.npm` on Linux/macOS
-                  path: |
-                      ~/.npm\
-                      node_modules
-                      */*/node_modules
-                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-build-${{ env.cache-name }}-
-                      ${{ runner.os }}-build-
-                      ${{ runner.os }}-
-
-            - name: Install dependencies 👨🏻‍💻
-              run: npm install
-
-            - name: Lerna bootstrap 🐉
+            - name: 🐉 Bootstrap repository
               run: npm run bootstrap
 
-            - name: Run linter 👀
+            - name: 🔍 Run linter
               run: npm run lint
 
-            - name: Run tests 🧪
+            - name: 🧪 Run tests
               run: npm run test
 
-            - name: Run build:packages 🐉
+            - name: 🏗️ Build all packages
               run: npm run build:packages

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -17,19 +17,16 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-22.04]
-                node: [14]
+                node: [14.x]
 
         name: Pre-Release Publish (${{ matrix.os }} / Node.js ${{ matrix.node }})
         runs-on: ${{ matrix.os }}
+
         steps:
-            - name: Checkout
-              uses: actions/checkout@v2
+            - name: Checkout repository
+              uses: actions/checkout@v3
               with:
-                  fetch-depth: "0"
-            - name: Setup Node ${{ matrix.node_version }}
-              uses: actions/setup-node@v2
-              with:
-                  node-version: ${{ matrix.node }}
+                  fetch-depth: 0
 
             - name: Git Identity
               run: |
@@ -39,24 +36,10 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Cache node_modules 📦
-              uses: actions/cache@v2
-              env:
-                  cache-name: cache-node-modules
+            - name: Setup Node.js ${{ matrix.node }}
+              uses: ./.github/actions/node-setup
               with:
-                  # npm cache files are stored in `~/.npm` on Linux/macOS
-                  path: |
-                      ~/.npm\
-                      node_modules
-                      */*/node_modules
-                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-build-${{ env.cache-name }}-
-                      ${{ runner.os }}-build-
-                      ${{ runner.os }}-
-
-            - name: Install
-              run: npm install
+                  node-version: ${{ matrix.node }}
 
             - name: Get Tag
               run: echo "LAST_VERSION=$(git describe --tags `git rev-list --tags --max-count=1` | tr -d v)" >> $GITHUB_ENV
@@ -94,7 +77,7 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Build
+            - name: Build packages
               run: npm run build:packages
 
             - name: Setting NPM

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -13,40 +13,21 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-22.04]
-                node: [14]
+                node: [14.x]
 
         name: Publish Storybook (${{ matrix.os }} / Node.js ${{ matrix.node }})
         runs-on: ${{ matrix.os }}
         steps:
-            - name: Checkout
-              uses: actions/checkout@v2
+            - name: Checkout repository
+              uses: actions/checkout@v3
               with:
-                  fetch-depth: "0"
+                  fetch-depth: 0
                   token: ${{ secrets.RELEASE_TOKEN }}
 
-            - name: Setup Node ${{ matrix.node_version }}
-              uses: actions/setup-node@v2
+            - name: Setup Node.js ${{ matrix.node }}
+              uses: ./.github/actions/node-setup
               with:
                   node-version: ${{ matrix.node }}
-
-            - name: Cache node_modules 📦
-              uses: actions/cache@v2
-              env:
-                  cache-name: cache-node-modules
-              with:
-                  # npm cache files are stored in `~/.npm` on Linux/macOS
-                  path: |
-                      ~/.npm\
-                      node_modules
-                      */*/node_modules
-                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-build-${{ env.cache-name }}-
-                      ${{ runner.os }}-build-
-                      ${{ runner.os }}-
-
-            - name: Install
-              run: npm install
               env:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -12,21 +12,16 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-22.04]
-                node: [14]
+                node: [14.x]
 
         name: Publish Master (${{ matrix.os }} / Node.js ${{ matrix.node }})
         runs-on: ${{ matrix.os }}
         steps:
-            - name: Checkout
-              uses: actions/checkout@v2
+            - name: Checkout repository
+              uses: actions/checkout@v3
               with:
-                  fetch-depth: "0"
+                  fetch-depth: 0
                   token: ${{ secrets.RELEASE_TOKEN }}
-
-            - name: Setup Node ${{ matrix.node_version }}
-              uses: actions/setup-node@v2
-              with:
-                  node-version: ${{ matrix.node }}
 
             - name: Git Identity
               run: |
@@ -44,24 +39,10 @@ jobs:
               env:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-            - name: Cache node_modules 📦
-              uses: actions/cache@v2
-              env:
-                  cache-name: cache-node-modules
+            - name: Setup Node.js ${{ matrix.node }}
+              uses: ./.github/actions/node-setup
               with:
-                  # npm cache files are stored in `~/.npm` on Linux/macOS
-                  path: |
-                      ~/.npm\
-                      node_modules
-                      */*/node_modules
-                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-build-${{ env.cache-name }}-
-                      ${{ runner.os }}-build-
-                      ${{ runner.os }}-
-
-            - name: Install
-              run: npm install
+                  node-version: ${{ matrix.node }}
               env:
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
### References

- https://github.com/actions/cache/blob/main/examples.md#node---lerna
- https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data
- https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches

I got identical CI times with this approach.

![image](https://user-images.githubusercontent.com/19409687/194282456-650980b8-f5e1-41eb-b4ab-4c55c56ad41e.png)
