### PR TITLE
feat(tooltip): add default delay to tooltip

### DIFF
--- a/packages/ui-components/src/components/tooltip/test/__snapshots__/tooltip.spec.tsx.snap
+++ b/packages/ui-components/src/components/tooltip/test/__snapshots__/tooltip.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tooltip (unit tests) when has a position should match the snapshot 1`] = `
-<kv-tooltip position="left" text="Tooltip">
+<kv-tooltip delay="1000" position="left" text="Tooltip">
   <mock:shadow-root>
     <div aria-describedby="tooltip" id="content" part="content">
       <slot></slot>
@@ -14,7 +14,7 @@ exports[`Tooltip (unit tests) when has a position should match the snapshot 1`] 
 `;
 
 exports[`Tooltip (unit tests) when uses default props should match the snapshot 1`] = `
-<kv-tooltip text="Tooltip">
+<kv-tooltip delay="1000" text="Tooltip">
   <mock:shadow-root>
     <div aria-describedby="tooltip" id="content" part="content">
       <slot></slot>

--- a/packages/ui-components/src/components/tooltip/tooltip.config.ts
+++ b/packages/ui-components/src/components/tooltip/tooltip.config.ts
@@ -4,3 +4,5 @@ export const DEFAULT_POSITION_CONFIG: Partial<ComputePositionConfig> = {
 	strategy: 'fixed',
 	middleware: [offset(5), shift({ padding: 5 })]
 };
+
+export const DEFAULT_DELAY_CONFIG: number = 1000;

--- a/packages/ui-components/src/components/tooltip/tooltip.tsx
+++ b/packages/ui-components/src/components/tooltip/tooltip.tsx
@@ -2,7 +2,7 @@ import { Component, Element, Host, Prop, State, h } from '@stencil/core';
 import { ComputePositionConfig, computePosition } from '@floating-ui/dom';
 import { isEmpty, merge } from 'lodash-es';
 
-import { DEFAULT_POSITION_CONFIG } from './tooltip.config';
+import { DEFAULT_DELAY_CONFIG, DEFAULT_POSITION_CONFIG } from './tooltip.config';
 import { ETooltipPosition } from '../../types';
 import { ITooltip } from './tooltip.types';
 import { isElementCollpased } from './tooltip.utils';
@@ -18,7 +18,7 @@ import { isElementCollpased } from './tooltip.utils';
 })
 export class KvTooltip implements ITooltip {
 	/** (optional) Delay to show tooltip in milliseconds. */
-	@Prop({ reflect: true }) delay?: number;
+	@Prop({ reflect: true }) delay?: number = DEFAULT_DELAY_CONFIG;
 	/** @inheritdoc */
 	@Prop({ reflect: true }) text: string;
 	/** @inheritdoc */


### PR DESCRIPTION
So, I talked with Iza to understand if this was a maps only requirement or a library requirement and she confirmed me that it was a library requirement.