### PR TITLE
feat(relative-time-picker): reorder items in relative time picker default config

### DIFF
--- a/packages/react-ui-components/src/stories/Components/TimePicker.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/TimePicker.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentStory } from '@storybook/react';
-import { ITimePickerTime, KvTimePicker } from '../../components';
-import React, { useState } from 'react';
+import { ITimePickerTime, KvTimePicker, KvTimePickerCustomEvent } from '../../components';
+import React, { useCallback, useState } from 'react';
 
 KvTimePicker.displayName = 'KvTimePicker';
 
@@ -27,7 +27,12 @@ export default {
 };
 
 const TimePickerTemplate: ComponentStory<typeof KvTimePicker> = args => {
+	const [showCalendar, setShowCalendar] = useState<boolean>(false);
 	const [selectedTime, setSelectedTime] = useState<ITimePickerTime>();
+
+	const onShowCalendarStateChange = useCallback(({ detail }: KvTimePickerCustomEvent<boolean>) => {
+		setShowCalendar(detail);
+	}, []);
 
 	const onRelativeTimeChange = ({ detail: newRelativeOption }: CustomEvent<ITimePickerTime>) => {
 		setSelectedTime({
@@ -37,10 +42,19 @@ const TimePickerTemplate: ComponentStory<typeof KvTimePicker> = args => {
 		});
 	};
 
-	return <KvTimePicker {...args} selectedTimeOption={selectedTime} onTimeRangeChange={onRelativeTimeChange} />;
+	return (
+		<KvTimePicker
+			{...args}
+			showCalendar={showCalendar}
+			onShowCalendarStateChange={onShowCalendarStateChange}
+			selectedTimeOption={selectedTime}
+			onTimeRangeChange={onRelativeTimeChange}
+		/>
+	);
 };
 
 const TimePickerSettedTimeTemplate: ComponentStory<typeof KvTimePicker> = args => {
+	const [showCalendar, setShowCalendar] = useState<boolean>(false);
 	const [selectedTime, setSelectedTime] = useState<ITimePickerTime>({
 		key: 'customize-interval',
 		range: [1681319856833, 1681406272018],
@@ -50,6 +64,10 @@ const TimePickerSettedTimeTemplate: ComponentStory<typeof KvTimePicker> = args =
 		}
 	});
 
+	const onShowCalendarStateChange = useCallback(({ detail }: KvTimePickerCustomEvent<boolean>) => {
+		setShowCalendar(detail);
+	}, []);
+
 	const onRelativeTimeChange = ({ detail: newRelativeOption }: CustomEvent<ITimePickerTime>) => {
 		setSelectedTime({
 			key: newRelativeOption.key,
@@ -58,10 +76,19 @@ const TimePickerSettedTimeTemplate: ComponentStory<typeof KvTimePicker> = args =
 		});
 	};
 
-	return <KvTimePicker {...args} selectedTimeOption={selectedTime} onTimeRangeChange={onRelativeTimeChange} />;
+	return (
+		<KvTimePicker
+			{...args}
+			showCalendar={showCalendar}
+			onShowCalendarStateChange={onShowCalendarStateChange}
+			selectedTimeOption={selectedTime}
+			onTimeRangeChange={onRelativeTimeChange}
+		/>
+	);
 };
 
 const TimePickerSettedRelativeTimeTemplate: ComponentStory<typeof KvTimePicker> = args => {
+	const [showCalendar, setShowCalendar] = useState<boolean>(false);
 	const [selectedTime, setSelectedTime] = useState<ITimePickerTime>({
 		key: 'last-24-h',
 		range: [],
@@ -71,6 +98,10 @@ const TimePickerSettedRelativeTimeTemplate: ComponentStory<typeof KvTimePicker> 
 		}
 	});
 
