### PR TITLE
fix(relative-time-picker): add default timezone to avoid firefox erros on relative time options list

### DIFF
--- a/packages/ui-components/src/components/relative-time-picker/relative-time-picker.config.ts
+++ b/packages/ui-components/src/components/relative-time-picker/relative-time-picker.config.ts
@@ -249,6 +249,20 @@ export const DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS: IRelativeTimePickerOption[][]
 				separator: 'to',
 				endDateFormatter: 'D MMM HH:mm'
 			}
+		},
+		{
+			label: 'Last 72 hours',
+			value: 'last-72-h',
+			comparisonConfig: ERelativeTimeComparisonConfig.RelativeAmountOfUnits,
+			startDate: {
+				amount: -72,
+				unit: 'hours'
+			},
+			labelRangeFormatter: {
+				startDateFormatter: 'D MMM HH:mm',
+				separator: 'to',
+				endDateFormatter: 'D MMM HH:mm'
+			}
 		}
 	],
 	[
@@ -437,7 +451,8 @@ export const DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS: IRelativeTimePickerOption[][]
 			value: 'all-time',
 			comparisonConfig: ERelativeTimeComparisonConfig.StartDate,
 			startDate: {
-				date: '1-01-2018'
+				date: '2018-01-01',
+				dateFormat: 'YYYY-MM-DD'
 			},
 			labelRangeFormatter: {
 				startDateFormatter: 'D MMM YYYY',

--- a/packages/ui-components/src/components/relative-time-picker/relative-time-picker.helper.ts
+++ b/packages/ui-components/src/components/relative-time-picker/relative-time-picker.helper.ts
@@ -6,13 +6,13 @@ import {
 	IRelativeTimePickerOption,
 	SelectedRangeDetail
 } from './relative-time-picker.types';
-import { calculateDate, isDateTimeBefore, newTimezoneDate } from '../../utils/date.helper';
+import { calculateDate, getDefaultTimezone, isDateTimeBefore, newTimezoneDate, newTimezoneDateFromFormat } from '../../utils/date.helper';
 import dayjs, { Dayjs } from 'dayjs';
 import { isEmpty } from 'lodash-es';
 import { BOTTOM_OPTIONS_HEIGHT, GROUP_GAP, MAX_HEIGHT, PADDING_SIZE, SELECT_OPTION_HEIGHT } from './relative-time-picker.config';
 import { SelectedTimestampRange } from '../../types';
 
-export const buildRelativeTimeSelectOptions = (options: IRelativeTimePickerOption[][], timeZone: string): IRelativeTimeDropdownOption[][] => {
+export const buildRelativeTimeSelectOptions = (options: IRelativeTimePickerOption[][], timeZone: string = getDefaultTimezone()): IRelativeTimeDropdownOption[][] => {
 	return options.reduce<IRelativeTimeDropdownOption[][]>((acc, group) => {
 		const groupOptions = buildRelativeTimeGroupOptions(group, timeZone);
 		acc.push(groupOptions);
@@ -54,8 +54,8 @@ export const buildOptionRange = (option: IRelativeTimePickerOption, timeZone: st
 
 // Build date from config with start and end date
 export const buildStartDateEndDateConfigRange = (option: IRelativeTimePickerOption, timeZone: string): SelectedRangeDetail => {
-	const startDateTime = newTimezoneDate(timeZone, option.startDate.date);
-	const endDateTime = newTimezoneDate(timeZone, option.endDate.date);
+	const startDateTime = newTimezoneDateFromFormat(timeZone, option.startDate.dateFormat, option.startDate.date);
+	const endDateTime = newTimezoneDateFromFormat(timeZone, option.endDate.dateFormat, option.endDate.date);
 
 	return buildSelectedRangeDetail(startDateTime, endDateTime, option.labelRangeFormatter);
 };
@@ -63,7 +63,7 @@ export const buildStartDateEndDateConfigRange = (option: IRelativeTimePickerOpti
 // Build date from config with start or end date
 export const buildSingleDateConfigRange = (option: IRelativeTimePickerOption, timeZone: string): SelectedRangeDetail => {
 	const nowDateTime = newTimezoneDate(timeZone);
-	const calculatedDate = newTimezoneDate(timeZone, option.startDate.date);
+	const calculatedDate = newTimezoneDateFromFormat(timeZone, option.startDate.dateFormat, option.startDate.date);
 
 	return buildSelectedRangeDetail(nowDateTime, calculatedDate, option.labelRangeFormatter);
 };

--- a/packages/ui-components/src/components/relative-time-picker/relative-time-picker.tsx
+++ b/packages/ui-components/src/components/relative-time-picker/relative-time-picker.tsx
@@ -79,7 +79,7 @@ export class KvRelativeTimePicker implements IRelativeTimePicker, IRelativeTimeP
 	@Watch('options')
 	handleRelativeTimeOptionsChanges() {
 		const optionsToBuild = this.options ?? DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS;
-		const dropdownOptions = buildRelativeTimeSelectOptions(optionsToBuild, this.selectedTimezone);
+		const dropdownOptions = buildRelativeTimeSelectOptions(optionsToBuild, this.getSelectedTimezone());
 		this.relativeTimeOptions = dropdownOptions;
 
 		if (!isEmpty(this.selectedTimeKey) && this.selectedTimeKey !== CUSTOMIZE_INTERVAL_KEY) {

--- a/packages/ui-components/src/components/relative-time-picker/relative-time-picker.types.ts
+++ b/packages/ui-components/src/components/relative-time-picker/relative-time-picker.types.ts
@@ -53,6 +53,8 @@ export type DateTimeCalculation = {
 	// Date which the calculation should be relative to.
 	// if undefined, now will be used
 	date?: DateInput;
+	// Format of the provided date
+	dateFormat?: string;
 	// the amount of units to add to the relative time
 	// if this number is negative, the amount will be subtracted
 	amount?: number;

--- a/packages/ui-components/src/utils/date.helper.ts
+++ b/packages/ui-components/src/utils/date.helper.ts
@@ -28,6 +28,7 @@ dayjs.extend(utc);
 
 export const newDate = (date?: DateInput) => dayjs(date);
 export const newTimezoneDate = (timezone: string, date?: DateInput) => dayjs.tz(date, timezone);
+export const newTimezoneDateFromFormat = (timezone: string, format: string, date: DateInput) => dayjs.tz(date, format, timezone);
 
 // Constructors
 export const fromISO = (date: string): dayjs.Dayjs => newDate(date);


### PR DESCRIPTION
In firefox, the list of relative time options was not appearing because for some reason, no timezone was being considered in the method that created the date even though we were sending it via props. 

This PR adresses the issue and also adds a format to the dates that are used in the config for us to be able to specify the format of the date that we sent in the config file.