### PR TITLE
fix(action-button): remove ghost button flickering on hover

### DIFF
--- a/packages/ui-components/src/components/action-button/action-button.scss
+++ b/packages/ui-components/src/components/action-button/action-button.scss
@@ -86,14 +86,14 @@ $btn-border-colors: (
 		primary: kv-color('primary', 'dark'),
 		secondary: kv-color('neutral-5'),
 		tertiary: kv-color('neutral-2'),
-		ghost: transparent,
+		ghost: kv-color('neutral-7'),
 		danger: kv-color('error', 'dark')
 	),
 	focus: (
 		primary: kv-color('primary'),
 		secondary: kv-color('neutral-0'),
 		tertiary: transparent,
-		ghost: transparent,
+		ghost: kv-color('neutral-7'),
 		danger: transparent
 	),
 	disabled: (
@@ -107,7 +107,7 @@ $btn-border-colors: (
 		primary: kv-color('primary', 'dark'),
 		secondary: kv-color('neutral-5'),
 		tertiary: kv-color('neutral-2'),
-		ghost: transparent,
+		ghost: kv-color('neutral-7'),
 		danger: kv-color('error', 'dark')
 	)
 );


### PR DESCRIPTION
We're having an issue with the ghost action button. When the cursor was on over the button after the animation ended the button does a little jump. The following video illustrates the issue:

https://github.com/kelvininc/ui-components/assets/17494742/86397a73-0407-440d-95c7-7d50c8b3e3ce

