### PR TITLE
fix(time-picker): sync initial view with show calendar toggle state

### DIFF
--- a/packages/react-ui-components/src/stories/Components/AbsoluteTimePicker.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/AbsoluteTimePicker.stories.tsx
@@ -10,16 +10,16 @@ export default {
 	component: 'kv-absolute-time-picker',
 	argTypes: {
 		onSelectRangeDatesChange: {
-			action: 'change'
+			action: 'selectRangeDatesChange'
 		},
 		onBackButtonClicked: {
-			action: 'change'
+			action: 'backButtonClicked'
 		},
 		onRelativeTimeConfigReset: {
-			action: 'change'
+			action: 'relativeTimeConfigReset'
 		},
 		onRelativeTimeConfigChange: {
-			action: 'change'
+			action: 'relativeTimeConfigChange'
 		}
 	},
 	parameters: {

--- a/packages/react-ui-components/src/stories/Components/DateTimeInput.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/DateTimeInput.stories.tsx
@@ -13,7 +13,7 @@ export default {
 			options: Object.values(EComponentSize)
 		},
 		onTextChange: { action: 'text changed...' },
-		onTextFieldBlur: { action: 'text field on blur' }
+		onDateTimeBlur: { action: 'date time on blur' }
 	},
 	parameters: {
 		notes: require('@ui-notes/date-time-input/readme.md')

--- a/packages/react-ui-components/src/stories/Components/TimePicker.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/TimePicker.stories.tsx
@@ -9,13 +9,16 @@ export default {
 	component: 'kv-time-picker',
 	argTypes: {
 		onTimeRangeChange: {
-			action: 'change'
+			action: 'timeRangeChange'
 		},
 		onDropdownStateChange: {
-			action: 'change'
+			action: 'dropdownStateChange'
 		},
 		onCancelClicked: {
-			action: 'change'
+			action: 'cancelClicked'
+		},
+		onShowCalendarStateChange: {
+			action: 'showCalendarStateChange'
 		}
 	},
 	parameters: {

--- a/packages/ui-components/src/components/time-picker/readme.md
+++ b/packages/ui-components/src/components/time-picker/readme.md
@@ -52,11 +52,12 @@ export const KvTimePickerExample: React.FC = () => (
 
 ## Events
 
-| Event                 | Description                           | Type                                   |
-| --------------------- | ------------------------------------- | -------------------------------------- |
-| `cancelClicked`       | Emitted when cancel button is clicked | `CustomEvent<CustomEvent<MouseEvent>>` |
-| `dropdownStateChange` | Emitted when dropdown state changes   | `CustomEvent<boolean>`                 |
-| `timeRangeChange`     | Emitted when time range changes       | `CustomEvent<ITimePickerTime>`         |
+| Event                     | Description                                     | Type                                   |
+| ------------------------- | ----------------------------------------------- | -------------------------------------- |
+| `cancelClicked`           | Emitted when cancel button is clicked           | `CustomEvent<CustomEvent<MouseEvent>>` |
+| `dropdownStateChange`     | Emitted when dropdown state changes             | `CustomEvent<boolean>`                 |
+| `showCalendarStateChange` | Emitted when show calendar button state changes | `CustomEvent<boolean>`                 |
+| `timeRangeChange`         | Emitted when time range changes                 | `CustomEvent<ITimePickerTime>`         |
 
 
 ## Dependencies

--- a/packages/ui-components/src/components/time-picker/time-picker.tsx
+++ b/packages/ui-components/src/components/time-picker/time-picker.tsx
@@ -44,7 +44,7 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 	/** @inheritdoc */
 	@Prop({ reflect: true }) disabled?: boolean = false;
 	/** @inheritdoc */
-	@Prop({ reflect: true }) showCalendar?: boolean = false;
+	@Prop({ reflect: true, mutable: true }) showCalendar?: boolean = false;
 	/** @inheritdoc */
 	@Prop({ reflect: true }) selectedTimeOption?: ITimePickerTime;
 	/** @inheritdoc */
@@ -83,10 +83,17 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 	@Event() dropdownStateChange: EventEmitter<boolean>;
 	/** @inheritdoc */
 	@Event() cancelClicked: EventEmitter<CustomEvent<MouseEvent>>;
+	/** @inheritdoc */
+	@Event() showCalendarStateChange: EventEmitter<boolean>;
 
 	@Watch('selectedTimeOption')
 	handleSelectTimeStateChange(timeState: ITimePickerTime) {
 		this.selectedTimeState = timeState;
+	}
+
+	@Watch('showCalendar')
+	handleShowCalendarChange() {
+		this.syncShowCalendarViewState();
 	}
 
 	componentWillLoad() {
@@ -97,6 +104,11 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 				this.selectedTimeState = this.selectedTimeOption;
 			}
 		}
+		this.syncShowCalendarViewState();
+	}
+
+	private syncShowCalendarViewState() {
+		this.timePickerView = this.showCalendar ? ETimePickerView.FullView : ETimePickerView.RelativeTimePicker;
 	}
 
 	private resetDefaultSelectedTimeState = () => {
@@ -217,6 +229,7 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 	private onShowCalendarClick = () => {
 		if (!this.calendarViewLocked) {
 			this.timePickerView = this.showCalendar ? ETimePickerView.RelativeTimePicker : ETimePickerView.FullView;
+			this.showCalendarStateChange.emit(!this.showCalendar);
 			this.showCalendar = !this.showCalendar;
 		}
 	};

--- a/packages/ui-components/src/components/time-picker/time-picker.types.ts
+++ b/packages/ui-components/src/components/time-picker/time-picker.types.ts
@@ -37,6 +37,8 @@ export interface ITimePickerEvents {
 	dropdownStateChange: EventEmitter<boolean>;
 	/** Emitted when cancel button is clicked */
 	cancelClicked: EventEmitter<CustomEvent<MouseEvent>>;
+	/** Emitted when show calendar button state changes */
+	showCalendarStateChange: EventEmitter<boolean>;
 }
 
 export interface ITimePickerTime {


### PR DESCRIPTION
There was a bug when the show calendar toggle was set to true and the component was opened for the first time. The time picker view didnt match with the toggle state.

It was also added an event that emits the state of the toggle when it changes.