### PR TITLE
fix(react-ui-components): change build config to organize correctly the lodash dependency

### DIFF
--- a/packages/react-ui-components/package-lock.json
+++ b/packages/react-ui-components/package-lock.json
@@ -4382,6 +4382,59 @@
 				}
 			}
 		},
+		"@optimize-lodash/rollup-plugin": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@optimize-lodash/rollup-plugin/-/rollup-plugin-4.0.1.tgz",
+			"integrity": "sha512-Scqshe8dSKVnJPncHx/LyW00ZSz2XnbOxnS3PcPpRi89XShd5EbY44GaoeY1Fl8qlD5pqspjOoj7cJKmM6Fmdw==",
+			"dev": true,
+			"requires": {
+				"@optimize-lodash/transform": "3.x",
+				"@rollup/pluginutils": "~5.0.2"
+			},
+			"dependencies": {
+				"@rollup/pluginutils": {
+					"version": "5.0.2",
+					"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+					"integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+					"dev": true,
+					"requires": {
+						"@types/estree": "^1.0.0",
+						"estree-walker": "^2.0.2",
+						"picomatch": "^2.3.1"
+					}
+				},
+				"@types/estree": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+					"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+					"dev": true
+				},
+				"estree-walker": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+					"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+					"dev": true
+				}
+			}
+		},
+		"@optimize-lodash/transform": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@optimize-lodash/transform/-/transform-3.0.0.tgz",
+			"integrity": "sha512-w5cuqlbFdMgkPpSuGnsiMNfjOaXBKkxnBNHThTQQ8drdxeMzCsUlQMQITMo4t3+mPFR8NIA2rlxF0GRJSYqBuw==",
+			"dev": true,
+			"requires": {
+				"estree-walker": "2.x",
+				"magic-string": "0.25.x"
+			},
+			"dependencies": {
+				"estree-walker": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+					"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+					"dev": true
+				}
+			}
+		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.7.tgz",

