### PR TITLE
fix(time-picker): allow empty timezone state in props

### DIFF
--- a/packages/react-ui-components/src/stories/Components/TimePicker.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/TimePicker.stories.tsx
@@ -82,6 +82,23 @@ const TimePickerSettedRelativeTimeTemplate: ComponentStory<typeof KvTimePicker> 
 	return <KvTimePicker {...args} selectedTimeOption={selectedTime} onTimeRangeChange={onRelativeTimeChange} />;
 };
 
+const TimePickerWithoutTimezoneTemplate: ComponentStory<typeof KvTimePicker> = args => {
+	const [selectedTime, setSelectedTime] = useState<ITimePickerTime>({
+		key: 'last-72-h',
+		range: []
+	});
+	const onRelativeTimeChange = ({ detail: newRelativeOption }: CustomEvent<ITimePickerTime>) => {
+		setSelectedTime({
+			key: newRelativeOption.key,
+			range: newRelativeOption.range,
+			timezone: newRelativeOption.timezone
+		});
+	};
+
+	return <KvTimePicker {...args} selectedTimeOption={selectedTime} onTimeRangeChange={onRelativeTimeChange} />;
+};
+
 export const DefaultState = TimePickerTemplate.bind({});
 export const AbsoluteTimeOptionSelected = TimePickerSettedTimeTemplate.bind({});
 export const RelativeTimeOptionSelected = TimePickerSettedRelativeTimeTemplate.bind({});
+export const NoTimezoneProvided = TimePickerWithoutTimezoneTemplate.bind({});

--- a/packages/ui-components/src/components/time-picker/time-picker.tsx
+++ b/packages/ui-components/src/components/time-picker/time-picker.tsx
@@ -88,7 +88,10 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 
 	@Watch('selectedTimeOption')
 	handleSelectTimeStateChange(timeState: ITimePickerTime) {
-		this.selectedTimeState = timeState;
+		this.selectedTimeState = {
+			...timeState,
+			timezone: timeState.timezone ?? this.getSelectedTimezone()
+		};
 	}
 
 	@Watch('showCalendar')
@@ -101,7 +104,7 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 			this.resetDefaultSelectedTimeState();
 		} else {
 			if (isEmpty(this.selectedTimeState)) {
-				this.selectedTimeState = this.selectedTimeOption;
+				this.syncTimeStateWithTimeOption();
 			}
 		}
 		this.syncShowCalendarViewState();
@@ -109,6 +112,13 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 
 	private syncShowCalendarViewState() {
 		this.timePickerView = this.showCalendar ? ETimePickerView.FullView : ETimePickerView.RelativeTimePicker;
+	}
+
+	private syncTimeStateWithTimeOption() {
+		this.selectedTimeState = {
+			...this.selectedTimeOption,
+			timezone: this.selectedTimeOption.timezone ?? this.getSelectedTimezone()
+		};
 	}
 
 	private resetDefaultSelectedTimeState = () => {
@@ -138,7 +148,7 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 		this.dropdownStateChange.emit(isDropdownOpen);
 		if (!this.isApplyButtonDisabled() && !isDropdownOpen) {
 			if (!isEmpty(this.selectedTimeOption)) {
-				this.selectedTimeState = this.selectedTimeOption;
+				this.syncTimeStateWithTimeOption();
 			} else {
 				this.resetDefaultSelectedTimeState();
 			}
@@ -176,7 +186,7 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 	};
 
 	private onSelectedTimezoneChange = ({ detail: timezone }: CustomEvent<ITimePickerTimezone>) => {
-		const previousTimezone = this.selectedTimeState.timezone.name;
+		const previousTimezone = this.getSelectedTimezone().name;
 		const range =
 			this.selectedTimeState.key === CUSTOMIZE_INTERVAL_KEY
 				? getTimestampFromDateRange(this.selectedTimeState.range, previousTimezone, timezone.name)
@@ -285,7 +295,7 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 			return false;
 		}
 
-		if (this.selectedTimeState && this.selectedTimeOption && this.selectedTimeState.timezone.name !== this.selectedTimeOption.timezone.name) {
+		if (this.selectedTimeState && this.selectedTimeOption && this.selectedTimeState.timezone?.name !== this.selectedTimeOption.timezone?.name) {
 			return false;
 		}
 


### PR DESCRIPTION
This pr fixes an issue that happened when a timeOption was defined but the timezone was undefined. This would result in an error. 
With this, we can discard the timezone and the component will assume the browser default.