### PR TITLE
fix(textfield): remove placeholder from inputmask configuration

### DIFF
--- a/packages/ui-components/src/components/text-field/text-field.config.ts
+++ b/packages/ui-components/src/components/text-field/text-field.config.ts
@@ -7,6 +7,7 @@ export const COMMON_INPUT_MASK_CONFIG: Inputmask.Options = {
 	showMaskOnHover: false,
 	showMaskOnFocus: false,
 	clearMaskOnLostFocus: false,
+	placeholder: '',
 	oncleared: function () {
 		this.value = '';
 	}

--- a/packages/ui-components/src/components/text-field/text-field.tsx
+++ b/packages/ui-components/src/components/text-field/text-field.tsx
@@ -117,7 +117,6 @@ export class KvTextField implements ITextField, ITextFieldEvents {
 				...getInputMaskConfig(this.type),
 				min: this.min,
 				max: this.max,
-				placeholder: this.placeholder,
 				regex: this.inputMaskRegex
 			}).mask(this.nativeInput);
 		}


### PR DESCRIPTION
This PR removes the placeholder from the inputmask configuration because this was causing the input to display only the first letter of the placeholder. The placeholder should only be defined in the input html tag