--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -57,6 +57,7 @@
 		"fs-extra": "10.0.0"
 	},
 	"devDependencies": {
+		"@optimize-lodash/rollup-plugin": "^4.0.1",
 		"@pxtrn/storybook-addon-docs-stencil": "^6.4.1",
 		"@rollup/plugin-node-resolve": "^13.1.3",
 		"@rollup/plugin-typescript": "8.3.3",
@@ -83,7 +84,7 @@
 		"eslint-plugin-storybook": "^0.6.1",
 		"jest": "^23.0.0",
 		"jest-dom": "^3.0.2",
-		"lodash-es": "^4.17.21",
+		"lodash": "^4.17.21",
 		"prettier": "^2.5.1",
 		"react": "^17.0.2",
 		"react-dom": "^17.0.2",

--- a/packages/react-ui-components/rollup.config.js
+++ b/packages/react-ui-components/rollup.config.js
@@ -3,37 +3,52 @@ import copy from 'rollup-plugin-copy';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
 import typescript from '@rollup/plugin-typescript';
 import postcss from 'rollup-plugin-postcss';
+import { optimizeLodashImports } from '@optimize-lodash/rollup-plugin';
 
-export default {
-	input: 'src/components/index.ts',
-	output: [
-		{
+const input = 'src/components/index.ts';
+
+const getPlugins = (lodashImportOpts = {}, otherPlugins = []) => {
+	return [
+		peerDepsExternal(),
+		resolve(),
+		optimizeLodashImports({ ...lodashImportOpts }),
+		typescript({ tsconfig: './tsconfig.lib.json' }),
+		postcss(),
+		...otherPlugins
+	];
+};
+
+export default [
+	{
+		input,
+		output: {
 			dir: 'dist/',
 			entryFileNames: '[name].esm.js',
 			chunkFileNames: '[name]-[hash].esm.js',
 			format: 'es',
 			sourcemap: true
 		},
-		{
+		external: id => !/^(\.|\/)/.test(id),
+		plugins: getPlugins({ useLodashEs: true })
+	},
+	{
+		input,
+		output: {
 			dir: 'dist/',
 			format: 'commonjs',
 			preferConst: true,
 			sourcemap: true
-		}
-	],
-	external: id => !/^(\.|\/)/.test(id),
-	plugins: [
-		peerDepsExternal(),
-		resolve(),
-		typescript({ tsconfig: './tsconfig.lib.json' }),
-		postcss(),
-		copy({
-			targets: [
-				{
-					src: '../ui-components/src/assets',
-					dest: './'
-				}
-			]
-		})
-	]
-};
+		},
+		external: id => !/^(\.|\/)/.test(id),
+		plugins: getPlugins({}, [
+			copy({
+				targets: [
+					{
+						src: '../ui-components/src/assets',
+						dest: './'
+					}
+				]
+			})
+		])
+	}
+];

--- a/packages/react-ui-components/src/components/SchemaForm/SchemaForm.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/SchemaForm.tsx
@@ -2,7 +2,7 @@ import { EActionButtonType, EComponentSize } from '@kelvininc/ui-components';
 import Form, { FormProps, IChangeEvent, withTheme } from '@rjsf/core';
 import { deepEquals, getSubmitButtonOptions } from '@rjsf/utils';
 import classNames from 'classnames';
-import { cloneDeep, isEmpty, isEqualWith } from 'lodash-es';
+import { cloneDeep, isEmpty, isEqualWith } from 'lodash';
 import React, { ComponentProps, ComponentType, ForwardedRef, forwardRef, PropsWithChildren, useEffect, useMemo, useRef, useState } from 'react';
 import { useScroll } from '../../utils';
 import { KvActionButtonText } from '../stencil-generated';

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -1,7 +1,7 @@
 import { EActionButtonType, EComponentSize, EIconName } from '@kelvininc/ui-components';
 import { ArrayFieldTemplateItemType } from '@rjsf/utils';
 import classNames from 'classnames';
-import { get } from 'lodash-es';
+import { get } from 'lodash';
 import React from 'react';
 import { KvActionButtonIcon } from '../../../stencil-generated';
 import styles from './ArrayFieldItemTemplate.module.scss';

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/BaseInputTemplate/BaseInputTemplate.tsx
@@ -1,6 +1,6 @@
 import { EInputFieldType, EValidationState } from '@kelvininc/ui-components';
 import classNames from 'classnames';
-import { get, isArray, isEmpty } from 'lodash-es';
+import { get, isArray, isEmpty } from 'lodash';
 import React, { useCallback, useMemo } from 'react';
 import { KvTextField } from '../../../stencil-generated';
 import styles from './BaseInputTemplate.module.scss';

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/DescriptionFieldTemplate/DescriptionFieldTemplate.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/DescriptionFieldTemplate/DescriptionFieldTemplate.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { DescriptionFieldProps } from '@rjsf/utils';
 import { KvInfoLabel } from '../../../stencil-generated';
 import styles from './DescriptionFieldTemplate.module.scss';
-import { isString } from 'lodash-es';
+import { isString } from 'lodash';
 import { isValidLabel } from '../helper';
 
 const DescriptionFieldTemplate = ({ description }: DescriptionFieldProps) => {

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/ErrorListTemplate/ErrorListTemplate.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/ErrorListTemplate/ErrorListTemplate.tsx
@@ -1,6 +1,6 @@
 import { EValidationState } from '@kelvininc/ui-components';
 import { ErrorListProps, RJSFValidationError } from '@rjsf/utils';
-import { isEmpty } from 'lodash-es';
+import { isEmpty } from 'lodash';
 import React from 'react';
 import { KvFormHelpText } from '../../../stencil-generated';
 import styles from './ErrorListTemplate.module.scss';

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/FieldTemplate/FieldTemplate.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/FieldTemplate/FieldTemplate.tsx
@@ -1,6 +1,6 @@
 import { EValidationState } from '@kelvininc/ui-components';
 import { FieldTemplateProps, getTemplate, getUiOptions } from '@rjsf/utils';
-import { isEmpty } from 'lodash-es';
+import { isEmpty } from 'lodash';
 import React from 'react';
 import { KvFormHelpText } from '../../../stencil-generated';
 import styles from './FieldTemplate.module.scss';

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -1,7 +1,7 @@
 import { EActionButtonType, EComponentSize, EIconName } from '@kelvininc/ui-components';
 import { ObjectFieldTemplateProps, canExpand, getTemplate, getUiOptions } from '@rjsf/utils';
 import classNames from 'classnames';
-import { get } from 'lodash-es';
+import { get } from 'lodash';
 import React, { useMemo } from 'react';
 import { KvActionButtonIcon } from '../../../stencil-generated';
 import { INPUT_INLINE_WIDTH } from '../../config';

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/TitleFieldTemplate/TitleFieldTemplate.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/TitleFieldTemplate/TitleFieldTemplate.tsx
@@ -1,5 +1,5 @@
 import { TitleFieldProps } from '@rjsf/utils';
-import { get } from 'lodash-es';
+import { get } from 'lodash';
 import React from 'react';
 import { KvInfoLabel } from '../../../stencil-generated';
 import { isValidLabel } from '../helper';

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/helper.ts
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/helper.ts
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash-es';
+import { isEmpty } from 'lodash';
 
 export const isValidLabel = (label: string) => {
 	return !isEmpty(label?.trim());

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/CheckboxesWidget/CheckboxesWidget.tsx
@@ -3,7 +3,7 @@ import { KvFormLabel, KvRadioButtonGroup } from '../../../stencil-generated';
 import React, { useCallback, useMemo } from 'react';
 import { buildRadioButtons, buildSelectedRadioButtons, toggleSelectedOptions } from './utils';
 import { ICheckboxConfig } from './types';
-import { get, isEmpty } from 'lodash-es';
+import { get, isEmpty } from 'lodash';
 
 const CheckboxesWidget = ({ schema, label, id, disabled, options, value, required, readonly, onChange, uiSchema }: WidgetProps) => {
 	const { enumOptions, enumDisabled, allButton } = options;

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/RadioWidget/RadioWidget.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/RadioWidget/RadioWidget.tsx
@@ -3,7 +3,7 @@ import { WidgetProps } from '@rjsf/utils';
 import { KvRadio, KvFormLabel } from '../../../stencil-generated';
 import styles from './RadioWidget.module.scss';
 import classNames from 'classnames';
-import { get } from 'lodash-es';
+import { get } from 'lodash';
 
 const RadioWidget = ({ label, required, schema, id, options, value, disabled, readonly, onChange, uiSchema }: WidgetProps) => {
 	const { enumOptions, enumDisabled, inline } = options;

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/ReadOnlyValueWidget/ReadOnlyValueWidget.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/ReadOnlyValueWidget/ReadOnlyValueWidget.tsx
@@ -1,5 +1,5 @@
 import { WidgetProps } from '@rjsf/utils';
-import { get } from 'lodash-es';
+import { get } from 'lodash';
 import React from 'react';
 import { getMatchingOption } from './helper';
 import styles from './ReadOnlyValueWidget.module.scss';

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/SelectWidget.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/SelectWidget.tsx
@@ -1,7 +1,7 @@
 import { EValidationState } from '@kelvininc/ui-components';
 import { WidgetProps } from '@rjsf/utils';
 import classNames from 'classnames';
-import { isEmpty } from 'lodash-es';
+import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { KvMultiSelectDropdown, KvSingleSelectDropdown } from '../../../stencil-generated';
 import styles from './SelectWidget.module.scss';

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/utils.ts
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/utils.ts
@@ -1,6 +1,6 @@
 import { asNumber, guessType } from '@rjsf/utils';
 import { JSONSchema7 } from 'json-schema';
-import { get } from 'lodash-es';
+import { get } from 'lodash';
 import { EnumOptions, IUIDropdownOptions } from './types';
 
 const numericTypes = ['number', 'integer'];

--- a/packages/react-ui-components/src/utils/useScroll.ts
+++ b/packages/react-ui-components/src/utils/useScroll.ts
@@ -1,4 +1,4 @@
-import { throttle } from 'lodash-es';
+import { throttle } from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 
 export function getScrollTop(element?: HTMLDivElement) {


### PR DESCRIPTION
**Problem**

The `react-ui-components generate` a commonjs package that uses `lodash-es` as a module.

**Solution**

With [optimize lodash plugin](https://www.npmjs.com/package/@optimize-lodash/rollup-plugin) ES & CJS generated files have different approaches to handle lodash methods;

ES
`import { isEmpty } from 'lodash-es'`

CJS
`import isEmpty from lodash/isEmpty`