### PR TITLE
feat(wizard): add a more imperative approach to footer actions

### DIFF
--- a/packages/react-ui-components/src/stories/Components/Wizard.stories.tsx
+++ b/packages/react-ui-components/src/stories/Components/Wizard.stories.tsx
@@ -62,7 +62,7 @@ const DEFAULT_ARGS = {
 	steps: [
 		{
 			title: 'Info',
-			allowGoBack: true
+			cancelable: true
 		},
 		{
 			title: 'Configuration',

--- a/packages/ui-components/src/components/wizard-footer/readme.md
+++ b/packages/ui-components/src/components/wizard-footer/readme.md
@@ -112,25 +112,32 @@ export const KvWizardFooterExample: React.FC = () => {
 
 | Property                          | Attribute             | Description                                                                                  | Type             | Default     |
 | --------------------------------- | --------------------- | -------------------------------------------------------------------------------------------- | ---------------- | ----------- |
+| `cancelEnabled`                   | `cancel-enabled`      | (optional) Defines if the `cancel` button should be enabled and interactable                 | `boolean`        | `true`      |
+| `completeBtnLabel`                | `complete-btn-label`  |                                                                                              | `string`         | `'Submit'`  |
+| `completeEnabled`                 | `complete-enabled`    | (optional) Defines if the `complete` button should be enabled and interactable               | `boolean`        | `undefined` |
 | `currentStep` _(required)_        | `current-step`        | (required) Defines the current step index                                                    | `number`         | `undefined` |
 | `hasError`                        | `has-error`           | (optional) Defines if the progress bar should be in an error state                           | `boolean`        | `undefined` |
 | `label`                           | `label`               | (optional) Defines the label to display next to the step counter (defaults to: "Progress: ") | `string`         | `undefined` |
-| `nextBtnLabel`                    | `next-btn-label`      | (required) A label to show on the `next` button                                              | `string`         | `'Next'`    |
-| `nextEnabled`                     | `next-enabled`        | (required) Defines if the `next` button should be enabled and interactable                   | `boolean`        | `true`      |
-| `prevBtnLabel`                    | `prev-btn-label`      | (optional) A label to show on the `previous` button                                          | `string`         | `undefined` |
-| `prevEnabled`                     | `prev-enabled`        | (required) Defines if the `previous` button should be enabled and interactable               | `boolean`        | `true`      |
+| `nextEnabled`                     | `next-enabled`        | (optional) Defines if the `next` button should be enabled and interactable                   | `boolean`        | `true`      |
+| `prevEnabled`                     | `prev-enabled`        | (optional) Defines if the `previous` button should be enabled and interactable               | `boolean`        | `true`      |
 | `progressPercentage` _(required)_ | `progress-percentage` | (required) Defines the percentage of steps completed                                         | `number`         | `undefined` |
+| `showCancelBtn`                   | `show-cancel-btn`     | (required) A boolean that determines whether the `cencel` button should be shown             | `boolean`        | `undefined` |
+| `showCompleteBtn`                 | `show-complete-btn`   | (required) A boolean that determines whether the `complete` button should be shown           | `boolean`        | `undefined` |
+| `showNextBtn`                     | `show-next-btn`       | (required) A boolean that determines whether the `next` button should be shown               | `boolean`        | `undefined` |
+| `showPrevBtn`                     | `show-prev-btn`       | (required) A boolean that determines whether the `previous` button should be shown           | `boolean`        | `undefined` |
 | `showStepBar`                     | `show-step-bar`       | (optional) Defines if the step bar should render                                             | `boolean`        | `true`      |
 | `steps` _(required)_              | --                    | (required) Defines the steps array to render                                                 | `IStepBarStep[]` | `undefined` |
 
 
 ## Events
 
-| Event       | Description                                                      | Type                  |
-| ----------- | ---------------------------------------------------------------- | --------------------- |
-| `nextClick` | Fires when the `next` button is clicked                          | `CustomEvent<void>`   |
-| `prevClick` | Fires when the `previous` button is clicked                      | `CustomEvent<void>`   |
-| `stepClick` | Fires when a step on the step bar is clicked and emits the index | `CustomEvent<number>` |
+| Event           | Description                                                      | Type                  |
+| --------------- | ---------------------------------------------------------------- | --------------------- |
+| `cancelClick`   | Fires when the `cancel` button is clicked                        | `CustomEvent<void>`   |
+| `completeClick` | Fires when the `complete` button is clicked                      | `CustomEvent<void>`   |
+| `nextClick`     | Fires when the `next` button is clicked                          | `CustomEvent<void>`   |
+| `prevClick`     | Fires when the `previous` button is clicked                      | `CustomEvent<void>`   |
+| `stepClick`     | Fires when a step on the step bar is clicked and emits the index | `CustomEvent<number>` |
 
 
 ## CSS Custom Properties

--- a/packages/ui-components/src/components/wizard-footer/test/__snapshots__/wizard-footer.spec.tsx.snap
+++ b/packages/ui-components/src/components/wizard-footer/test/__snapshots__/wizard-footer.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Wizard Footer (unit tests) when using required props and steps dont have errors should match the snapshot 1`] = `
-<kv-wizard-footer current-step="1" next-btn-label="Next" next-enabled="" prev-enabled="" progress-percentage="50" show-step-bar="">
+<kv-wizard-footer cancel-enabled="" complete-btn-label="Submit" current-step="1" next-enabled="" prev-enabled="" progress-percentage="50" show-step-bar="">
   <mock:shadow-root>
     <div class="wizard-footer-container">
       <div class="wizard-stepper">
@@ -9,7 +9,6 @@ exports[`Wizard Footer (unit tests) when using required props and steps dont hav
       </div>
       <div class="actions-container">
         <slot name="additional-actions"></slot>
-        <kv-action-button-text text="Next" type="primary"></kv-action-button-text>
       </div>
     </div>
   </mock:shadow-root>
@@ -17,7 +16,7 @@ exports[`Wizard Footer (unit tests) when using required props and steps dont hav
 `;
 
 exports[`Wizard Footer (unit tests) when using required props and steps have errors should match the snapshot 1`] = `
-<kv-wizard-footer current-step="1" has-error="" next-btn-label="Next" next-enabled="" prev-enabled="" progress-percentage="50" show-step-bar="">
+<kv-wizard-footer cancel-enabled="" complete-btn-label="Submit" current-step="1" has-error="" next-enabled="" prev-enabled="" progress-percentage="50" show-step-bar="">
   <mock:shadow-root>
     <div class="wizard-footer-container">
       <div class="wizard-stepper">
@@ -25,7 +24,6 @@ exports[`Wizard Footer (unit tests) when using required props and steps have err
       </div>
       <div class="actions-container">
         <slot name="additional-actions"></slot>
-        <kv-action-button-text text="Next" type="primary"></kv-action-button-text>
       </div>
     </div>
   </mock:shadow-root>

--- a/packages/ui-components/src/components/wizard-footer/wizard-footer.tsx
+++ b/packages/ui-components/src/components/wizard-footer/wizard-footer.tsx
@@ -1,7 +1,6 @@
 import { Component, Event, EventEmitter, Host, Prop, h } from '@stencil/core';
 import { IWizardFooter, IWizardFooterEvents } from './wizard-footer.types';
 import { EActionButtonType, IStepBarStep } from '../../types';
-import { isEmpty } from 'lodash';
 
 @Component({
 	tag: 'kv-wizard-footer',
@@ -22,20 +21,34 @@ export class KvWizardFooter implements IWizardFooter, IWizardFooterEvents {
 	/** @inheritdoc */
 	@Prop({ reflect: true }) showStepBar?: boolean = true;
 	/** @inheritdoc */
-	@Prop({ reflect: true }) prevBtnLabel?: string;
+	@Prop({ reflect: true }) completeBtnLabel: string = 'Submit';
 	/** @inheritdoc */
-	@Prop({ reflect: true }) nextBtnLabel: string = 'Next';
+	@Prop({ reflect: true }) cancelEnabled: boolean = true;
 	/** @inheritdoc */
 	@Prop({ reflect: true }) prevEnabled: boolean = true;
 	/** @inheritdoc */
 	@Prop({ reflect: true }) nextEnabled: boolean = true;
+	/** @inheritdoc */
+	@Prop({ reflect: true }) completeEnabled: boolean;
+	/** @inheritdoc */
+	@Prop({ reflect: true }) showCancelBtn: boolean;
+	/** @inheritdoc */
+	@Prop({ reflect: true }) showPrevBtn: boolean;
+	/** @inheritdoc */
+	@Prop({ reflect: true }) showNextBtn: boolean;
+	/** @inheritdoc */
+	@Prop({ reflect: true }) showCompleteBtn: boolean;
 
 	/** @inheritdoc */
 	@Event() stepClick: EventEmitter<number>;
 	/** @inheritdoc */
+	@Event() cancelClick: EventEmitter<void>;
+	/** @inheritdoc */
 	@Event() prevClick: EventEmitter<void>;
 	/** @inheritdoc */
 	@Event() nextClick: EventEmitter<void>;
+	/** @inheritdoc */
+	@Event() completeClick: EventEmitter<void>;
 
 	private onPrevClick = () => {
 		this.prevClick.emit();
@@ -43,6 +56,14 @@ export class KvWizardFooter implements IWizardFooter, IWizardFooterEvents {
 
 	private onNextClick = () => {
 		this.nextClick.emit();
+	};
+
+	private onCancelClick = () => {
+		this.cancelClick.emit();
+	};
+
+	private onCompleteClick = () => {
+		this.completeClick.emit();
 	};
 
 	private onStepClick = ({ detail }: CustomEvent<number>) => {
@@ -67,10 +88,21 @@ export class KvWizardFooter implements IWizardFooter, IWizardFooterEvents {
 					</div>
 					<div class="actions-container">
 						<slot name="additional-actions" />
-						{!isEmpty(this.prevBtnLabel) && (
-							<kv-action-button-text type={EActionButtonType.Tertiary} text={this.prevBtnLabel} disabled={!this.prevEnabled} onClickButton={this.onPrevClick} />
+						{this.showCancelBtn && (
+							<kv-action-button-text type={EActionButtonType.Tertiary} text="Cancel" disabled={!this.cancelEnabled} onClickButton={this.onCancelClick} />
 						)}
-						<kv-action-button-text type={EActionButtonType.Primary} text={this.nextBtnLabel} disabled={!this.nextEnabled} onClickButton={this.onNextClick} />
+						{this.showPrevBtn && (
+							<kv-action-button-text type={EActionButtonType.Tertiary} text="Previous" disabled={!this.prevEnabled} onClickButton={this.onPrevClick} />
+						)}
+						{this.showNextBtn && <kv-action-button-text type={EActionButtonType.Primary} text="Next" disabled={!this.nextEnabled} onClickButton={this.onNextClick} />}
+						{this.showCompleteBtn && (
+							<kv-action-button-text
+								type={EActionButtonType.Primary}
+								text={this.completeBtnLabel}
+								disabled={!this.completeEnabled}
+								onClickButton={this.onCompleteClick}
+							/>
+						)}
 					</div>
 				</div>
 			</Host>

--- a/packages/ui-components/src/components/wizard-footer/wizard-footer.types.ts
+++ b/packages/ui-components/src/components/wizard-footer/wizard-footer.types.ts
@@ -4,14 +4,22 @@ import { IStepBar } from '../../types';
 export interface IWizardFooter extends IStepBar {
 	/** (optional) Defines if the step bar should render */
 	showStepBar?: boolean;
-	/** (optional) A label to show on the `previous` button */
-	prevBtnLabel?: string;
-	/** (required) A label to show on the `next` button */
-	nextBtnLabel: string;
-	/** (required) Defines if the `previous` button should be enabled and interactable */
+	/** (optional) Defines if the `previous` button should be enabled and interactable */
 	prevEnabled: boolean;
-	/** (required) Defines if the `next` button should be enabled and interactable */
+	/** (optional) Defines if the `cancel` button should be enabled and interactable */
+	cancelEnabled: boolean;
+	/** (optional) Defines if the `next` button should be enabled and interactable */
 	nextEnabled: boolean;
+	/** (optional) Defines if the `complete` button should be enabled and interactable */
+	completeEnabled: boolean;
+	/** (required) A boolean that determines whether the `cencel` button should be shown */
+	showCancelBtn?: boolean;
+	/** (required) A boolean that determines whether the `previous` button should be shown */
+	showPrevBtn?: boolean;
+	/** (required) A boolean that determines whether the `next` button should be shown */
+	showNextBtn?: boolean;
+	/** (required) A boolean that determines whether the `complete` button should be shown */
+	showCompleteBtn?: boolean;
 }
 
 export interface IWizardFooterEvents {
@@ -21,4 +29,8 @@ export interface IWizardFooterEvents {
 	prevClick: EventEmitter<void>;
 	/** Fires when the `next` button is clicked */
 	nextClick: EventEmitter<void>;
+	/** Fires when the `cancel` button is clicked */
+	cancelClick: EventEmitter<void>;
+	/** Fires when the `complete` button is clicked */
+	completeClick: EventEmitter<void>;
 }

--- a/packages/ui-components/src/components/wizard/readme.md
+++ b/packages/ui-components/src/components/wizard/readme.md
@@ -68,7 +68,7 @@ export const KvWizardExample: React.FC = () => {
 
 | Property                   | Attribute            | Description                                                                         | Type                                     | Default     |
 | -------------------------- | -------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------- | ----------- |
-| `completeBtnLabel`         | `complete-btn-label` | (optional) A label to show on the last step button. Default: 'Submit'               | `string`                                 | `'Submit'`  |
+| `completeBtnLabel`         | `complete-btn-label` | (optional) A label to show on the last step button. Default: 'Submit'               | `string`                                 | `undefined` |
 | `currentStep` _(required)_ | `current-step`       | (required) Defines the current step index                                           | `number`                                 | `undefined` |
 | `currentStepState`         | `current-step-state` | (optional) Defines the current step state. Only the success state allows to proceed | `EStepState.Error \| EStepState.Success` | `undefined` |
 | `showHeader`               | `show-header`        | (optional) Defines if the header should render. Default: true                       | `boolean`                                | `true`      |

--- a/packages/ui-components/src/components/wizard/test/__snapshots__/wizard.spec.tsx.snap
+++ b/packages/ui-components/src/components/wizard/test/__snapshots__/wizard.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Wizard (unit tests) when current step don't have state should match the snapshot 1`] = `
-<kv-wizard complete-btn-label="Submit" current-step="1" show-header="" show-step-bar="">
+<kv-wizard current-step="1" show-header="" show-step-bar="">
   <mock:shadow-root>
     <div class="wizard">
       <div class="wizard-header">
@@ -11,7 +11,9 @@ exports[`Wizard (unit tests) when current step don't have state should match the
         <slot name="step-content"></slot>
       </div>
       <div class="wizard-footer">
-        <kv-wizard-footer currentstep="1" nextbtnlabel="Next" prevbtnlabel="Back" prevenabled="" progresspercentage="50" showstepbar=""></kv-wizard-footer>
+        <kv-wizard-footer cancelenabled="" currentstep="1" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="" showstepbar="">
+          <slot name="additional-actions" slot="additional-actions"></slot>
+        </kv-wizard-footer>
       </div>
     </div>
   </mock:shadow-root>
@@ -19,7 +21,7 @@ exports[`Wizard (unit tests) when current step don't have state should match the
 `;
 
 exports[`Wizard (unit tests) when current step have errors should match the snapshot 1`] = `
-<kv-wizard complete-btn-label="Submit" current-step="1" current-step-state="error" show-header="" show-step-bar="">
+<kv-wizard current-step="1" current-step-state="error" show-header="" show-step-bar="">
   <mock:shadow-root>
     <div class="wizard">
       <div class="wizard-header">
@@ -29,7 +31,9 @@ exports[`Wizard (unit tests) when current step have errors should match the snap
         <slot name="step-content"></slot>
       </div>
       <div class="wizard-footer">
-        <kv-wizard-footer currentstep="1" haserror="" nextbtnlabel="Next" prevbtnlabel="Back" prevenabled="" progresspercentage="50" showstepbar=""></kv-wizard-footer>
+        <kv-wizard-footer cancelenabled="" currentstep="1" haserror="" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="" showstepbar="">
+          <slot name="additional-actions" slot="additional-actions"></slot>
+        </kv-wizard-footer>
       </div>
     </div>
   </mock:shadow-root>
@@ -37,7 +41,7 @@ exports[`Wizard (unit tests) when current step have errors should match the snap
 `;
 
 exports[`Wizard (unit tests) when current step have success state should match the snapshot 1`] = `
-<kv-wizard complete-btn-label="Submit" current-step="1" current-step-state="success" show-header="" show-step-bar="">
+<kv-wizard current-step="1" current-step-state="success" show-header="" show-step-bar="">
   <mock:shadow-root>
     <div class="wizard">
       <div class="wizard-header">
@@ -47,7 +51,9 @@ exports[`Wizard (unit tests) when current step have success state should match t
         <slot name="step-content"></slot>
       </div>
       <div class="wizard-footer">
-        <kv-wizard-footer currentstep="1" nextbtnlabel="Next" nextenabled="" prevbtnlabel="Back" prevenabled="" progresspercentage="50" showstepbar=""></kv-wizard-footer>
+        <kv-wizard-footer cancelenabled="" completeenabled="" currentstep="1" nextenabled="" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="" showstepbar="">
+          <slot name="additional-actions" slot="additional-actions"></slot>
+        </kv-wizard-footer>
       </div>
     </div>
   </mock:shadow-root>
@@ -55,7 +61,7 @@ exports[`Wizard (unit tests) when current step have success state should match t
 `;
 
 exports[`Wizard (unit tests) when current step is the first one should match the snapshot 1`] = `
-<kv-wizard complete-btn-label="Submit" current-step="0" current-step-state="success" show-header="" show-step-bar="">
+<kv-wizard current-step="0" current-step-state="success" show-header="" show-step-bar="">
   <mock:shadow-root>
     <div class="wizard">
       <div class="wizard-header">
@@ -65,7 +71,9 @@ exports[`Wizard (unit tests) when current step is the first one should match the
         <slot name="step-content"></slot>
       </div>
       <div class="wizard-footer">
-        <kv-wizard-footer currentstep="0" nextbtnlabel="Next" nextenabled="" prevbtnlabel="Cancel" prevenabled="" progresspercentage="0" showstepbar=""></kv-wizard-footer>
+        <kv-wizard-footer cancelenabled="" completeenabled="" currentstep="0" nextenabled="" progresspercentage="0" showcancelbtn="" shownextbtn="" showstepbar="">
+          <slot name="additional-actions" slot="additional-actions"></slot>
+        </kv-wizard-footer>
       </div>
     </div>
   </mock:shadow-root>
@@ -83,7 +91,9 @@ exports[`Wizard (unit tests) when current step is the last one should match the 
         <slot name="step-content"></slot>
       </div>
       <div class="wizard-footer">
-        <kv-wizard-footer currentstep="2" nextbtnlabel="Deploy" nextenabled="" prevbtnlabel="Back" prevenabled="" progresspercentage="100" showstepbar=""></kv-wizard-footer>
+        <kv-wizard-footer cancelenabled="" completebtnlabel="Deploy" completeenabled="" currentstep="2" nextenabled="" prevenabled="" progresspercentage="100" showcompletebtn="" showprevbtn="" showstepbar="">
+          <slot name="additional-actions" slot="additional-actions"></slot>
+        </kv-wizard-footer>
       </div>
     </div>
   </mock:shadow-root>
@@ -91,14 +101,16 @@ exports[`Wizard (unit tests) when current step is the last one should match the 
 `;
 
 exports[`Wizard (unit tests) when showHeader is false should match the snapshot 1`] = `
-<kv-wizard complete-btn-label="Submit" current-step="1" show-step-bar="">
+<kv-wizard current-step="1" show-step-bar="">
   <mock:shadow-root>
     <div class="wizard">
       <div class="wizard-content">
         <slot name="step-content"></slot>
       </div>
       <div class="wizard-footer">
-        <kv-wizard-footer currentstep="1" nextbtnlabel="Next" prevbtnlabel="Back" prevenabled="" progresspercentage="50" showstepbar=""></kv-wizard-footer>
+        <kv-wizard-footer cancelenabled="" currentstep="1" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="" showstepbar="">
+          <slot name="additional-actions" slot="additional-actions"></slot>
+        </kv-wizard-footer>
       </div>
     </div>
   </mock:shadow-root>
@@ -106,7 +118,7 @@ exports[`Wizard (unit tests) when showHeader is false should match the snapshot 
 `;
 
 exports[`Wizard (unit tests) when showStepBar is false should match the snapshot 1`] = `
-<kv-wizard complete-btn-label="Submit" current-step="1" show-header="">
+<kv-wizard current-step="1" show-header="">
   <mock:shadow-root>
     <div class="wizard">
       <div class="wizard-header">
@@ -116,7 +128,9 @@ exports[`Wizard (unit tests) when showStepBar is false should match the snapshot
         <slot name="step-content"></slot>
       </div>
       <div class="wizard-footer">
-        <kv-wizard-footer currentstep="1" nextbtnlabel="Next" prevbtnlabel="Back" prevenabled="" progresspercentage="50"></kv-wizard-footer>
+        <kv-wizard-footer cancelenabled="" currentstep="1" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="">
+          <slot name="additional-actions" slot="additional-actions"></slot>
+        </kv-wizard-footer>
       </div>
     </div>
   </mock:shadow-root>

--- a/packages/ui-components/src/components/wizard/test/wizard.mock.ts
+++ b/packages/ui-components/src/components/wizard/test/wizard.mock.ts
@@ -3,7 +3,7 @@ import { IWizardStep } from '../wizard.types';
 export const MOCK_STEPS: IWizardStep[] = [
 	{
 		title: 'Info',
-		allowGoBack: true
+		cancelable: true
 	},
 	{
 		title: 'Configuration',

--- a/packages/ui-components/src/components/wizard/test/wizard.spec.tsx
+++ b/packages/ui-components/src/components/wizard/test/wizard.spec.tsx
@@ -52,10 +52,14 @@ describe('Wizard (unit tests)', () => {
 				],
 				currentStep: 1,
 				hasError: false,
-				prevBtnLabel: 'Back',
+				showPrevBtn: true,
 				prevEnabled: true,
-				nextBtnLabel: 'Next',
+				showNextBtn: true,
 				nextEnabled: false,
+				showCancelBtn: false,
+				cancelEnabled: true,
+				showCompleteBtn: false,
+				completeEnabled: false,
 				progressPercentage: 50
 			});
 		});
@@ -105,10 +109,14 @@ describe('Wizard (unit tests)', () => {
 				],
 				currentStep: 1,
 				hasError: true,
-				prevBtnLabel: 'Back',
+				showPrevBtn: true,
 				prevEnabled: true,
-				nextBtnLabel: 'Next',
+				showNextBtn: true,
 				nextEnabled: false,
+				showCancelBtn: false,
+				cancelEnabled: true,
+				showCompleteBtn: false,
+				completeEnabled: false,
 				progressPercentage: 50
 			});
 		});
@@ -158,10 +166,14 @@ describe('Wizard (unit tests)', () => {
 				],
 				currentStep: 1,
 				hasError: false,
-				prevBtnLabel: 'Back',
+				showPrevBtn: true,
 				prevEnabled: true,
-				nextBtnLabel: 'Next',
+				showNextBtn: true,
 				nextEnabled: true,
+				showCancelBtn: false,
+				cancelEnabled: true,
+				showCompleteBtn: false,
+				completeEnabled: true,
 				progressPercentage: 50
 			});
 		});
@@ -173,6 +185,28 @@ describe('Wizard (unit tests)', () => {
 			});
 
 			it('should emit to goToStep 2', () => {
+				expect(comp.goToStep.emit).toHaveBeenCalledWith(2);
+			});
+		});
+
+		describe('and previous button is clicked', () => {
+			beforeEach(() => {
+				jest.spyOn(comp.goToStep, 'emit');
+				comp.onPrevClick();
+			});
+
+			it('should emit to goToStep 1', () => {
+				expect(comp.goToStep.emit).toHaveBeenCalledWith(0);
+			});
+		});
+
+		describe('and next button is clicked', () => {
+			beforeEach(() => {
+				jest.spyOn(comp.goToStep, 'emit');
+				comp.onNextClick();
+			});
+
+			it('should emit to goToStep 1', () => {
 				expect(comp.goToStep.emit).toHaveBeenCalledWith(2);
 			});
 		});
@@ -222,33 +256,15 @@ describe('Wizard (unit tests)', () => {
 				],
 				currentStep: 0,
 				hasError: false,
-				prevBtnLabel: 'Cancel',
-				prevEnabled: true,
-				nextBtnLabel: 'Next',
+				showPrevBtn: false,
+				prevEnabled: false,
+				showNextBtn: true,
 				nextEnabled: true,
+				showCancelBtn: true,
+				cancelEnabled: true,
+				showCompleteBtn: false,
+				completeEnabled: true,
 				progressPercentage: 0
-			});
-		});
-
-		describe('and previous button is clicked', () => {
-			beforeEach(() => {
-				jest.spyOn(comp.cancelClick, 'emit');
-				comp.onPrevClick();
-			});
-
-			it('should emit to cancelClick', () => {
-				expect(comp.cancelClick.emit).toHaveBeenCalled();
-			});
-		});
-
-		describe('and next button is clicked', () => {
-			beforeEach(() => {
-				jest.spyOn(comp.goToStep, 'emit');
-				comp.onNextClick();
-			});
-
-			it('should emit to goToStep 1', () => {
-				expect(comp.goToStep.emit).toHaveBeenCalledWith(1);
 			});
 		});
 	});
