### PR TITLE
refactor(code-editor)!: separate font loading logic and add kelvin theme

### DIFF
--- a/packages/react-ui-components/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/react-ui-components/src/components/CodeEditor/CodeEditor.tsx
@@ -1,53 +1,45 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import Editor, { useMonaco } from '@monaco-editor/react';
-import { DEFAULT_EDITOR_LANGUAGE, DEFAULT_EDITOR_THEME, DEFAULT_PADDING_TOP, FONT_NOT_FOUND_ERROR } from './config';
-import { ECodeEditorTheme, ICodeEditorProps, OnEditorChangeCallback } from './types';
+import { DEFAULT_CODE_EDITOR_LANGUAGE, DEFAULT_CODE_EDITOR_THEME, KELVIN_CODE_EDITOR_THEME } from './config';
+import { ECodeEditorTheme, ICodeEditorProps, OnCodeEditorChange } from './types';
 import { KvLoader } from '../stencil-generated';
-import { getEditorOptions } from './utils';
+import { getEditorOptions, getFontOptions } from './utils';
+import { useFontsApi } from '../../utils';
+
+const CodeEditorLoader = () => <KvLoader isLoading />;
 
 export const KvCodeEditor = ({
 	code,
-	readOnly = false,
-	loadingComponent = <KvLoader isLoading />,
-	language = DEFAULT_EDITOR_LANGUAGE,
-	theme = DEFAULT_EDITOR_THEME,
-	customTheme,
-	paddingTop = DEFAULT_PADDING_TOP,
+	language = DEFAULT_CODE_EDITOR_LANGUAGE,
+	theme = DEFAULT_CODE_EDITOR_THEME,
+	customTheme = KELVIN_CODE_EDITOR_THEME,
+	customOptions,
+	LoadingComponent = CodeEditorLoader,
 	onChange
 }: ICodeEditorProps) => {
 	const monaco = useMonaco();
-	const [isFontLoaded, setFontLoaded] = useState(false);
+	const options = useMemo(() => getEditorOptions(customOptions), [customOptions]);
+	const { isFontLoaded, loadFont } = useFontsApi(getFontOptions(options));
 
-	const options = useMemo(() => getEditorOptions({ readOnly, padding: { top: paddingTop } }), [readOnly, paddingTop]);
+	const hasLoaded = useMemo(() => monaco && isFontLoaded, [monaco, isFontLoaded]);
 
-	const loadFont = useCallback(async () => {
-		try {
-			const { fontSize, fontFamily } = options;
-			await document.fonts.load(`${fontSize}px ${fontFamily}`);
-			setFontLoaded(true);
-		} catch (error) {
-			throw new Error(FONT_NOT_FOUND_ERROR);
-		}
-	}, [options.fontSize, options.fontFamily]);
-
-	const setupEditor = useCallback(() => {
+	const defineCustomTheme = useCallback(() => {
 		if (!monaco || !customTheme) return;
 		monaco.editor.defineTheme(ECodeEditorTheme.Custom, customTheme);
-		monaco.editor.setTheme(ECodeEditorTheme.Custom);
-	}, [monaco, customTheme]);
+	}, [customTheme, monaco]);
 
-	const onTextChange: OnEditorChangeCallback = useCallback(value => onChange?.(value), [onChange]);
+	const onTextChange: OnCodeEditorChange = useCallback(value => onChange?.(value), [onChange]);
 
 	useEffect(() => {
 		loadFont();
-		setupEditor();
-	}, [loadFont, setupEditor]);
+		defineCustomTheme();
+	}, [loadFont, defineCustomTheme]);
 
-	if (!isFontLoaded) {
-		return loadingComponent;
+	if (!hasLoaded) {
+		return <LoadingComponent />;
 	}
 
-	return <Editor language={language} theme={theme} options={options} value={code} loading={loadingComponent} onChange={onTextChange} />;
+	return <Editor language={language} theme={theme} options={options} loading={<LoadingComponent />} value={code} onChange={onTextChange} />;
 };
 
 export default KvCodeEditor;

--- a/packages/react-ui-components/src/components/CodeEditor/config.ts
+++ b/packages/react-ui-components/src/components/CodeEditor/config.ts
@@ -1,7 +1,24 @@
-import { ECodeEditorTheme } from './types';
+import { CodeEditorTheme, ECodeEditorTheme, CodeEditorOptions } from './types';
 
-export const DEFAULT_EDITOR_LANGUAGE = 'yaml';
-export const DEFAULT_EDITOR_THEME = ECodeEditorTheme.Dark;
-export const DEFAULT_PADDING_TOP = 0;
+export const DEFAULT_CODE_EDITOR_LANGUAGE = 'yaml';
+export const DEFAULT_CODE_EDITOR_THEME = ECodeEditorTheme.Custom;
 
