### PR TITLE
fix(toggletip): stop click event propagation

### DIFF
--- a/packages/ui-components/src/components/dropdown/readme.md
+++ b/packages/ui-components/src/components/dropdown/readme.md
@@ -111,7 +111,7 @@ export class KvDropdownExample {
 
 ### `onToggleOpenState() => Promise<void>`
 
-Toogles the dropdown open state
+Toggles the dropdown open state
 
 #### Returns
 

--- a/packages/ui-components/src/components/toggle-tip/readme.md
+++ b/packages/ui-components/src/components/toggle-tip/readme.md
@@ -87,10 +87,11 @@ export const ToggleTipExample: React.FC = () => (
 
 ## Shadow Parts
 
-| Part                        | Description                  |
-| --------------------------- | ---------------------------- |
-| `"toggle-tip-container"`    | The toggle tip container.    |
-| `"toggle-tip-slot-content"` | The toggle tip slot content. |
+| Part                                  | Description                             |
+| ------------------------------------- | --------------------------------------- |
+| `"toggle-tip-container"`              | The toggle tip container.               |
+| `"toggle-tip-open-element-container"` | The toggle tip's open element container |
+| `"toggle-tip-slot-content"`           | The toggle tip slot content.            |
 
 
 ## CSS Custom Properties

--- a/packages/ui-components/src/components/toggle-tip/test/__snapshots__/toggle-tip.spec.tsx.snap
+++ b/packages/ui-components/src/components/toggle-tip/test/__snapshots__/toggle-tip.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Toggle Tip (unit tests) when has a position should match the snapshot 1`] = `
 <kv-toggle-tip position="left" text="Toggle tip">
   <mock:shadow-root>
-    <div class="toggle-tip-open-element-wrapper" id="toggle-tip-open-element-wrapper">
+    <div class="toggle-tip-open-element-wrapper" id="toggle-tip-open-element-wrapper" part="toggle-tip-open-element-container">
       <slot name="open-element-slot"></slot>
     </div>
     <div class="toggle-tip-container" id="toggle-tip-container" part="toggle-tip-container">
@@ -22,7 +22,7 @@ exports[`Toggle Tip (unit tests) when has a position should match the snapshot 1
 exports[`Toggle Tip (unit tests) when uses default props should match the snapshot 1`] = `
 <kv-toggle-tip text="Toggle tip">
   <mock:shadow-root>
-    <div class="toggle-tip-open-element-wrapper" id="toggle-tip-open-element-wrapper">
+    <div class="toggle-tip-open-element-wrapper" id="toggle-tip-open-element-wrapper" part="toggle-tip-open-element-container">
       <slot name="open-element-slot"></slot>
     </div>
     <div class="toggle-tip-container" id="toggle-tip-container" part="toggle-tip-container">

--- a/packages/ui-components/src/components/toggle-tip/toggle-tip.tsx
+++ b/packages/ui-components/src/components/toggle-tip/toggle-tip.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_AUTOPLACEMENT_CONFIG, DEFAULT_OFFSET, DEFAULT_SHIFT_CONFIG, DEF
 import { IToggleTip, IToggleTipEvents } from './toggle-tip.types';
 
 /**
+ * @part toggle-tip-open-element-container - The toggle tip's open element container
  * @part toggle-tip-container - The toggle tip container.
  * @part toggle-tip-slot-content - The toggle tip slot content.
  */
@@ -82,7 +83,8 @@ export class KvToggleTip implements IToggleTip, IToggleTipEvents {
 		return middleware;
 	};
 
-	private onButtonClick = () => {
+	private onButtonClick = (ev: MouseEvent) => {
+		ev.stopPropagation();
 		this.isOpen = !this.isOpen;
 		this.openStateChange.emit(this.isOpen);
 	};
@@ -137,7 +139,7 @@ export class KvToggleTip implements IToggleTip, IToggleTipEvents {
 	render() {
 		return (
 			<Host>
-				<div id="toggle-tip-open-element-wrapper" class="toggle-tip-open-element-wrapper">
+				<div id="toggle-tip-open-element-wrapper" class="toggle-tip-open-element-wrapper" part="toggle-tip-open-element-container">
 					<slot name="open-element-slot"></slot>
 				</div>
 				<div id="toggle-tip-container" class="toggle-tip-container" part="toggle-tip-container">


### PR DESCRIPTION
Click event propagation was causing erratic behaviour in the `checkForClickOutside` function that would cause the click event in the projected content slot to have a `target` outside the toggletip's element.

This would cause an issue where clicking on the projected content would be interpreted as a click outside of it and wouldn't allow the toggletip to open.

A small addition on this PR is adding an additional `part` to the component so we can style the `open-element` container from a parent element.