### PR TITLE
fix(typography)!: update typography mixins according to DS

### DIFF
--- a/packages/react-ui-components/src/stories/foundation/Typography/Typography.scss
+++ b/packages/react-ui-components/src/stories/foundation/Typography/Typography.scss
@@ -13,9 +13,6 @@
 	.kv-font-h2-semibold {
 		@include kv-font-h2-semibold;
 	}
-	.kv-font-h3-regular {
-		@include kv-font-h3-regular;
-	}
 	.kv-font-h3-semibold {
 		@include kv-font-h3-semibold;
 	}
@@ -30,9 +27,6 @@
 	.kv-font-label-large-regular {
 		@include kv-font-label-large-regular;
 	}
-	.kv-font-label-medium-light {
-		@include kv-font-label-medium-light;
-	}
 	.kv-font-label-medium-regular {
 		@include kv-font-label-medium-regular;
 	}
@@ -41,6 +35,12 @@
 	}
 	.kv-font-label-small-semibold {
 		@include kv-font-label-small-semibold;
+	}
+	.kv-font-label-small-bold {
+		@include kv-font-label-small-bold;
+	}
+	.kv-font-label-small-uppercase-regular {
+		@include kv-font-label-small-uppercase-regular;
 	}
 	.kv-font-label-small-uppercase-semibold {
 		@include kv-font-label-small-uppercase-semibold;
@@ -53,6 +53,12 @@
 	}
 	.kv-font-label-xsmall-regular {
 		@include kv-font-label-xsmall-regular;
+	}
+	.kv-font-label-xsmall-semibold {
+		@include kv-font-label-xsmall-semibold;
+	}
+	.kv-font-label-xsmall-bold {
+		@include kv-font-label-xsmall-bold;
 	}
 	.kv-font-label-xsmall-uppercase-regular {
 		@include kv-font-label-xsmall-uppercase-regular;
@@ -70,6 +76,9 @@
 	}
 	.kv-font-span-semibold {
 		@include kv-font-span-semibold;
+	}
+	.kv-font-span-uppercase-semibold {
+		@include kv-font-span-uppercase-semibold;
 	}
 
 	/** PARAGRAPHS **/

--- a/packages/react-ui-components/src/stories/foundation/Typography/Typography.stories.mdx
+++ b/packages/react-ui-components/src/stories/foundation/Typography/Typography.stories.mdx
@@ -1,95 +1,78 @@
 import { Meta } from '@storybook/addon-docs';
 import './Typography.scss';
-const headings = [
-	'kv-font-h1-semibold',
-	'kv-font-h2-semibold',
-	'kv-font-h2-regular',
-	'kv-font-h3-semibold',
-	'kv-font-h3-regular',
-	'kv-font-h4-semibold',
-	'kv-font-h5-semibold'
-];
+const headings = ['kv-font-h1-semibold', 'kv-font-h2-semibold', 'kv-font-h2-regular', 'kv-font-h3-semibold', 'kv-font-h4-semibold', 'kv-font-h5-semibold'];
 const labels = [
 	'kv-font-label-large-regular',
 	'kv-font-label-medium-regular',
-	'kv-font-label-medium-light',
 	'kv-font-label-small-uppercase-bold',
 	'kv-font-label-small-uppercase-semibold',
+	'kv-font-label-small-uppercase-regular',
+	'kv-font-label-small-bold',
 	'kv-font-label-small-semibold',
 	'kv-font-label-small-regular',
-	'kv-font-label-xsmall-uppercase-semibold',
 	'kv-font-label-xsmall-uppercase-regular',
+	'kv-font-label-xsmall-uppercase-semibold',
 	'kv-font-label-xsmall-bold',
+	'kv-font-label-xsmall-semibold',
 	'kv-font-label-xsmall-regular',
 	'kv-font-label-xsmall-light'
 ];
-const spans = [
-	'kv-font-span-semibold',
-	'kv-font-span-regular'
-];
-const paragraphs = [
-	'kv-font-paragraph-regular',
-	'kv-font-paragraph-light'
-];
+const spans = ['kv-font-span-semibold', 'kv-font-span-regular', 'kv-font-span-uppercase-semibold'];
+const paragraphs = ['kv-font-paragraph-regular', 'kv-font-paragraph-light'];
 
 <Meta
 	parameters={{
 		viewMode: 'docs',
 		options: { isToolshown: false }
 	}}
