### PR TITLE
feat(select-option)!: add right slot to component

### DIFF
--- a/packages/react-ui-components/src/stories/Components/SelectOption.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/SelectOption.stories.tsx
@@ -43,6 +43,18 @@ const BottomSlotSelectOptionTemplate: ComponentStory<typeof KvSelectOption> = ar
 		</KvSelectOption>
 	);
 };
+const RightSlotSelectOptionTemplate: ComponentStory<typeof KvSelectOption> = args => {
+	const cssProps = {
+		'--select-option-flex-alignment': 'center',
+		'--select-option-justify-content': 'space-between'
+	} as CSSProperties;
+
+	return (
+		<KvSelectOption {...args} style={cssProps}>
+			{args.children}
+		</KvSelectOption>
+	);
+};
 
 export const Default = SelectOptionTemplate.bind({});
 Default.args = {
@@ -56,6 +68,19 @@ Default.args = {
 export const BottomSlot = BottomSlotSelectOptionTemplate.bind({});
 BottomSlot.args = {
 	...Default.args,
-	hasBottomSlot: true,
-	children: <div>Hello</div>
+	children: (
+		<div slot="text-bottom-slot" style={{ color: '#fff' }}>
+			Bottom Slot
+		</div>
+	)
+};
+
+export const RightSlot = RightSlotSelectOptionTemplate.bind({});
+RightSlot.args = {
+	...Default.args,
+	children: (
+		<div slot="text-right-slot" style={{ display: 'flex', alignItems: 'center', color: '#fff' }}>
+			Right Slot
+		</div>
+	)
 };

--- a/packages/ui-components/src/components/select-option/readme.md
+++ b/packages/ui-components/src/components/select-option/readme.md
@@ -41,14 +41,13 @@ export const KvSelectOptionExample: React.FC = () => (
 
 ## Properties
 
-| Property             | Attribute         | Description                                                     | Type      | Default     |
-| -------------------- | ----------------- | --------------------------------------------------------------- | --------- | ----------- |
-| `disabled`           | `disabled`        | (optional) If `true` the item is disabled                       | `boolean` | `false`     |
-| `hasBottomSlot`      | `has-bottom-slot` | (optional) If `true` styles the item to fit content below label | `boolean` | `false`     |
-| `label` _(required)_ | `label`           | (required) The text to display on the item                      | `string`  | `undefined` |
-| `selected`           | `selected`        | (optional) If `true` the item is selected                       | `boolean` | `false`     |
-| `togglable`          | `togglable`       | (optional)  If `true` the item is togglable                     | `boolean` | `false`     |
-| `value` _(required)_ | `value`           | (required) The item value                                       | `string`  | `undefined` |
+| Property             | Attribute   | Description                                 | Type      | Default     |
+| -------------------- | ----------- | ------------------------------------------- | --------- | ----------- |
+| `disabled`           | `disabled`  | (optional) If `true` the item is disabled   | `boolean` | `false`     |
+| `label` _(required)_ | `label`     | (required) The text to display on the item  | `string`  | `undefined` |
+| `selected`           | `selected`  | (optional) If `true` the item is selected   | `boolean` | `false`     |
+| `togglable`          | `togglable` | (optional)  If `true` the item is togglable | `boolean` | `false`     |
+| `value` _(required)_ | `value`     | (required) The item value                   | `string`  | `undefined` |
 
 
 ## Events

--- a/packages/ui-components/src/components/select-option/select-option.scss
+++ b/packages/ui-components/src/components/select-option/select-option.scss
@@ -15,6 +15,7 @@
 	--select-option-height: 32px;
 	--select-option-transition-duration: 100ms;
 	--select-option-flex-alignment: center;
+	--select-option-justify-content: flex-start;
 
 	--select-option-background-color: #{kv-color('neutral-7')};
 	--select-option-background-color-selected: #{kv-color('neutral-6')};
@@ -28,11 +29,16 @@
 	height: var(--select-option-height);
 	padding: 0 $spacing-4x;
 	display: flex;
-	align-items: var(--select-option-flex-alignment);
+	justify-content: var(--select-option-justify-content);
 	user-select: none;
 	cursor: pointer;
 	background-color: var(--select-option-background-color);
 	transition: background-color var(--select-option-transition-duration) linear;
+
+	.label-wrapper {
+		display: flex;
+		align-items: var(--select-option-flex-alignment);
+	}
 
 	.text-container {
 		display: flex;
@@ -69,7 +75,6 @@
 
 	&.has-bottom-slot {
 		padding: $spacing-2x $spacing-3x;
-		align-items: var(--select-option-flex-alignment);
 	}
 
 	kv-checkbox {

--- a/packages/ui-components/src/components/select-option/select-option.tsx
+++ b/packages/ui-components/src/components/select-option/select-option.tsx
@@ -1,5 +1,6 @@
-import { Component, Host, h, Prop, EventEmitter, Event } from '@stencil/core';
+import { Component, Element, Host, h, Prop, EventEmitter, Event } from '@stencil/core';
 import { ISelectOption, ISelectOptionEvents } from './select-option.types';
+import { isNil } from 'lodash';
 
 @Component({
 	tag: 'kv-select-option',
@@ -7,6 +8,8 @@ import { ISelectOption, ISelectOptionEvents } from './select-option.types';
 	shadow: true
 })
 export class KvSelectOption implements ISelectOption, ISelectOptionEvents {
+	@Element() el!: HTMLKvSelectOptionElement;
+
 	/** @inheritdoc */
 	@Prop({ reflect: true }) label!: string;
 	/** @inheritdoc */
@@ -17,8 +20,6 @@ export class KvSelectOption implements ISelectOption, ISelectOptionEvents {
 	@Prop({ reflect: true }) selected?: boolean = false;
 	/** @inheritdoc */
 	@Prop({ reflect: true }) togglable?: boolean = false;
-	/** @inheritdoc */
-	@Prop({ reflect: true }) hasBottomSlot?: boolean = false;
 
 	/** @inheritdoc */
 	@Event() itemSelected: EventEmitter<string>;
@@ -28,6 +29,10 @@ export class KvSelectOption implements ISelectOption, ISelectOptionEvents {
 			this.itemSelected.emit(this.value);
 		}
 	};
+
+	private get hasBottomSlot() {
+		return !isNil(this.el.querySelector('[slot="text-bottom-slot"]'));
+	}
 
 	render() {
 		return (
@@ -41,11 +46,14 @@ export class KvSelectOption implements ISelectOption, ISelectOptionEvents {
 					}}
 					onClick={this.onItemClick}
 				>
-					{this.togglable && <kv-checkbox checked={this.selected} />}
-					<div class="text-container">
-						<div class="item-label">{this.label}</div>
-						<slot></slot>
+					<div class="label-wrapper">
+						{this.togglable && <kv-checkbox checked={this.selected} />}
+						<div class="text-container">
+							<div class="item-label">{this.label}</div>
+							<slot name="text-bottom-slot"></slot>
+						</div>
 					</div>
+					<slot name="text-right-slot"></slot>
 				</div>
 			</Host>
 		);

--- a/packages/ui-components/src/components/select-option/select-option.types.ts
+++ b/packages/ui-components/src/components/select-option/select-option.types.ts
@@ -11,8 +11,6 @@ export interface ISelectOption {
 	selected?: boolean;
 	/** (optional)  If `true` the item is togglable */
 	togglable?: boolean;
-	/** (optional) If `true` styles the item to fit content below label */
-	hasBottomSlot?: boolean;
 }
 
 export interface ISelectOptionEvents {

--- a/packages/ui-components/src/components/select-option/test/__snapshots__/select-option.spec.tsx.snap
+++ b/packages/ui-components/src/components/select-option/test/__snapshots__/select-option.spec.tsx.snap
@@ -1,30 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`KvSelectOption (unit tests) when rendering with bottom slot flag \`true\` should match the snapshot 1`] = `
-<kv-select-option has-bottom-slot="" label="Option 1" value="option1">
-  <mock:shadow-root>
-    <div class="has-bottom-slot select-option">
-      <div class="text-container">
-        <div class="item-label">
-          Option 1
-        </div>
-        <slot></slot>
-      </div>
-    </div>
-  </mock:shadow-root>
-</kv-select-option>
-`;
-
 exports[`KvSelectOption (unit tests) when rendering with default props when the component loads should match the snapshot 1`] = `
 <kv-select-option label="Option 1" value="option1">
   <mock:shadow-root>
     <div class="select-option">
-      <div class="text-container">
-        <div class="item-label">
-          Option 1
+      <div class="label-wrapper">
+        <div class="text-container">
+          <div class="item-label">
+            Option 1
+          </div>
+          <slot name="text-bottom-slot"></slot>
         </div>
-        <slot></slot>
       </div>
+      <slot name="text-right-slot"></slot>
     </div>
   </mock:shadow-root>
 </kv-select-option>

--- a/packages/ui-components/src/components/select-option/test/select-option.e2e.ts
+++ b/packages/ui-components/src/components/select-option/test/select-option.e2e.ts
@@ -55,14 +55,15 @@ describe('Select Item (end-to-end)', () => {
 		});
 	});
 
-	describe('when the component renders with has-bottom-slot flag', () => {
+	describe('when the component renders with a bottom slot', () => {
 		beforeEach(async () => {
 			page = await newE2EPage();
 			await page.setContent(`
 				<kv-select-option
 					label='Option 1'
 					value='option1'
-					has-bottom-slot>
+				>
+					<div slot="text-bottom-slot">Bottom Slot</div>
 				</kv-select-option>`);
 			selectOptionEl = await page.find('kv-select-option');
 			itemEl = await page.find('kv-select-option >>> .select-option');
@@ -70,6 +71,26 @@ describe('Select Item (end-to-end)', () => {
 
 		it('should have the .has-bottom-slot class', () => {
 			expect(itemEl).toHaveClass('has-bottom-slot');
+		});
+	});
+
+	describe('when the component renders with a right slot', () => {
+		beforeEach(async () => {
+			page = await newE2EPage();
+			await page.setContent(`
+				<kv-select-option
+					label='Option 1'
+					value='option1'
+				>
+					<div class="slot-class" slot="text-right-slot">Right Slot</div>
+				</kv-select-option>`);
+		});
+
+		it('should have the content of the right slot', async () => {
+			const selectOptionComponent = await page.find('kv-select-option');
+			const slotComponent = await selectOptionComponent.find('.slot-class');
+			expect(slotComponent).toBeTruthy();
+			expect(slotComponent.innerText).toBe('Right Slot');
 		});
 	});
 });

--- a/packages/ui-components/src/components/select-option/test/select-option.spec.tsx
+++ b/packages/ui-components/src/components/select-option/test/select-option.spec.tsx
@@ -37,22 +37,4 @@ describe('KvSelectOption (unit tests)', () => {
 			});
 		});
 	});
-
-	describe('when rendering with bottom slot flag `true`', () => {
-		beforeEach(async () => {
-			page = await newSpecPage({
-				components: [KvSelectOption],
-				template: () => <kv-select-option label="Option 1" value="option1" hasBottomSlot></kv-select-option>
-			});
-			component = page.rootInstance;
-		});
-
-		it('should match the snapshot', () => {
-			expect(page.root).toMatchSnapshot();
-		});
-
-		it('should set the component `hasBottomSlot` prop to true', () => {
-			expect(component.hasBottomSlot).toEqual(true);
-		});
-	});
 });

--- a/packages/ui-components/src/components/tooltip/readme.md
+++ b/packages/ui-components/src/components/tooltip/readme.md
@@ -77,10 +77,10 @@ export const TagLetterExample: React.FC = () => (
 
 ## CSS Custom Properties
 
-| Name                      | Description                                         |
-| ------------------------- | --------------------------------------------------- |
-| `--container-white-space` | The white space strategy for the tooltip container. |
-| `--container-z-index`     | The z-index value for the tooltip container.        |
+| Name                      | Description                                                           |
+| ------------------------- | --------------------------------------------------------------------- |
+| `--container-white-space` | The white space strategy for the tooltip container (default: normal). |
+| `--container-z-index`     | The z-index value for the tooltip container.                          |
 
 
 ## Dependencies


### PR DESCRIPTION
BREAKING CHANGE

This PR adds the a slot to the right side of the select option. This option is needed to the new time range picker that displays text on the right of the main label.

![Screenshot 2023-03-03 at 16 46 38](https://user-images.githubusercontent.com/37366547/222778423-ad86bcf3-e007-4f4a-9be7-2878f2b0714c.png)
![Screenshot 2023-03-03 at 16 46 48](https://user-images.githubusercontent.com/37366547/222778436-035acce7-29f7-468d-9262-39d3021fc29d.png)
