### PR TITLE
fix(help-text): change help-text label color to match DS

### DIFF
--- a/packages/ui-components/src/components/form-help-text/form-help-text.scss
+++ b/packages/ui-components/src/components/form-help-text/form-help-text.scss
@@ -6,7 +6,7 @@
 	 * @prop --help-text-error-color: Help Text color when state is invalid.
 	 */
 
-	--help-text-default-color: #{kv-color('neutral-5')};
+	--help-text-default-color: #{kv-color('neutral-4')};
 	--help-text-error-color: #{kv-color('error')};
 }
 

--- a/packages/ui-components/src/components/text-field/text-field.base.scss
+++ b/packages/ui-components/src/components/text-field/text-field.base.scss
@@ -36,7 +36,7 @@
 
 	--text-color-icon-default: #{kv-color('neutral-4')};
 	--text-color-input-disabled: #{kv-color('neutral-5')};
-	--text-color-help-text-default: #{kv-color('neutral-5')};
+	--text-color-help-text-default: #{kv-color('neutral-4')};
 	--text-color-help-text-error: #{kv-color('error')};
 
 	--border-color-error: #{kv-color('error')};


### PR DESCRIPTION
The help text component had the incorrect color set for it's label, this PR fixes it so it matches our design system.