@@ -297,10 +313,14 @@ describe('Wizard (unit tests)', () => {
 				],
 				currentStep: 2,
 				hasError: false,
-				prevBtnLabel: 'Back',
+				showPrevBtn: true,
 				prevEnabled: true,
-				nextBtnLabel: 'Deploy',
+				showNextBtn: false,
 				nextEnabled: true,
+				showCancelBtn: false,
+				cancelEnabled: true,
+				showCompleteBtn: true,
+				completeEnabled: true,
 				progressPercentage: 100
 			});
 		});
@@ -313,17 +333,6 @@ describe('Wizard (unit tests)', () => {
 
 			it('should emit to goToStep 1', () => {
 				expect(comp.goToStep.emit).toHaveBeenCalledWith(1);
-			});
-		});
-
-		describe('and next button is clicked', () => {
-			beforeEach(() => {
-				jest.spyOn(comp.completeClick, 'emit');
-				comp.onNextClick();
-			});
-
-			it('should emit to completeClick', () => {
-				expect(comp.completeClick.emit).toHaveBeenCalled();
 			});
 		});
 	});

--- a/packages/ui-components/src/components/wizard/wizard.helper.ts
+++ b/packages/ui-components/src/components/wizard/wizard.helper.ts
@@ -15,7 +15,7 @@ export const buildHeaderConfig = (steps?: IWizardStep[], currentStep?: number): 
 	};
 };
 