-export const FONT_NOT_FOUND_ERROR = `Font was not found, make sure the 'Inconsolata' font is included in your css`;
+export const DEFAULT_CODE_EDITOR_OPTIONS: CodeEditorOptions = {
+	readOnly: false,
+	padding: {
+		top: 12
+	}
+};
+
+export const KELVIN_CODE_EDITOR_THEME: CodeEditorTheme = {
+	base: 'vs-dark',
+	inherit: true,
+	rules: [],
+	colors: {
+		'editor.background': '#202020',
+		'editorGutter.background': '#2A2A2A'
+	}
+};
+
+export const MONACO_FONT_FAMILY = `Menlo, Monaco, "Courier New", monospace`;
+export const MONACO_FONT_SIZE = 12;

--- a/packages/react-ui-components/src/components/CodeEditor/readme.md
+++ b/packages/react-ui-components/src/components/CodeEditor/readme.md
@@ -28,13 +28,9 @@ All the props described below are optional.
 Use this property to pass a starting value to the editor.
 Defaults to: `undefined`
 
-### _readOnly (boolean)_
-Use this property to set the editor to a read only mode where the user cannot modify the value.
-Defaults to: `false`
-
-### _loadingComponent (ReactNode)_
+### _LoadingComponent (FunctionComponent)_
 Use this property to define a placeholder component to display when the editor is loading.
-Defaults to: `<KvLoader />`
+Defaults to: `<KvLoader isLoading />`
 
 ### _language (string)_
 Use this property to define the language mode of the editor.
@@ -48,9 +44,8 @@ Defaults to: `ECodeEditorTheme.Dark`
 Use this property to define and set a custom theme on the editor
 Defaults to: `undefined`
 
-### _paddingTop (number)_
-Use this property to add some padding (in px) at the top of the editor
-Defaults to: `0`
+### _customOptions (CodeEditorOptions)_
+Use this property to define options on the editor
 
 ### _onChange (OnEditorChangeCallback)_
 Use this property to pass a callback function for when the value (`code`) changes.

--- a/packages/react-ui-components/src/components/CodeEditor/types.ts
+++ b/packages/react-ui-components/src/components/CodeEditor/types.ts
@@ -1,8 +1,9 @@
 import type { editor } from 'monaco-editor';
+import { FunctionComponent } from 'react';
 
