### PR TITLE
fix(dropdown): add missing flip middleware

### DIFF
--- a/packages/ui-components/src/components/advanced-date-select-dropdown/advanced-date-select-dropdown.config.ts
+++ b/packages/ui-components/src/components/advanced-date-select-dropdown/advanced-date-select-dropdown.config.ts
@@ -1,6 +1,8 @@
-import { ComputePositionConfig, offset } from '@floating-ui/dom';
+import { ComputePositionConfig, offset, size, MiddlewareState } from '@floating-ui/dom';
 import { EIconName } from '../icon/icon.types';
 import { EInputFieldType, EValidationState, ITextField } from '../text-field/text-field.types';
+
+const DEFAULT_DROPDOWN_OFFSET = 8;
 
 export const DEFAULT_DATE_INPUT_CONFIG: Partial<ITextField> = {
 	placeholder: 'Select a date',
@@ -11,5 +13,14 @@ export const DEFAULT_DATE_INPUT_CONFIG: Partial<ITextField> = {
 
 export const DEFAULT_DROPDOWN_POSITION_OPTIONS: Partial<ComputePositionConfig> = {
 	placement: 'bottom-end',
-	middleware: [offset(8)]
+	middleware: [
+		offset(DEFAULT_DROPDOWN_OFFSET),
+		size({
+			apply({ elements }: MiddlewareState) {
+				Object.assign(elements.floating.style, {
+					width: '544px'
+				});
+			}
+		})
+	]
 };

--- a/packages/ui-components/src/components/calendar-advanced-date-selector/calendar-advanced-date-selector.scss
+++ b/packages/ui-components/src/components/calendar-advanced-date-selector/calendar-advanced-date-selector.scss
@@ -4,7 +4,7 @@
 	background-color: kv-color('neutral-7');
 	border: 0.5px solid kv-color('neutral-6');
 	border-radius: 4px;
-	min-width: 544px;
+	width: 544px;
 }
 
 .selector {

--- a/packages/ui-components/src/components/dropdown/dropdown.config.ts
+++ b/packages/ui-components/src/components/dropdown/dropdown.config.ts
@@ -1,4 +1,4 @@
-import { ComputePositionConfig, MiddlewareState, offset, size } from '@floating-ui/dom';
+import { ComputePositionConfig, MiddlewareState, offset, size, flip } from '@floating-ui/dom';
 import { EInputFieldType, EValidationState, ITextField } from '../text-field/text-field.types';
 
 export const DROPDOWN_DEFAULT_PLACEHOLDER = 'Select an option';
@@ -15,6 +15,10 @@ export const DEFAULT_DROPDOWN_POSITION_CONFIG: Partial<ComputePositionConfig> = 
 	placement: 'bottom',
 	middleware: [
 		offset(DEFAULT_DROPDOWN_OFFSET),
+		flip({
+			padding: 16,
+			fallbackPlacements: ['top-end', 'bottom-end', 'top-start', 'bottom-start']
+		}),
 		size({
 			apply({ rects, elements }: MiddlewareState) {
 				Object.assign(elements.floating.style, {


### PR DESCRIPTION
This PR adds the flip middleware to the `kv-dropdown` that was removed on #240.
It also adds a fixed width to the calendar dropdown in order to allow it to have an absolute position.