### PR TITLE
fix(multi-select-dropdown): add empty check to options

### DIFF
--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/utils.ts
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/utils.ts
@@ -60,7 +60,7 @@ export const buildDropdownOptions = (options?: EnumOptions, disabledOptions?: En
 		  }, {})
 		: [];
 
-export const searchDropdownOptions = (term: string, options: IUIDropdownOptions) => {
+export const searchDropdownOptions = (term: string, options: IUIDropdownOptions): IUIDropdownOptions => {
 	const lowerCaseTerm = term.toLowerCase();
 	return Object.keys(options).reduce<IUIDropdownOptions>((accumulator, key) => {
 		const option = options[key];

--- a/packages/ui-components/src/components/action-button-split/action-button-split.tsx
+++ b/packages/ui-components/src/components/action-button-split/action-button-split.tsx
@@ -1,5 +1,4 @@
-import { Component, Event, EventEmitter, h, Host, Prop, State, Watch } from '@stencil/core';
-import { isEmpty } from 'lodash-es';
+import { Component, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
 import { EActionButtonType, IButton } from '../action-button/action-button.types';
 import { EComponentSize, IAnchor, EAnchorTarget } from '../../utils/types';
 import { EIconName, EOtherIconName } from '../icon/icon.types';
@@ -40,15 +39,6 @@ export class KvActionButtonSplit implements IButton, IAnchor {
 	@Prop({ reflect: true }) target?: EAnchorTarget;
 	/** @inheritdoc */
 	@Prop({ reflect: true }) download?: string;
-
-	/** Whether the left button icon exists and it's not empty */
-	@State() hasIcon: boolean = !isEmpty(this.icon);
-
-	/** Watch `icon` property for changes and update `hasIcon` accordingly */
-	@Watch('icon')
-	iconHandler(newIcon: string) {
-		this.hasIcon = !isEmpty(newIcon);
-	}
 
 	/** Emitted when left button is clicked */
 	@Event() clickLeftButton: EventEmitter<MouseEvent>;

--- a/packages/ui-components/src/components/action-button-split/test/action-button-split.spec.ts
+++ b/packages/ui-components/src/components/action-button-split/test/action-button-split.spec.ts
@@ -26,7 +26,6 @@ describe('Action Button Split (unit tests)', () => {
 
 		it('should initialize `icon` with undefined', () => {
 			expect(component.icon).toBeUndefined();
-			expect(component.hasIcon).toBe(false);
 		});
 
 		it('should initialize `size` with large', () => {
@@ -45,20 +44,6 @@ describe('Action Button Split (unit tests)', () => {
 
 		it('should match the snapshot', () => {
 			expect(page.root).toMatchSnapshot();
-		});
-
-		it('should initialize `hasIcon` with true', () => {
-			expect(component.hasIcon).toBe(true);
-		});
-
-		describe('and the icon is removed', () => {
-			beforeEach(() => {
-				page.root.setAttribute('icon', '');
-			});
-
-			it('should change `hasIcon` to false', () => {
-				expect(component.hasIcon).toBe(false);
-			});
 		});
 	});
 });

--- a/packages/ui-components/src/components/action-button-text/action-button-text.tsx
+++ b/packages/ui-components/src/components/action-button-text/action-button-text.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, EventEmitter, h, Host, Prop, State, Watch } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Host, Prop, State } from '@stencil/core';
 import { isEmpty } from 'lodash-es';
 import { EActionButtonType, IButton, IButtonEvents } from '../action-button/action-button.types';
 import { EAnchorTarget, EComponentSize, IAnchor } from '../../utils/types';
@@ -39,15 +39,6 @@ export class KvActionButtonText implements IButton, IButtonEvents, IAnchor {
 	/** @inheritdoc */
 	@Event() blurButton: EventEmitter<FocusEvent>;
 
-	/** (optional) Whether the icon exist and it's not empty */
-	@State() hasIcon: boolean = !isEmpty(this.icon);
-
-	/** Watch `icon` property for changes and update `hasIcon` accordingly */
-	@Watch('icon')
-	iconHandler(newIcon: string) {
-		this.hasIcon = !isEmpty(newIcon);
-	}
-
 	render() {
 		return (
 			<Host>
@@ -61,7 +52,7 @@ export class KvActionButtonText implements IButton, IButtonEvents, IAnchor {
 					target={this.target}
 					exportparts="button"
 				>
-					{this.hasIcon && <kv-icon name={this.icon} exportparts="icon" />}
+					{this.icon && <kv-icon name={this.icon} exportparts="icon" />}
 					<span class="action-button-text" part="button-text">
 						{this.text}
 					</span>

--- a/packages/ui-components/src/components/action-button-text/test/action-button-text.spec.ts
+++ b/packages/ui-components/src/components/action-button-text/test/action-button-text.spec.ts
@@ -26,7 +26,6 @@ describe('Action Button Text (unit tests)', () => {
 
 		it('should initialize `icon` with undefined', () => {
 			expect(component.icon).toBeUndefined();
-			expect(component.hasIcon).toBe(false);
 		});
 
 		it('should initialize `size` with large', () => {
@@ -45,20 +44,6 @@ describe('Action Button Text (unit tests)', () => {
 
 		it('should match the snapshot', () => {
 			expect(page.root).toMatchSnapshot();
-		});
-
-		it('should initialize `hasIcon` with true', () => {
-			expect(component.hasIcon).toBe(true);
-		});
-
-		describe('and the icon is removed', () => {
-			beforeEach(() => {
-				page.root.setAttribute('icon', '');
-			});
-
-			it('should change `hasIcon` to false', () => {
-				expect(component.hasIcon).toBe(false);
-			});
 		});
 	});
 });

--- a/packages/ui-components/src/components/multi-select-dropdown/multi-select-dropdown.helper.ts
+++ b/packages/ui-components/src/components/multi-select-dropdown/multi-select-dropdown.helper.ts
@@ -1,8 +1,8 @@
 import { isNil } from 'lodash-es';
-import { IMultiSelectDropdownOption } from './multi-select-dropdown.types';
+import { IMultiSelectDropdownOptions } from './multi-select-dropdown.types';
 
-export const getSelectedOptionsCount = (options: { [key: string]: IMultiSelectDropdownOption }, selectedOptions: { [key: string]: boolean }): string[] => {
-	return Object.keys(selectedOptions).reduce((accumulator, selectOption) => {
+export const getSelectedOptionsCount = (options: IMultiSelectDropdownOptions = {}, selectedOptions: { [key: string]: boolean } = {}): string[] => {
+	return Object.keys(selectedOptions).reduce<string[]>((accumulator, selectOption) => {
 		if (isNil(options[selectOption])) {
 			return accumulator;
 		}
@@ -15,7 +15,7 @@ export const getSelectedOptionsCount = (options: { [key: string]: IMultiSelectDr
 	}, []);
 };
 
-export const getDropdownDisplayValue = (options: { [key: string]: IMultiSelectDropdownOption }, selectedOptions: { [key: string]: boolean }): string => {
+export const getDropdownDisplayValue = (options: IMultiSelectDropdownOptions = {}, selectedOptions: { [key: string]: boolean } = {}): string => {
 	return getSelectedOptionsCount(options, selectedOptions).reduce((acc, optionKey, currentIndex, selectedOptionsArray) => {
 		if (isNil(options[optionKey])) {
 			if (currentIndex === selectedOptionsArray.length - 1) {

--- a/packages/ui-components/src/components/select-group/select-group.helper.ts
+++ b/packages/ui-components/src/components/select-group/select-group.helper.ts
@@ -1,7 +1,7 @@
 import { groupBy, isEmpty } from 'lodash-es';
 import { EMPTY_GROUP_NAME, NO_GROUP_NAME } from './select-group.config';
 
-export const buildSelectGroups = <T extends { group?: string }>(options: Record<string, T>): Record<string, T[]> => {
+export const buildSelectGroups = <T extends { group?: string }>(options: Record<string, T> = {}): Record<string, T[]> => {
 	/**
 	 * Note: All options that do not contain a `group` filed will be aggregated on an `undefined` (EMPTY_GROUP_NAME) group name.
 	 */


### PR DESCRIPTION
This PR is related to https://github.com/kelvininc/ui-components/issues/210.

We were not handling the possibility of the options prop being `undefined`.