+	const onShowCalendarStateChange = useCallback(({ detail }: KvTimePickerCustomEvent<boolean>) => {
+		setShowCalendar(detail);
+	}, []);
+
 	const onRelativeTimeChange = ({ detail: newRelativeOption }: CustomEvent<ITimePickerTime>) => {
 		setSelectedTime({
 			key: newRelativeOption.key,
@@ -79,14 +110,26 @@ const TimePickerSettedRelativeTimeTemplate: ComponentStory<typeof KvTimePicker> 
 		});
 	};
 
-	return <KvTimePicker {...args} selectedTimeOption={selectedTime} onTimeRangeChange={onRelativeTimeChange} />;
+	return (
+		<KvTimePicker
+			{...args}
+			showCalendar={showCalendar}
+			onShowCalendarStateChange={onShowCalendarStateChange}
+			selectedTimeOption={selectedTime}
+			onTimeRangeChange={onRelativeTimeChange}
+		/>
+	);
 };
 
 const TimePickerWithoutTimezoneTemplate: ComponentStory<typeof KvTimePicker> = args => {
+	const [showCalendar, setShowCalendar] = useState<boolean>(false);
 	const [selectedTime, setSelectedTime] = useState<ITimePickerTime>({
 		key: 'last-72-h',
 		range: []
 	});
+	const onShowCalendarStateChange = useCallback(({ detail }: KvTimePickerCustomEvent<boolean>) => {
+		setShowCalendar(detail);
+	}, []);
 	const onRelativeTimeChange = ({ detail: newRelativeOption }: CustomEvent<ITimePickerTime>) => {
 		setSelectedTime({
 			key: newRelativeOption.key,
@@ -95,7 +138,15 @@ const TimePickerWithoutTimezoneTemplate: ComponentStory<typeof KvTimePicker> = a
 		});
 	};
 
-	return <KvTimePicker {...args} selectedTimeOption={selectedTime} onTimeRangeChange={onRelativeTimeChange} />;
+	return (
+		<KvTimePicker
+			{...args}
+			showCalendar={showCalendar}
+			onShowCalendarStateChange={onShowCalendarStateChange}
+			selectedTimeOption={selectedTime}
+			onTimeRangeChange={onRelativeTimeChange}
+		/>
+	);
 };
 
 export const DefaultState = TimePickerTemplate.bind({});

--- a/packages/ui-components/src/components/relative-time-picker/relative-time-picker.config.ts
+++ b/packages/ui-components/src/components/relative-time-picker/relative-time-picker.config.ts
@@ -267,6 +267,20 @@ export const DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS: IRelativeTimePickerOption[][]
 	],
 	[
 		{
+			label: 'Last 7 days',
+			value: 'last-7-d',
+			comparisonConfig: ERelativeTimeComparisonConfig.RelativeAmountOfUnits,
+			startDate: {
+				amount: -7,
+				unit: 'days'
+			},
+			labelRangeFormatter: {
+				startDateFormatter: 'D MMM',
+				separator: 'to',
+				endDateFormatter: 'D MMM'
+			}
+		},
+		{
 			label: 'Last week',
 			value: 'last-1-w',
 			comparisonConfig: ERelativeTimeComparisonConfig.AbsoluteAmountOfUnits,
@@ -285,13 +299,15 @@ export const DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS: IRelativeTimePickerOption[][]
 				separator: 'to',
 				endDateFormatter: 'D MMM'
 			}
-		},
+		}
+	],
+	[
 		{
-			label: 'Last 7 days',
-			value: 'last-7-d',
+			label: 'Last 30 days',
+			value: 'last-30-d',
 			comparisonConfig: ERelativeTimeComparisonConfig.RelativeAmountOfUnits,
 			startDate: {
-				amount: -7,
+				amount: -30,
 				unit: 'days'
 			},
 			labelRangeFormatter: {
@@ -299,9 +315,7 @@ export const DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS: IRelativeTimePickerOption[][]
 				separator: 'to',
 				endDateFormatter: 'D MMM'
 			}
-		}
-	],
-	[
+		},
 		{
 			label: 'Last month',
 			value: 'last-1-m',
@@ -321,23 +335,23 @@ export const DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS: IRelativeTimePickerOption[][]
 				separator: 'to',
 				endDateFormatter: 'D MMM'
 			}
