### PR TITLE
fix(code-editor)!: remove debounce time from onChange

### DIFF
--- a/packages/react-ui-components/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-ui-components/src/components/CodeEditor/CodeEditor.tsx
@@ -1,15 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import Editor, { OnMount, useMonaco } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
-import { DEFAULT_CHANGE_DEBOUNCE_TIME, DEFAULT_EDITOR_LANGUAGE, DEFAULT_EDITOR_THEME, DEFAULT_MONACO_OPTIONS, DEFAULT_PADDING_TOP } from './config';
+import { DEFAULT_EDITOR_LANGUAGE, DEFAULT_EDITOR_THEME, DEFAULT_MONACO_OPTIONS, DEFAULT_PADDING_TOP } from './config';
 import { ECodeEditorTheme, ICodeEditorProps, OnEditorChangeCallback } from './types';
-import { DebouncedFunc, debounce } from 'lodash';
 import { KvLoader } from '../stencil-generated';
 
 export const KvCodeEditor = ({
 	code,
 	readOnly = false,
-	debounceTime = DEFAULT_CHANGE_DEBOUNCE_TIME,
 	loadingComponent = <KvLoader />,
 	language = DEFAULT_EDITOR_LANGUAGE,
 	theme = DEFAULT_EDITOR_THEME,
@@ -21,7 +19,7 @@ export const KvCodeEditor = ({
 	const editorRef = useRef<editor.IStandaloneCodeEditor>();
 	const readOnlyRef = useRef<boolean>(readOnly);
 
-	const onChangeDebounced: DebouncedFunc<OnEditorChangeCallback> = useMemo(() => debounce(value => onChange?.(value), debounceTime), []);
+	const onTextChange: OnEditorChangeCallback = value => onChange?.(value);
 	const onEditorMount: OnMount = useMemo(() => editor => (editorRef.current = editor), []);
 
 	const editorOptions: editor.IEditorOptions = useMemo(() => ({ readOnly, padding: { top: paddingTop } }), [readOnly, paddingTop]);
@@ -45,9 +43,7 @@ export const KvCodeEditor = ({
 		updateOptions();
 	}, [setupEditor, updateOptions]);
 
-	return (
-		<Editor language={language} theme={theme} options={DEFAULT_MONACO_OPTIONS} value={code} loading={loadingComponent} onMount={onEditorMount} onChange={onChangeDebounced} />
-	);
+	return <Editor language={language} theme={theme} options={DEFAULT_MONACO_OPTIONS} value={code} loading={loadingComponent} onMount={onEditorMount} onChange={onTextChange} />;
 };
 
 export default KvCodeEditor;

--- a/packages/react-ui-components/src/components/CodeEditor/config.ts
+++ b/packages/react-ui-components/src/components/CodeEditor/config.ts
@@ -1,7 +1,6 @@
 import { ECodeEditorTheme } from './types';
 import type { editor } from 'monaco-editor';
 
-export const DEFAULT_CHANGE_DEBOUNCE_TIME = 200;
 export const DEFAULT_EDITOR_LANGUAGE = 'yaml';
 export const DEFAULT_EDITOR_THEME = ECodeEditorTheme.Dark;
 export const DEFAULT_PADDING_TOP = 0;

--- a/packages/react-ui-components/src/components/CodeEditor/readme.md
+++ b/packages/react-ui-components/src/components/CodeEditor/readme.md
@@ -32,10 +32,6 @@ Defaults to: `undefined`
 Use this property to set the editor to a read only mode where the user cannot modify the value.
 Defaults to: `false`
 
-### _debounceTime (number)_
-Use this property to define the debounce time in ms of the `onChange` function.
-Defaults to: `200`
-
 ### _loadingComponent (ReactNode)_
 Use this property to define a placeholder component to display when the editor is loading.
 Defaults to: `<KvLoader />`

--- a/packages/react-ui-components/src/components/CodeEditor/types.ts
+++ b/packages/react-ui-components/src/components/CodeEditor/types.ts
@@ -15,8 +15,6 @@ export interface ICodeEditorProps {
 	code?: string;
 	/** Use this property to set the editor to a read only mode where the user cannot modify the value. */
 	readOnly?: boolean;
-	/** Use this property to define the debounce time in ms of the `onChange` function. */
-	debounceTime?: number;
 	/** Use this property to define a placeholder component to display when the editor is loading. */
 	loadingComponent?: ReactNode;
 	/** Use this property to define the language mode of the editor. */

--- a/packages/react-ui-components/src/stories/Components/CodeEditor.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/CodeEditor.stories.tsx
@@ -12,11 +12,6 @@ export default {
 				type: 'text'
 			}
 		},
-		debounceTime: {
-			control: {
-				type: 'number'
-			}
-		},
 		language: {
 			control: {
 				type: 'text'


### PR DESCRIPTION
BREAKING CHANGE: This commit removes the `debounceTime` property from the component, therefore removing the default 200ms wait before firing a change event.

Removing this also removed the memoization of the onChange callback, which was causing some issues in render cycles.