### PR TITLE
feat(code-editor): add padding top option

### DIFF
--- a/packages/react-ui-components/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-ui-components/src/components/CodeEditor/CodeEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import Editor, { OnMount, useMonaco } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
-import { DEFAULT_CHANGE_DEBOUNCE_TIME, DEFAULT_EDITOR_LANGUAGE, DEFAULT_EDITOR_THEME, DEFAULT_MONACO_OPTIONS } from './config';
+import { DEFAULT_CHANGE_DEBOUNCE_TIME, DEFAULT_EDITOR_LANGUAGE, DEFAULT_EDITOR_THEME, DEFAULT_MONACO_OPTIONS, DEFAULT_PADDING_TOP } from './config';
 import { ECodeEditorTheme, ICodeEditorProps, OnEditorChangeCallback } from './types';
 import { DebouncedFunc, debounce } from 'lodash';
 import { KvLoader } from '../stencil-generated';
@@ -14,6 +14,7 @@ export const KvCodeEditor = ({
 	language = DEFAULT_EDITOR_LANGUAGE,
 	theme = DEFAULT_EDITOR_THEME,
 	customTheme,
+	paddingTop = DEFAULT_PADDING_TOP,
 	onChange
 }: ICodeEditorProps) => {
 	const monaco = useMonaco();
@@ -23,6 +24,8 @@ export const KvCodeEditor = ({
 	const onChangeDebounced: DebouncedFunc<OnEditorChangeCallback> = useMemo(() => debounce(value => onChange?.(value), debounceTime), []);
 	const onEditorMount: OnMount = useMemo(() => editor => (editorRef.current = editor), []);
 
+	const editorOptions: editor.IEditorOptions = useMemo(() => ({ readOnly, padding: { top: paddingTop } }), [readOnly, paddingTop]);
+
 	const setupEditor = useCallback(() => {
 		if (!monaco || !customTheme) return;
 		monaco.editor.defineTheme(ECodeEditorTheme.Custom, customTheme);
@@ -30,15 +33,17 @@ export const KvCodeEditor = ({
 	}, [monaco, customTheme]);
 
 	const updateOptions = useCallback(() => {
-		if (!readOnlyRef.current || !editorRef.current) return;
-		readOnlyRef.current = readOnly;
-		editorRef.current.updateOptions({ readOnly });
-	}, [editorRef.current, readOnlyRef.current, readOnly]);
+		if (!editorRef.current) return;
+		if (readOnlyRef.current) {
+			readOnlyRef.current = readOnly;
+		}
+		editorRef.current.updateOptions(editorOptions);
+	}, [editorRef.current, readOnlyRef.current, editorOptions]);
 
 	useEffect(() => {
 		setupEditor();
 		updateOptions();
-	}, [setupEditor]);
+	}, [setupEditor, updateOptions]);
 
 	return (
 		<Editor language={language} theme={theme} options={DEFAULT_MONACO_OPTIONS} value={code} loading={loadingComponent} onMount={onEditorMount} onChange={onChangeDebounced} />

--- a/packages/react-ui-components/src/components/CodeEditor/config.ts
+++ b/packages/react-ui-components/src/components/CodeEditor/config.ts
@@ -4,6 +4,7 @@ import type { editor } from 'monaco-editor';
 export const DEFAULT_CHANGE_DEBOUNCE_TIME = 200;
 export const DEFAULT_EDITOR_LANGUAGE = 'yaml';
 export const DEFAULT_EDITOR_THEME = ECodeEditorTheme.Dark;
+export const DEFAULT_PADDING_TOP = 0;
 
 export const DEFAULT_MONACO_OPTIONS: editor.IStandaloneEditorConstructionOptions = {
 	fontFamily: 'Inconsolata',

--- a/packages/react-ui-components/src/components/CodeEditor/readme.md
+++ b/packages/react-ui-components/src/components/CodeEditor/readme.md
@@ -52,6 +52,10 @@ Defaults to: `ECodeEditorTheme.Dark`
 Use this property to define and set a custom theme on the editor
 Defaults to: `undefined`
 
+### _paddingTop (number)_
+Use this property to add some padding (in px) at the top of the editor
+Defaults to: `0`
+
 ### _onChange (OnEditorChangeCallback)_
 Use this property to pass a callback function for when the value (`code`) changes.
 Defaults to: `undefined`

--- a/packages/react-ui-components/src/components/CodeEditor/types.ts
+++ b/packages/react-ui-components/src/components/CodeEditor/types.ts
@@ -25,6 +25,8 @@ export interface ICodeEditorProps {
 	theme?: ECodeEditorTheme;
 	/** Use this property to define and set a custom theme on the editor */
 	customTheme?: CustomThemeData;
+	/** Use this property to add some padding (in px) at the top of the editor */
+	paddingTop?: number;
 	/** Use this property to pass a callback function for when the value (`code`) changes. */
 	onChange?: OnEditorChangeCallback;
 }

--- a/packages/react-ui-components/src/stories/Components/CodeEditor.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/CodeEditor.stories.tsx
@@ -37,6 +37,11 @@ export default {
 			control: {
 				type: 'boolean'
 			}
+		},
+		paddingTop: {
+			control: {
+				type: 'number'
+			}
 		}
 	},
 	parameters: {


### PR DESCRIPTION
This pull request adds the possibility of having a padding at the top of the editor, the screenshot may not be very clear but you can see the blank space at the top.

![image](https://user-images.githubusercontent.com/13225555/219520054-95699705-4622-48ef-a755-6fa800bc627c.png)

After scrolling down:
![image](https://user-images.githubusercontent.com/13225555/219520274-c38bbff7-9cb0-48c9-999b-ad5004825954.png)