-		},
-		{
-			label: 'Last 30 days',
-			value: 'last-30-d',
-			comparisonConfig: ERelativeTimeComparisonConfig.RelativeAmountOfUnits,
-			startDate: {
-				amount: -30,
-				unit: 'days'
-			},
-			labelRangeFormatter: {
-				startDateFormatter: 'D MMM',
-				separator: 'to',
-				endDateFormatter: 'D MMM'
-			}
 		}
 	],
 	[
+		{
+			label: 'Last 90 days',
+			value: 'last-90-d',
+			comparisonConfig: ERelativeTimeComparisonConfig.RelativeAmountOfUnits,
+			startDate: {
+				amount: -90,
+				unit: 'days'
+			},
+			labelRangeFormatter: {
+				startDateFormatter: 'D MMM YYYY',
+				separator: 'to',
+				endDateFormatter: 'D MMM YYYY'
+			}
+		},
 		{
 			label: 'Last quarter',
 			value: 'last-1-q',
@@ -357,13 +371,15 @@ export const DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS: IRelativeTimePickerOption[][]
 				separator: 'to',
 				endDateFormatter: 'D MMM YYYY'
 			}
-		},
+		}
+	],
+	[
 		{
-			label: 'Last 90 days',
-			value: 'last-90-d',
+			label: 'Last 365 days',
+			value: 'last-365-d',
 			comparisonConfig: ERelativeTimeComparisonConfig.RelativeAmountOfUnits,
 			startDate: {
-				amount: -90,
+				amount: -365,
 				unit: 'days'
 			},
 			labelRangeFormatter: {
@@ -371,9 +387,7 @@ export const DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS: IRelativeTimePickerOption[][]
 				separator: 'to',
 				endDateFormatter: 'D MMM YYYY'
 			}
-		}
-	],
-	[
+		},
 		{
 			label: 'Last year',
 			value: 'last-1-y',
@@ -393,13 +407,15 @@ export const DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS: IRelativeTimePickerOption[][]
 				separator: 'to',
 				endDateFormatter: 'D MMM YYYY'
 			}
-		},
+		}
+	],
+	[
 		{
-			label: 'Last 365 days',
-			value: 'last-365-d',
+			label: 'Last 731 days',
+			value: 'last-731-d',
 			comparisonConfig: ERelativeTimeComparisonConfig.RelativeAmountOfUnits,
 			startDate: {
-				amount: -365,
+				amount: -731,
 				unit: 'days'
 			},
 			labelRangeFormatter: {
@@ -407,9 +423,7 @@ export const DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS: IRelativeTimePickerOption[][]
 				separator: 'to',
 				endDateFormatter: 'D MMM YYYY'
 			}
-		}
-	],
-	[
+		},
 		{
 			label: 'Last 2 years',
 			value: 'last-2-y',
@@ -423,20 +437,6 @@ export const DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS: IRelativeTimePickerOption[][]
 				amount: -1,
 				unit: 'year',
 				unitReference: EUnitReference.EndOfUnit
-			},
-			labelRangeFormatter: {
-				startDateFormatter: 'D MMM YYYY',
-				separator: 'to',
-				endDateFormatter: 'D MMM YYYY'
-			}
-		},
-		{
-			label: 'Last 731 days',
-			value: 'last-731-d',
-			comparisonConfig: ERelativeTimeComparisonConfig.RelativeAmountOfUnits,
-			startDate: {
-				amount: -731,
-				unit: 'days'
 			},
 			labelRangeFormatter: {
 				startDateFormatter: 'D MMM YYYY',


### PR DESCRIPTION
This PR re-orders the default time picker options and fixes the show calendar toggle in the stories that needed to have a state to handle the changes.