-export const buildFooterConfig = (steps?: IWizardStep[], currentStep?: number, currentStepState?: EStepState, completeBtnLabel?: string): IWizardFooter => {
+export const buildFooterConfig = (steps?: IWizardStep[], currentStep?: number, currentStepState?: EStepState): IWizardFooter => {
 	if (isEmpty(steps) || isNil(currentStep) || currentStep < 0 || currentStep > steps.length - 1) {
 		return null;
 	}
@@ -33,10 +33,14 @@ export const buildFooterConfig = (steps?: IWizardStep[], currentStep?: number, c
 		steps: stepsConfig,
 		currentStep,
 		hasError: currentStepState === EStepState.Error,
-		prevBtnLabel: steps[currentStep].allowGoBack ? (currentStep === 0 ? 'Cancel' : 'Back') : undefined,
-		prevEnabled: steps[currentStep].allowGoBack,
-		nextBtnLabel: currentStep === steps.length - 1 ? completeBtnLabel : 'Next',
+		showPrevBtn: steps[currentStep].allowGoBack ?? false,
+		prevEnabled: currentStep > 0,
+		showNextBtn: currentStep < steps.length - 1,
 		nextEnabled: currentStepState === EStepState.Success,
+		showCancelBtn: steps[currentStep].cancelable ?? false,
+		cancelEnabled: true,
+		showCompleteBtn: currentStep === steps.length - 1,
+		completeEnabled: currentStepState === EStepState.Success,
 		progressPercentage: currentStep * (100 / (steps.length - 1))
 	};
 };

--- a/packages/ui-components/src/components/wizard/wizard.tsx
+++ b/packages/ui-components/src/components/wizard/wizard.tsx
@@ -21,7 +21,7 @@ export class KvWizard implements IWizard, IWizardEvents {
 	/** @inheritdoc */
 	@Prop({ reflect: true }) showStepBar: boolean = true;
 	/** @inheritdoc */
-	@Prop({ reflect: true }) completeBtnLabel: string = 'Submit';
+	@Prop({ reflect: true }) completeBtnLabel?: string;
 
 	/** @inheritdoc */
 	@Event() goToStep: EventEmitter<number>;
@@ -39,44 +39,31 @@ export class KvWizard implements IWizard, IWizardEvents {
 	@Watch('steps')
 	stepsChangeHandler(newValue: IWizardStep[]) {
 		this.currentHeader = buildHeaderConfig(newValue, this.currentStep);
-		this.currentFooter = buildFooterConfig(newValue, this.currentStep, this.currentStepState, this.completeBtnLabel);
+		this.currentFooter = buildFooterConfig(newValue, this.currentStep, this.currentStepState);
 	}
 	/** Watch the `currentStep` property and update internal state accordingly */
 	@Watch('currentStep')
 	currentStepChangeHandler(newValue: number) {
 		this.currentHeader = buildHeaderConfig(this.steps, newValue);
-		this.currentFooter = buildFooterConfig(this.steps, newValue, this.currentStepState, this.completeBtnLabel);
+		this.currentFooter = buildFooterConfig(this.steps, newValue, this.currentStepState);
 	}
 	/** Watch the `currentStepState` property and update internal state accordingly */
 	@Watch('currentStepState')
 	hasErrorStepChangeHandler(newValue: EStepState) {
-		this.currentFooter = buildFooterConfig(this.steps, this.currentStep, newValue, this.completeBtnLabel);
-	}
-	/** Watch the `completeBtnLabel` property and update internal state accordingly */
-	@Watch('completeBtnLabel')
-	completeBtnLabelStepChangeHandler(newValue: string) {
-		this.currentFooter = buildFooterConfig(this.steps, this.currentStep, this.currentStepState, newValue);
+		this.currentFooter = buildFooterConfig(this.steps, this.currentStep, newValue);
 	}
 
 	componentWillLoad() {
 		this.currentHeader = buildHeaderConfig(this.steps, this.currentStep);
-		this.currentFooter = buildFooterConfig(this.steps, this.currentStep, this.currentStepState, this.completeBtnLabel);
+		this.currentFooter = buildFooterConfig(this.steps, this.currentStep, this.currentStepState);
 	}
 
 	onPrevClick = () => {
-		if (this.currentStep === 0) {
-			this.cancelClick.emit();
-		} else {
-			this.goToStep.emit(this.currentStep - 1);
-		}
+		this.goToStep.emit(this.currentStep - 1);
 	};
 
 	onNextClick = () => {
-		if (this.currentStep === this.steps.length - 1) {
-			this.completeClick.emit();
-		} else {
-			this.goToStep.emit(this.currentStep + 1);
-		}
+		this.goToStep.emit(this.currentStep + 1);
 	};
 
 	onStepClick = ({ detail }: CustomEvent<number>) => {
@@ -88,7 +75,7 @@ export class KvWizard implements IWizard, IWizardEvents {
 			<div class="wizard">
 				{this.showHeader && <div class="wizard-header">{this.currentHeader && <kv-wizard-header {...this.currentHeader}></kv-wizard-header>}</div>}
 				<div class={{ 'wizard-content': true, 'has-header': this.showHeader }}>
-					<slot name={`step-content`}></slot>
+					<slot name="step-content"></slot>
 				</div>
 				<div class="wizard-footer">
 					<kv-wizard-footer
@@ -96,8 +83,11 @@ export class KvWizard implements IWizard, IWizardEvents {
 						onNextClick={this.onNextClick}
 						onStepClick={this.onStepClick}
 						showStepBar={this.showStepBar}
+						completeBtnLabel={this.completeBtnLabel}
 						{...this.currentFooter}
-					></kv-wizard-footer>
+					>
+						<slot slot="additional-actions" name="additional-actions" />
+					</kv-wizard-footer>
 				</div>
 			</div>
 		);

--- a/packages/ui-components/src/components/wizard/wizard.types.ts
+++ b/packages/ui-components/src/components/wizard/wizard.types.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from '@stencil/core';
 
 export interface IWizardStep {
 	title: string;
+	cancelable?: boolean;
 	allowGoBack?: boolean;
 }
 
@@ -17,7 +18,7 @@ export interface IWizard {
 	/** (optional) Defines if the step bar should render. Default: true */
 	showStepBar?: boolean;
 	/** (optional) A label to show on the last step button. Default: 'Submit' */
-	completeBtnLabel: string;
+	completeBtnLabel?: string;
 }
 
 export interface IWizardEvents {


### PR DESCRIPTION
I noticed that in some situations we need to allow the user to stop a wizard flow at any step.

We could use the `additional-actions` slot and control this from outside this component, but I believe this behaviour will be needed in more scenarios shortly hence we might as well add it to the Component itself.

That's what this PR does, adds a cancelable prop to the IWizardStep to allow any step to have a "cancel" action button.