-export type OnEditorChangeCallback = (value: string | undefined) => void;
-export type CustomThemeData = editor.IStandaloneThemeData;
-export type CustomEditorOptions = editor.IEditorOptions & editor.IGlobalEditorOptions;
+export type OnCodeEditorChange = (value: string | undefined) => void;
+export type CodeEditorOptions = editor.IGlobalEditorOptions & editor.IEditorOptions;
+export type CodeEditorTheme = editor.IStandaloneThemeData;
 
 export enum ECodeEditorTheme {
 	Dark = 'vs-dark',
@@ -13,18 +14,16 @@ export enum ECodeEditorTheme {
 export interface ICodeEditorProps {
 	/** Use this property to pass a starting value to the editor. */
 	code?: string;
-	/** Use this property to set the editor to a read only mode where the user cannot modify the value. */
-	readOnly?: boolean;
-	/** Use this property to define a placeholder component to display when the editor is loading. */
-	loadingComponent?: JSX.Element;
 	/** Use this property to define the language mode of the editor. */
 	language?: string;
 	/** Use this property to define the theme of the editor. */
 	theme?: ECodeEditorTheme;
 	/** Use this property to define and set a custom theme on the editor */
-	customTheme?: CustomThemeData;
-	/** Use this property to add some padding (in px) at the top of the editor */
-	paddingTop?: number;
+	customTheme?: CodeEditorTheme;
+	/** Use this property to define options on the editor */
+	customOptions?: CodeEditorOptions;
+	/** Use this property to define a placeholder component to display when the editor is loading. */
+	LoadingComponent?: FunctionComponent;
 	/** Use this property to pass a callback function for when the value (`code`) changes. */
-	onChange?: OnEditorChangeCallback;
+	onChange?: OnCodeEditorChange;
 }

--- a/packages/react-ui-components/src/components/CodeEditor/utils.ts
+++ b/packages/react-ui-components/src/components/CodeEditor/utils.ts
@@ -1,12 +1,18 @@
-import { CustomEditorOptions } from './types';
+import { IFontOptions } from '../../utils/useFontsApi';
+import { MONACO_FONT_FAMILY, MONACO_FONT_SIZE } from './config';
+import { CodeEditorOptions } from './types';
 
-export const getEditorOptions = (customOptions?: CustomEditorOptions): CustomEditorOptions => ({
+export const getEditorOptions = (customOptions?: CodeEditorOptions): CodeEditorOptions => ({
 	fontFamily: 'Inconsolata',
 	fontSize: 14,
 	wordWrap: 'on',
 	renderLineHighlight: 'none',
 	scrollBeyondLastLine: false,
 	automaticLayout: true,
+	readOnly: false,
+	padding: {
+		top: 12
+	},
 	scrollbar: {
 		useShadows: false,
 		verticalScrollbarSize: 6
@@ -21,3 +27,7 @@ export const getEditorOptions = (customOptions?: CustomEditorOptions): CustomEdi
 	},
 	...(customOptions || {})
 });
+
+export const getFontOptions = ({ fontFamily, fontSize }: CodeEditorOptions): IFontOptions => {
+	return { fontFamily: fontFamily || MONACO_FONT_FAMILY, fontSize: fontSize || MONACO_FONT_SIZE };
+};

--- a/packages/react-ui-components/src/stories/Components/CodeEditor.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/CodeEditor.stories.tsx
@@ -1,7 +1,7 @@
 import { ComponentStory } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import React from 'react';
-import { KvCodeEditor, ECodeEditorTheme, CustomThemeData } from '../../components';
+import { KvCodeEditor, ECodeEditorTheme } from '../../components';
 
 export default {
 	title: 'Inputs/CodeEditor',
@@ -23,19 +23,14 @@ export default {
 			},
 			options: Object.values(ECodeEditorTheme)
 		},
-		customTheme: {
+		customOptions: {
 			control: {
 				type: 'object'
 			}
 		},
-		readOnly: {
+		customTheme: {
 			control: {
-				type: 'boolean'
-			}
-		},
-		paddingTop: {
-			control: {
-				type: 'number'
+				type: 'object'
 			}
 		}
 	},
@@ -45,6 +40,14 @@ export default {
 };
 
 const onChangeAction = action('Data Changed');
+
+const code = `{
+	"name": "Name",
+	"props": {
+		"title": "Title",
+		"owner": 1
+	}
+}`;
 
 const DefaultCodeEditorTemplate: ComponentStory<typeof KvCodeEditor> = args => {
 	const wrapperStyle = { width: '640px', height: '480px' };
@@ -57,11 +60,15 @@ const DefaultCodeEditorTemplate: ComponentStory<typeof KvCodeEditor> = args => {
 };
 
 export const Default = DefaultCodeEditorTemplate.bind(this);
+Default.args = {
+	language: 'json',
+	code
+};
 
-const CustomCodeEditorTemplate: ComponentStory<typeof KvCodeEditor> = args => {
-	const wrapperStyle = { width: '640px', height: '480px' };
-
-	const customDarkTheme: CustomThemeData = {
+export const CustomTheme = DefaultCodeEditorTemplate.bind(this);
+CustomTheme.args = {
+	...Default.args,
+	customTheme: {
 		base: 'vs-dark',
 		inherit: true,
 		rules: [],
@@ -70,13 +77,5 @@ const CustomCodeEditorTemplate: ComponentStory<typeof KvCodeEditor> = args => {
 			'editor.background': '#3f3f3f',
 			'editor.lineHighlightBorder': '#3f3f3f'
 		}
-	};
-
-	return (
-		<div style={wrapperStyle}>
-			<KvCodeEditor {...args} customTheme={customDarkTheme} onChange={onChangeAction} />
-		</div>
-	);
+	}
 };
-
-export const CustomTheme = CustomCodeEditorTemplate.bind(this);

--- a/packages/react-ui-components/src/utils/useFontsApi/constants.ts
+++ b/packages/react-ui-components/src/utils/useFontsApi/constants.ts
@@ -1,0 +1,1 @@
+export const FONT_NOT_FOUND_ERROR = `Font was not found, make sure the font you're trying to use is correctly imported in your project`;

--- a/packages/react-ui-components/src/utils/useFontsApi/index.ts
+++ b/packages/react-ui-components/src/utils/useFontsApi/index.ts
@@ -1,2 +1,2 @@
-export * from './useScroll';
+export * from './types';
 export * from './useFontsApi';

--- a/packages/react-ui-components/src/utils/useFontsApi/types.ts
+++ b/packages/react-ui-components/src/utils/useFontsApi/types.ts
@@ -1,0 +1,10 @@
+export type FontsApi = {
+	isFontLoaded: boolean;
+	checkFont: () => boolean;
+	loadFont: () => void;
+};
+
+export type IFontOptions = {
+	fontFamily: string;
+	fontSize: number;
+};

--- a/packages/react-ui-components/src/utils/useFontsApi/useFontsApi.ts
+++ b/packages/react-ui-components/src/utils/useFontsApi/useFontsApi.ts
@@ -1,0 +1,24 @@
+import { useCallback, useMemo, useState } from 'react';
+import { FontsApi, IFontOptions } from './types';
+import { FONT_NOT_FOUND_ERROR } from './constants';
+
+export const useFontsApi = ({ fontFamily, fontSize }: IFontOptions): FontsApi => {
+	const fontName = useMemo(() => `${fontSize}px ${fontFamily}`, [fontFamily, fontSize]);
+	const [isFontLoaded, setFontLoaded] = useState(() => document.fonts.check(fontName));
+
+	const checkFont = useCallback(() => document.fonts.check(fontName), [fontName]);
+
+	const loadFont = useCallback(() => {
+		if (isFontLoaded) return;
+
+		document.fonts
+			.load(fontName)
+			.then(() => setFontLoaded(true))
+			.catch(() => {
+				setFontLoaded(false);
+				throw new Error(FONT_NOT_FOUND_ERROR);
+			});
+	}, [fontName]);
+
+	return { isFontLoaded, checkFont, loadFont };
+};


### PR DESCRIPTION
BREAKING CHANGE: `readOnly` and `paddingTop` properties were moved to the `customOptions` object
