### PR TITLE
fix(modal)!: click outside behavior can now be customized

### DIFF
--- a/packages/react-ui-components/src/stories/Components/Modal.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/Modal.stories.tsx
@@ -43,10 +43,10 @@ NoCloseButton.args = {
 	showCloseButton: false
 };
 
-export const NoBackdrop = ControlledModalTemplate.bind(this);
-NoBackdrop.args = {
+export const NoOverlay = ControlledModalTemplate.bind(this);
+NoOverlay.args = {
 	...DefaultState.args,
-	hasBackdrop: false
+	showOverlay: false
 };
 
 export const WithContentProjection = ControlledModalTemplate.bind(this);

--- a/packages/ui-components/src/components/modal/modal.base.scss
+++ b/packages/ui-components/src/components/modal/modal.base.scss
@@ -6,9 +6,8 @@
 	* @prop --modal-width: The modal's width in px.
 	* @prop --modal-header-height: The modal's header height in px.
 	* @prop --modal-footer-height: The modal's footer height in px.
-	* @prop --modal-overlay-z-index: The modal's overlay z-index css property value.
-	* @prop --modal-body-z-index: The modal's body z-index css property value.
-	* @prop --modal-backdrop-color: The modal's backdrop/overlay color.
+	* @prop --modal-z-index: The modal's z-index
+	* @prop --modal-overlay-color: The modal's overlay color.
 	* @prop --modal-background-color: The modal's background color.
 	* @prop --modal-title-text-color: The modal's text header color.
 	* @prop --modal-close-button-width: The modal's close button width
@@ -18,9 +17,8 @@
 	--modal-width: fit-content;
 	--modal-header-height: 60px;
 	--modal-footer-height: unset;
-	--modal-overlay-z-index: 0;
-	--modal-body-z-index: 1;
-	--modal-backdrop-color: #{kv-color('background', 'step-1')};
+	--modal-z-index: 1;
+	--modal-overlay-color: #{kv-color('background', 'step-1')};
 	--modal-background-color: #{kv-color('background')};
 	--modal-title-text-color: #{kv-color('kv-text')};
 	--modal-close-button-width: 20px;
@@ -30,8 +28,8 @@
 .modal-overlay {
 	position: fixed;
 	inset: 0;
-	z-index: var(--modal-overlay-z-index);
-	background: var(--modal-backdrop-color);
+	z-index: var(--modal-z-index);
+	background: var(--modal-overlay-color);
 }
 
 .modal-container {
@@ -51,7 +49,7 @@
 	background-color: var(--modal-background-color);
 	display: flex;
 	flex-direction: column;
-	z-index: var(--modal-body-z-index);
+	z-index: var(--modal-z-index);
 
 	.top-bar {
 		display: flex;

--- a/packages/ui-components/src/components/modal/modal.light.scss
+++ b/packages/ui-components/src/components/modal/modal.light.scss
@@ -1,6 +1,6 @@
 @import './modal.base';
 
 :host {
-	--modal-backdrop-color: #{kv-color('neutral-6', 'base', 0.5)};
+	--modal-overlay-color: #{kv-color('neutral-6', 'base', 0.5)};
 	--modal-background-color: #{kv-color('neutral-0')};
 }

--- a/packages/ui-components/src/components/modal/modal.night.scss
+++ b/packages/ui-components/src/components/modal/modal.night.scss
@@ -1,6 +1,6 @@
 @import './modal.base';
 
 :host {
-	--modal-backdrop-color: #{kv-color('neutral-9', 'base', 0.8)};
+	--modal-overlay-color: #{kv-color('neutral-9', 'base', 0.8)};
 	--modal-background-color: #{kv-color('neutral-8')};
 }

--- a/packages/ui-components/src/components/modal/modal.tsx
+++ b/packages/ui-components/src/components/modal/modal.tsx
@@ -14,9 +14,9 @@ export class KvModal implements IModalConfig, IModalEvents {
 	/** @inheritdoc */
 	@Prop() headerTitle?: string;
 	/** @inheritdoc */
-	@Prop() hasBackdrop: boolean = true;
+	@Prop() showOverlay: boolean = true;
 	/** @inheritdoc */
-	@Prop() closable?: boolean = true;
+	@Prop() closeOnOverlayClick?: boolean = true;
 	/** @inheritdoc */
 	@Prop() showCloseButton: boolean = true;
 
@@ -29,22 +29,20 @@ export class KvModal implements IModalConfig, IModalEvents {
 	};
 
 	render() {
-		const shouldShowCloseBtn = this.closable && this.showCloseButton;
-
 		return (
 			<Host>
 				<div
 					class={{
-						'modal-overlay': this.hasBackdrop
+						'modal-overlay': this.showOverlay
 					}}
-					onClick={this.closable && this.onClose}
+					onClick={this.closeOnOverlayClick && this.onClose}
 				/>
 				<div class="modal-container">
 					<div class="top-bar">
 						<div class="title">{this.headerTitle}</div>
 						<div class="actions">
 							<slot name="more-top-actions"></slot>
-							{shouldShowCloseBtn && (
+							{this.showCloseButton && (
 								<div class="close" onClick={this.onClose}>
 									<kv-icon name={EIconName.Close}></kv-icon>
 								</div>

--- a/packages/ui-components/src/components/modal/modal.types.ts
+++ b/packages/ui-components/src/components/modal/modal.types.ts
@@ -1,13 +1,13 @@
 import { EventEmitter } from '@stencil/core';
 
 export interface IModalConfig {
-	/** (optional) The modal title label */
+	/** (optional) Defines the modal title label */
 	headerTitle?: string;
-	/** (optional) The modal has a backdrop */
-	hasBackdrop?: boolean;
-	/** (optional) The modal can be closed by the button or click outside */
-	closable?: boolean;
-	/** (optional) The modal shows the close button */
+	/** (optional) Defines if the modal has an overlay background */
+	showOverlay?: boolean;
+	/** (optional) Defines if the modal can be closed with a click on the overlay */
+	closeOnOverlayClick?: boolean;
+	/** (optional) Defines if the modal shows the close button */
 	showCloseButton?: boolean;
 }
 

--- a/packages/ui-components/src/components/modal/readme.md
+++ b/packages/ui-components/src/components/modal/readme.md
@@ -32,12 +32,12 @@ export const ModalOverlayExample: React.FC = (args: ModalOverlayProps) => {
 
 ## Properties
 
-| Property          | Attribute           | Description                                                       | Type      | Default     |
-| ----------------- | ------------------- | ----------------------------------------------------------------- | --------- | ----------- |
-| `closable`        | `closable`          | (optional) The modal can be closed by the button or click outside | `boolean` | `true`      |
-| `hasBackdrop`     | `has-backdrop`      | (optional) The modal has a backdrop                               | `boolean` | `true`      |
-| `headerTitle`     | `header-title`      | (optional) The modal title label                                  | `string`  | `undefined` |
-| `showCloseButton` | `show-close-button` | (optional) The modal shows the close button                       | `boolean` | `true`      |
+| Property              | Attribute                | Description                                                               | Type      | Default     |
+| --------------------- | ------------------------ | ------------------------------------------------------------------------- | --------- | ----------- |
+| `closeOnOverlayClick` | `close-on-overlay-click` | (optional) Defines if the modal can be closed with a click on the overlay | `boolean` | `true`      |
+| `headerTitle`         | `header-title`           | (optional) Defines the modal title label                                  | `string`  | `undefined` |
+| `showCloseButton`     | `show-close-button`      | (optional) Defines if the modal shows the close button                    | `boolean` | `true`      |
+| `showOverlay`         | `show-overlay`           | (optional) Defines if the modal has an overlay background                 | `boolean` | `true`      |
 
 
 ## Events
@@ -49,19 +49,18 @@ export const ModalOverlayExample: React.FC = (args: ModalOverlayProps) => {
 
 ## CSS Custom Properties
 
-| Name                          | Description                                     |
-| ----------------------------- | ----------------------------------------------- |
-| `--modal-backdrop-color`      | The modal's backdrop/overlay color.             |
-| `--modal-background-color`    | The modal's background color.                   |
-| `--modal-body-z-index`        | The modal's body z-index css property value.    |
-| `--modal-close-button-height` | The modal's close button height                 |
-| `--modal-close-button-width`  | The modal's close button width                  |
-| `--modal-footer-height`       | The modal's footer height in px.                |
-| `--modal-header-height`       | The modal's header height in px.                |
-| `--modal-height`              | The modal's height in px.                       |
-| `--modal-overlay-z-index`     | The modal's overlay z-index css property value. |
-| `--modal-title-text-color`    | The modal's text header color.                  |
-| `--modal-width`               | The modal's width in px.                        |
+| Name                          | Description                      |
+| ----------------------------- | -------------------------------- |
+| `--modal-background-color`    | The modal's background color.    |
+| `--modal-close-button-height` | The modal's close button height  |
+| `--modal-close-button-width`  | The modal's close button width   |
+| `--modal-footer-height`       | The modal's footer height in px. |
+| `--modal-header-height`       | The modal's header height in px. |
+| `--modal-height`              | The modal's height in px.        |
+| `--modal-overlay-color`       | The modal's overlay color.       |
+| `--modal-title-text-color`    | The modal's text header color.   |
+| `--modal-width`               | The modal's width in px.         |
+| `--modal-z-index`             | The modal's z-index              |
 
 
 ## Dependencies

--- a/packages/ui-components/src/components/modal/test/modal.e2e.ts
+++ b/packages/ui-components/src/components/modal/test/modal.e2e.ts
@@ -17,7 +17,7 @@ describe('Modal (end-to-end)', () => {
 			closeBtnEl = await page.find('kv-modal >>> .close');
 		});
 
-		it('should render the modal with a backdrop', async () => {
+		it('should render the modal with an overlay', async () => {
 			expect(overlayEl).toBeTruthy();
 		});
 
@@ -48,10 +48,10 @@ describe('Modal (end-to-end)', () => {
 		});
 	});
 
-	describe('when rendering with closable prop false', () => {
+	describe('when not allowing the modal to be closed', () => {
 		beforeEach(async () => {
 			page = await newE2EPage();
-			await page.setContent('<kv-modal closable="false"></kv-modal>');
+			await page.setContent('<kv-modal show-close-button="false" close-on-overlay-click="false"></kv-modal>');
 			hostEl = await page.find('kv-modal');
 			overlayEl = await page.find('kv-modal >>> .modal-overlay');
 			closeBtnEl = await page.find('kv-modal >>> .close');

--- a/packages/ui-components/src/components/modal/test/modal.spec.tsx
+++ b/packages/ui-components/src/components/modal/test/modal.spec.tsx
@@ -18,8 +18,8 @@ describe('Modal (unit tests)', () => {
 			expect(page.root).toMatchSnapshot();
 		});
 
-		it('should set the backdrop to render', () => {
-			expect(comp.hasBackdrop).toBe(true);
+		it('should set the overlay to render', () => {
+			expect(comp.showOverlay).toBe(true);
 		});
 
 		it('should set the close button to render', () => {


### PR DESCRIPTION
The modal component suffered from some logic issues that wouldn't allow us to define if we wanted a click outside to send a `close` event, this PR introduces a fix to define if we want that behaviour to occur or not.

This PR also introduces a smaller fix to the modal's z-index property so it can be properly rendered above any content, the value can be customised through a CSS prop.