-	title='Foundation/Typography'
+	title="Foundation/Typography"
 />
 
 # Typography
 
-*Kelvin's* primary typeface is Proxima Nova. **Proxima Nova** was designed to combine modern proportions with a geometric appearance. It allows you to build interfaces with a look and feel that combines a touch of user-friendly, contemporary, fresh, and timeless design.
-We will use the typeface at various weights, primarily *Light [300]*, *Regular [400]*, *Semibold [600]*, and *Bold [700]*.
+_Kelvin's_ primary typeface is Proxima Nova. **Proxima Nova** was designed to combine modern proportions with a geometric appearance. It allows you to build interfaces with a look and feel that combines a touch of user-friendly, contemporary, fresh, and timeless design.
+We will use the typeface at various weights, primarily _Light [300]_, _Regular [400]_, _Semibold [600]_, and _Bold [700]_.
 
-**Note**: Each variation has a `@mixin` available for use. In order to use those *mixins*, you'll need to import the `kv-typography.scss` file.
+**Note**: Each variation has a `@mixin` available for use. In order to use those _mixins_, you'll need to import the `kv-typography.scss` file.
 
 ## Headings
+
 <ul className="typography-container">
-	{
-		headings.map(typosKey => (
-			<li key={typosKey} className="typography">
-				<span className={typosKey}>{typosKey}</span>
-			</li>
-		))
-	}
+	{headings.map(typosKey => (
+		<li key={typosKey} className="typography">
+			<span className={typosKey}>{typosKey}</span>
+		</li>
+	))}
 </ul>
 
 ## Content
+
 ### Labels
+
 <ul className="typography-container">
-	{
-		labels.map(typosKey => (
-			<li key={typosKey} className="typography">
-				<span className={typosKey}>{typosKey}</span>
-			</li>
-		))
-	}
+	{labels.map(typosKey => (
+		<li key={typosKey} className="typography">
+			<span className={typosKey}>{typosKey}</span>
+		</li>
+	))}
 </ul>
 
 ### Spans
+
 <ul className="typography-container">
-	{
-		spans.map(typosKey => (
-			<li key={typosKey} className="typography">
-				<span className={typosKey}>{typosKey}</span>
-			</li>
-		))
-	}
+	{spans.map(typosKey => (
+		<li key={typosKey} className="typography">
+			<span className={typosKey}>{typosKey}</span>
+		</li>
+	))}
 </ul>
 
 ### Paragraphs
+
 <ul className="typography-container">
-	{
-		paragraphs.map(typosKey => (
-			<li key={typosKey} className="typography">
-				<span className={typosKey}>{typosKey}</span>
-			</li>
-		))
-	}
+	{paragraphs.map(typosKey => (
+		<li key={typosKey} className="typography">
+			<span className={typosKey}>{typosKey}</span>
+		</li>
+	))}
 </ul>
-
-

