### PR TITLE
feat(dropdown-base): add top and bottom spacing

### DIFF
--- a/packages/ui-components/src/components/select/select.scss
+++ b/packages/ui-components/src/components/select/select.scss
@@ -24,6 +24,7 @@
 }
 
 .select-options-container {
+	padding: $spacing-3x 0;
 	max-height: var(--select-max-height);
 	overflow-y: auto;
 }

--- a/packages/ui-components/src/components/tooltip/readme.md
+++ b/packages/ui-components/src/components/tooltip/readme.md
@@ -77,10 +77,10 @@ export const TagLetterExample: React.FC = () => (
 
 ## CSS Custom Properties
 
-| Name                      | Description                                         |
-| ------------------------- | --------------------------------------------------- |
-| `--container-white-space` | The white space strategy for the tooltip container. |
-| `--container-z-index`     | The z-index value for the tooltip container.        |
+| Name                      | Description                                                           |
+| ------------------------- | --------------------------------------------------------------------- |
+| `--container-white-space` | The white space strategy for the tooltip container (default: normal). |
+| `--container-z-index`     | The z-index value for the tooltip container.                          |
 
 
 ## Dependencies


### PR DESCRIPTION
**Description**

Adds a 12px padding to the top and the bottom of the options list.

**Demo**
![image](https://user-images.githubusercontent.com/55213469/222477610-6de00048-fe24-41d2-8827-c076f695faac.png)
