### PR TITLE
fix(tooltip): add white space normal

### DIFF
--- a/packages/ui-components/src/components/tooltip/readme.md
+++ b/packages/ui-components/src/components/tooltip/readme.md
@@ -2,6 +2,7 @@
 
 <!-- Auto Generated Below -->
 
+
 ## Usage
 
 ### Angular
@@ -23,6 +24,7 @@
 </kv-tooltip>
 ```
 
+
 ### React
 
 ```tsx
@@ -31,24 +33,26 @@ import React from 'react';
 import { KvTooltip, KvActionButton, ETooltipPosition, EActionButtonType } from '@kelvininc/react-ui-components';
 
 export const TagLetterExample: React.FC = () => (
-	<>
-		{/*-- Default --*/}
-		<KvTooltip text="Tooltip">
-			<KvActionButton type={EActionButtonType.Primary}>Hover me!</KvActionButton>
-		</KvTooltip>
+  <>
+    {/*-- Default --*/}
+	<KvTooltip text="Tooltip">
+		<KvActionButton type={EActionButtonType.Primary}>Hover me!</KvActionButton>
+	</KvTooltip>
 
-		{/*-- With Fixed Position --*/}
-		<KvTooltip text="Tooltip" position={ETooltipPosition.Left}>
-			<KvActionButton type={EActionButtonType.Primary}>Hover me!</KvActionButton>
-		</KvTooltip>
+	{/*-- With Fixed Position --*/}
+	<KvTooltip text="Tooltip" position={ETooltipPosition.Left}>
+		<KvActionButton type={EActionButtonType.Primary}>Hover me!</KvActionButton>
+	</KvTooltip>
 
-		{/*-- With Allowed Positions --*/}
-		<KvTooltip text="Tooltip" allowedPositions={[ETooltipPosition.Top, ETooltipPosition.Bottom]}>
-			<KvActionButton type={EActionButtonType.Primary}>Hover me!</KvActionButton>
-		</KvTooltip>
-	</>
+	{/*-- With Allowed Positions --*/}
+	<KvTooltip text="Tooltip" allowedPositions={[ETooltipPosition.Top, ETooltipPosition.Bottom]}>
+		<KvActionButton type={EActionButtonType.Primary}>Hover me!</KvActionButton>
+	</KvTooltip>
+  </>
 );
 ```
+
+
 
 ## Properties
 
@@ -62,6 +66,7 @@ export const TagLetterExample: React.FC = () => (
 | `text`           | `text`     | (optional) Text of tooltip                                                 | `string`                                                                                                                                                                                                                                                                                                                                         | `undefined`               |
 | `truncate`       | `truncate` | (optional) Set `true` to display tooltip only when the content is trucated | `boolean`                                                                                                                                                                                                                                                                                                                                        | `false`                   |
 
+
 ## Shadow Parts
 
 | Part          | Description            |
@@ -69,22 +74,23 @@ export const TagLetterExample: React.FC = () => (
 | `"container"` | The tooltip container. |
 | `"content"`   | The tooltip content.   |
 
+
 ## CSS Custom Properties
 
 | Name                  | Description                                  |
 | --------------------- | -------------------------------------------- |
 | `--container-z-index` | The z-index value for the tooltip container. |
 
+
 ## Dependencies
 
 ### Used by
 
--   [kv-info-label](../info-label)
--   [kv-text-field](../text-field)
--   [kv-tree-item](../tree-item)
+ - [kv-info-label](../info-label)
+ - [kv-text-field](../text-field)
+ - [kv-tree-item](../tree-item)
 
 ### Graph
-
 ```mermaid
 graph TD;
   kv-info-label --> kv-tooltip
@@ -93,4 +99,6 @@ graph TD;
   style kv-tooltip fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
----
+----------------------------------------------
+
+

--- a/packages/ui-components/src/components/tooltip/tooltip.scss
+++ b/packages/ui-components/src/components/tooltip/tooltip.scss
@@ -24,4 +24,5 @@
 	position: fixed;
 	z-index: var(--container-z-index);
 	display: none;
+	white-space: normal;
 }

--- a/packages/ui-components/src/components/tree-item/readme.md
+++ b/packages/ui-components/src/components/tree-item/readme.md
@@ -2,6 +2,7 @@
 
 <!-- Auto Generated Below -->
 
+
 ## Usage
 
 ### Angular
@@ -38,6 +39,7 @@
 	<kv-tree-item label="Node 3" slot="child-slot"></kv-tree-item>
 </kv-tree-item>
 ```
+
 
 ### React
 
@@ -81,6 +83,8 @@ export const TreeItemExample: React.FC = () => (
 );
 ```
 
+
+
 ## Properties
 
 | Property          | Attribute          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Type                                                                                                                     | Default                    |
@@ -108,6 +112,7 @@ export const TreeItemExample: React.FC = () => (
 | `target`          | `target`           | (optional) The anchor's target                                                                                                                                                                                                                                                                                                                                                                                                                                                        | `EAnchorTarget.BrowserDefault \| EAnchorTarget.NewTab \| EAnchorTarget.Parent \| EAnchorTarget.Top`                      | `undefined`                |
 | `tooltipDelay`    | `tooltip-delay`    | (optional) Delay to show tooltip in milliseconds.                                                                                                                                                                                                                                                                                                                                                                                                                                     | `number`                                                                                                                 | `undefined`                |
 
+
 ## Events
 
 | Event          | Description                               | Type                      |
@@ -115,17 +120,20 @@ export const TreeItemExample: React.FC = () => (
 | `itemClick`    | Emitted when the tree item is clicked     | `CustomEvent<MouseEvent>` |
 | `toggleExpand` | Emitted when the expand toggle is clicked | `CustomEvent<MouseEvent>` |
 
+
 ## Slots
 
 | Slot           | Description                                                                |
 | -------------- | -------------------------------------------------------------------------- |
 | `"child-slot"` | Content is placed in the child subgroup and can be expanded and collapsed. |
 
+
 ## Shadow Parts
 
 | Part         | Description             |
 | ------------ | ----------------------- |
 | `"children"` | The children container. |
+
 
 ## CSS Custom Properties
 
@@ -162,20 +170,20 @@ export const TreeItemExample: React.FC = () => (
 | `--title-color-selected`         | Node title color when node state is selected.       |
 | `--vertical-lines-height`        | Line height of children's connectors.               |
 
+
 ## Dependencies
 
 ### Used by
 
--   [kv-tree](../tree)
+ - [kv-tree](../tree)
 
 ### Depends on
 
--   [kv-icon](../icon)
--   [kv-tooltip](../tooltip)
--   [kv-badge](../badge)
+- [kv-icon](../icon)
+- [kv-tooltip](../tooltip)
+- [kv-badge](../badge)
 
 ### Graph
-
 ```mermaid
 graph TD;
   kv-tree-item --> kv-icon
@@ -185,4 +193,6 @@ graph TD;
   style kv-tree-item fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
----
+----------------------------------------------
+
+


### PR DESCRIPTION
I added this style so the white space does not get set by a CSS class in a inner div. What was happening in some cases was that a inner div a style such as `white-space: nowrap;` and the usage of the tooltip component was not producing the desired results (with the tooltip text leaving the card).