### PR TITLE
fix(text-field): update style

### DIFF
--- a/packages/ui-components/src/components/text-field/text-field.base.scss
+++ b/packages/ui-components/src/components/text-field/text-field.base.scss
@@ -40,7 +40,7 @@
 	--text-color-help-text-error: #{kv-color('error')};
 
 	--border-color-error: #{kv-color('error')};
-	--right-slot-padding-right: #{$spacing-9x};
+	--right-slot-padding-right: #{$spacing-2x};
 	--right-slot-width: 36px;
 	--left-slot-padding-left: #{$spacing-6x};
 	--left-slot-padding-top: 0;


### PR DESCRIPTION
In smaller usages (width-wise) of this component the text became partially hidden due to the right padding. Consequently the design specs were not being met.

Demo:

![ArcoLinux_2023-04-18_11-24-44](https://user-images.githubusercontent.com/55213469/232749323-98e1fb09-b1a6-448c-b220-6d9602e35bb7.png)
![ArcoLinux_2023-04-18_11-24-14](https://user-images.githubusercontent.com/55213469/232749328-4cefd7bb-e897-479a-a2c9-10f5d873670d.png)
