### PR TITLE
fix(action-button-icon): remove height offset

### DIFF
--- a/packages/react-ui-components/src/components/SchemaForm/Templates/ArrayFieldTemplate/ArrayFieldTemplate.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/ArrayFieldTemplate/ArrayFieldTemplate.module.scss
@@ -3,7 +3,7 @@
 .ArrayItemList {
 	display: flex;
 	flex-direction: column;
-	gap: $spacing-5x;
+	gap: var(--schema-form-fields-y-gap) var(--schema-form-fields-x-gap);
 }
 
 .ArrayFieldTemplate {

--- a/packages/ui-components/src/components/action-button-icon/action-button-icon.scss
+++ b/packages/ui-components/src/components/action-button-icon/action-button-icon.scss
@@ -42,6 +42,8 @@ kv-action-button {
 	--background-color-active-tertiary: #{kv-color('neutral-5')};
 	--border-color-active-tertiary: #{kv-color('neutral-4')};
 	--text-color-active-tertiary: #{kv-color('neutral-4')};
+
+	display: flex;
 }
 
 kv-icon {


### PR DESCRIPTION
This PR fixes an height offset added to the kv-action-button-icon.

This is just a quick fix since the problem might be in one of the kv-action-button mixins that were developed with the kv-icon offset in height. However, a more deep research is needed to confirm that there is actual something wrong with one of the mixins. 