--- a/packages/ui-components/src/assets/styles/kv-typography.scss
+++ b/packages/ui-components/src/assets/styles/kv-typography.scss
@@ -1,241 +1,274 @@
 /** HEADINGS **/
 @mixin kv-font-h1-semibold() {
 	font-family: $primary-font;
-	font-size: 2rem;
+	font-size: 32px;
 	font-weight: 600;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 2.875rem;
+	line-height: 48px;
 	letter-spacing: normal;
+	text-transform: none;
 }
 @mixin kv-font-h2-regular() {
 	font-family: $primary-font;
-	font-size: 1.5rem;
-	font-weight: normal;
+	font-size: 24px;
+	font-weight: 400;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 2.25rem;
+	line-height: 36px;
 	letter-spacing: normal;
+	text-transform: none;
 }
 @mixin kv-font-h2-semibold() {
 	font-family: $primary-font;
-	font-size: 1.5rem;
+	font-size: 24px;
 	font-weight: 600;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 2.25rem;
+	line-height: 36px;
 	letter-spacing: normal;
-}
-@mixin kv-font-h3-regular() {
-	font-family: $primary-font;
-	font-size: 1.25rem;
-	font-weight: normal;
-	font-stretch: normal;
-	font-style: normal;
-	line-height: 1.875rem;
-	letter-spacing: normal;
+	text-transform: none;
 }
 @mixin kv-font-h3-semibold() {
 	font-family: $primary-font;
-	font-size: 1.25rem;
+	font-size: 20px;
 	font-weight: 600;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 1.875rem;
+	line-height: 30px;
 	letter-spacing: normal;
+	text-transform: none;
 }
 @mixin kv-font-h4-semibold() {
 	font-family: $primary-font;
-	font-size: 1rem;
+	font-size: 16px;
 	font-weight: 600;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 1.5rem;
+	line-height: 24px;
 	letter-spacing: normal;
+	text-transform: none;
 }
 @mixin kv-font-h5-semibold() {
 	font-family: $primary-font;
-	font-size: 0.875rem;
+	font-size: 14px;
 	font-weight: 600;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 1.3125rem;
+	line-height: 21px;
 	letter-spacing: normal;
+	text-transform: none;
 }
 
 /** LABELS **/
 @mixin kv-font-label-large-regular() {
 	font-family: $primary-font;
-	font-size: 1.25rem;
-	font-weight: normal;
+	font-size: 20px;
+	font-weight: 400;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: normal;
+	line-height: 30px;
 	letter-spacing: normal;
-}
-@mixin kv-font-label-medium-light() {
-	font-family: $primary-font;
-	font-size: 1rem;
-	font-weight: 300;
-	font-stretch: normal;
-	font-style: normal;
-	line-height: normal;
-	letter-spacing: normal;
+	text-transform: none;
 }
 @mixin kv-font-label-medium-regular() {
 	font-family: $primary-font;
-	font-size: 1rem;
-	font-weight: normal;
+	font-size: 16px;
+	font-weight: 400;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: normal;
+	line-height: 24px;
 	letter-spacing: normal;
+	text-transform: none;
 }
 @mixin kv-font-label-small-regular() {
 	font-family: $primary-font;
-	font-size: 0.75rem;
-	font-weight: normal;
+	font-size: 12px;
+	font-weight: 400;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 1.125rem;
+	line-height: 18px;
 	letter-spacing: normal;
+	text-transform: none;
 }
 @mixin kv-font-label-small-semibold() {
 	font-family: $primary-font;
-	font-size: 0.75rem;
+	font-size: 12px;
 	font-weight: 600;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 1.125rem;
+	line-height: 18px;
 	letter-spacing: normal;
+	text-transform: none;
+}
+@mixin kv-font-label-small-bold() {
+	font-family: $primary-font;
+	font-size: 12px;
+	font-weight: 700;
+	font-stretch: normal;
+	font-style: normal;
+	line-height: 18px;
+	letter-spacing: normal;
+	text-transform: none;
 }
 @mixin kv-font-label-small-uppercase-regular() {
 	font-family: $primary-font;
-	font-size: 0.75rem;
-	font-weight: normal;
+	font-size: 12px;
+	font-weight: 400;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 1.125rem;
+	line-height: 18px;
+	letter-spacing: normal;
 	letter-spacing: 1.5px;
 	text-transform: uppercase;
 }
 @mixin kv-font-label-small-uppercase-semibold() {
 	font-family: $primary-font;
-	font-size: 0.75rem;
+	font-size: 12px;
 	font-weight: 600;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 1.125rem;
-	letter-spacing: 0.5px;
+	line-height: 18px;
+	letter-spacing: normal;
+	letter-spacing: 1.5px;
 	text-transform: uppercase;
 }
 @mixin kv-font-label-small-uppercase-bold() {
 	font-family: $primary-font;
-	font-size: 0.75rem;
-	font-weight: bold;
+	font-size: 12px;
+	font-weight: 700;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 1.125rem;
-	letter-spacing: 0.5px;
+	line-height: 18px;
+	letter-spacing: normal;
+	letter-spacing: 1.5px;
 	text-transform: uppercase;
 }
 @mixin kv-font-label-xsmall-light() {
 	font-family: $primary-font;
-	font-size: 0.625rem;
+	font-size: 10px;
 	font-weight: 300;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 0.9375rem;
+	line-height: 15px;
 	letter-spacing: normal;
+	text-transform: none;
 }
 @mixin kv-font-label-xsmall-regular() {
 	font-family: $primary-font;
-	font-size: 0.625rem;
-	font-weight: normal;
+	font-size: 10px;
+	font-weight: 400;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 0.9375rem;
+	line-height: 15px;
 	letter-spacing: normal;
+	text-transform: none;
+}
+@mixin kv-font-label-xsmall-semibold() {
+	font-family: $primary-font;
+	font-size: 10px;
+	font-weight: 600;
+	font-stretch: normal;
+	font-style: normal;
+	line-height: 15px;
+	letter-spacing: normal;
+	text-transform: none;
+}
+@mixin kv-font-label-xsmall-bold() {
+	font-family: $primary-font;
+	font-size: 10px;
+	font-weight: 700;
+	font-stretch: normal;
+	font-style: normal;
+	line-height: 15px;
+	letter-spacing: normal;
+	text-transform: none;
 }
 @mixin kv-font-label-xsmall-uppercase-regular() {
 	font-family: $primary-font;
-	font-size: 0.625rem;
-	font-weight: normal;
+	font-size: 10px;
+	font-weight: 300;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 0.9375rem;
-	letter-spacing: 0.5px;
+	line-height: 15px;
+	letter-spacing: normal;
 	text-transform: uppercase;
 }
 @mixin kv-font-label-xsmall-uppercase-semibold() {
 	font-family: $primary-font;
-	font-size: 0.625rem;
+	font-size: 10px;
 	font-weight: 600;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 0.9375rem;
-	letter-spacing: 0.5px;
-	text-transform: uppercase;
-}
-@mixin kv-font-label-xsmall-bold() {
-	font-family: $primary-font;
-	font-size: 0.625rem;
-	font-weight: bold;
-	font-stretch: normal;
-	font-style: normal;
-	line-height: 0.9375rem;
+	line-height: 15px;
 	letter-spacing: normal;
+	text-transform: uppercase;
 }
 
 /** SPANS **/
 @mixin kv-font-span-regular() {
 	font-family: $primary-font;
-	font-size: 0.875rem;
-	font-weight: normal;
+	font-size: 14px;
+	font-weight: 400;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: normal;
+	line-height: 21px;
 	letter-spacing: normal;
+	text-transform: none;
 }
 @mixin kv-font-span-semibold() {
 	font-family: $primary-font;
-	font-size: 0.875rem;
+	font-size: 14px;
 	font-weight: 600;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: normal;
+	line-height: 21px;
 	letter-spacing: normal;
+	text-transform: none;
+}
+@mixin kv-font-span-uppercase-semibold() {
+	font-family: $primary-font;
+	font-size: 14px;
+	font-weight: 600;
+	font-stretch: normal;
+	font-style: normal;
+	line-height: 21px;
+	letter-spacing: normal;
+	text-transform: uppercase;
 }
 
 /** PARAGRAPHS **/
 @mixin kv-font-paragraph-regular() {
 	font-family: $primary-font;
-	font-size: 0.875rem;
-	font-weight: normal;
+	font-size: 14px;
+	font-weight: 400;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 1.3125rem;
+	line-height: 21px;
 	letter-spacing: normal;
+	text-transform: none;
 }
 @mixin kv-font-paragraph-light() {
 	font-family: $primary-font;
-	font-size: 0.875rem;
+	font-size: 14px;
 	font-weight: 300;
 	font-stretch: normal;
 	font-style: normal;
-	line-height: 1.125rem;
+	line-height: 21px;
 	letter-spacing: normal;
+	text-transform: none;
 }
 
 /** CODE/CONSOLE **/
 @mixin kv-font-code() {
 	font-family: $console-font, monospace, Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono';
-	font-size: 0.75rem;
+	font-size: 12px;
 	font-weight: 400;
 	text-align: left;
 	white-space: pre;
 	word-spacing: 0.42px;
 	word-break: normal;
 	word-wrap: normal;
-	line-height: 1.125;
+	line-height: 21px;
+	text-transform: none;
 }


### PR DESCRIPTION
This PR updates the typography mixins according to our DS.

**BREAKING CHANGE**: `kv-font-h3-regular` and `kv-font-label-medium-light` mixins were removed.
