### PR TITLE
feat(wizard-footer): move additional actions slot for added flexibility

### DIFF
--- a/packages/ui-components/src/components/wizard-footer/readme.md
+++ b/packages/ui-components/src/components/wizard-footer/readme.md
@@ -140,6 +140,13 @@ export const KvWizardFooterExample: React.FC = () => {
 | `stepClick`     | Fires when a step on the step bar is clicked and emits the index | `CustomEvent<number>` |
 
 
+## Shadow Parts
+
+| Part                         | Description                                            |
+| ---------------------------- | ------------------------------------------------------ |
+| `"footer-actions-container"` | the container of footer stepper and additional actions |
+
+
 ## CSS Custom Properties
 
 | Name              | Description                                             |

--- a/packages/ui-components/src/components/wizard-footer/test/__snapshots__/wizard-footer.spec.tsx.snap
+++ b/packages/ui-components/src/components/wizard-footer/test/__snapshots__/wizard-footer.spec.tsx.snap
@@ -4,12 +4,13 @@ exports[`Wizard Footer (unit tests) when using required props and steps dont hav
 <kv-wizard-footer cancel-enabled="" complete-btn-label="Submit" current-step="1" next-enabled="" prev-enabled="" progress-percentage="50" show-step-bar="">
   <mock:shadow-root>
     <div class="wizard-footer-container">
-      <div class="wizard-stepper">
-        <kv-step-bar currentstep="1" progresspercentage="50"></kv-step-bar>
-      </div>
-      <div class="actions-container">
+      <div class="actions-container" part="footer-actions-container">
+        <div class="wizard-stepper">
+          <kv-step-bar currentstep="1" progresspercentage="50"></kv-step-bar>
+        </div>
         <slot name="additional-actions"></slot>
       </div>
+      <div class="buttons-container"></div>
     </div>
   </mock:shadow-root>
 </kv-wizard-footer>
@@ -19,12 +20,13 @@ exports[`Wizard Footer (unit tests) when using required props and steps have err
 <kv-wizard-footer cancel-enabled="" complete-btn-label="Submit" current-step="1" has-error="" next-enabled="" prev-enabled="" progress-percentage="50" show-step-bar="">
   <mock:shadow-root>
     <div class="wizard-footer-container">
-      <div class="wizard-stepper">
-        <kv-step-bar currentstep="1" haserror="" progresspercentage="50"></kv-step-bar>
-      </div>
-      <div class="actions-container">
+      <div class="actions-container" part="footer-actions-container">
+        <div class="wizard-stepper">
+          <kv-step-bar currentstep="1" haserror="" progresspercentage="50"></kv-step-bar>
+        </div>
         <slot name="additional-actions"></slot>
       </div>
+      <div class="buttons-container"></div>
     </div>
   </mock:shadow-root>
 </kv-wizard-footer>

--- a/packages/ui-components/src/components/wizard-footer/wizard-footer.scss
+++ b/packages/ui-components/src/components/wizard-footer/wizard-footer.scss
@@ -15,12 +15,16 @@
 
 	.actions-container {
 		display: flex;
+		flex: 1;
+
+		.wizard-stepper {
+			width: var(--stepper-width);
+			padding-right: $spacing-4x;
+		}
+	}
+
+	.buttons-container {
+		display: flex;
 		gap: $spacing-3x;
 	}
-
-	.wizard-stepper {
-		width: var(--stepper-width);
-		padding-right: $spacing-4x;
-	}
 }
-

--- a/packages/ui-components/src/components/wizard-footer/wizard-footer.tsx
+++ b/packages/ui-components/src/components/wizard-footer/wizard-footer.tsx
@@ -2,6 +2,9 @@ import { Component, Event, EventEmitter, Host, Prop, h } from '@stencil/core';
 import { IWizardFooter, IWizardFooterEvents } from './wizard-footer.types';
 import { EActionButtonType, IStepBarStep } from '../../types';
 
+/**
+ * @part footer-actions-container - the container of footer stepper and additional actions
+ */
 @Component({
 	tag: 'kv-wizard-footer',
 	styleUrl: 'wizard-footer.scss',
@@ -74,20 +77,22 @@ export class KvWizardFooter implements IWizardFooter, IWizardFooterEvents {
 		return (
 			<Host>
 				<div class="wizard-footer-container">
-					<div class="wizard-stepper">
+					<div class="actions-container" part="footer-actions-container">
 						{this.showStepBar && (
-							<kv-step-bar
-								label={this.label}
-								steps={this.steps}
-								currentStep={this.currentStep}
-								progressPercentage={this.progressPercentage}
-								hasError={this.hasError}
-								onStepClicked={this.onStepClick}
-							/>
+							<div class="wizard-stepper">
+								<kv-step-bar
+									label={this.label}
+									steps={this.steps}
+									currentStep={this.currentStep}
+									progressPercentage={this.progressPercentage}
+									hasError={this.hasError}
+									onStepClicked={this.onStepClick}
+								/>
+							</div>
 						)}
-					</div>
-					<div class="actions-container">
 						<slot name="additional-actions" />
+					</div>
+					<div class="buttons-container">
 						{this.showCancelBtn && (
 							<kv-action-button-text type={EActionButtonType.Tertiary} text="Cancel" disabled={!this.cancelEnabled} onClickButton={this.onCancelClick} />
 						)}

--- a/packages/ui-components/src/components/wizard/test/__snapshots__/wizard.spec.tsx.snap
+++ b/packages/ui-components/src/components/wizard/test/__snapshots__/wizard.spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`Wizard (unit tests) when current step don't have state should match the
         <slot name="step-content"></slot>
       </div>
       <div class="wizard-footer">
-        <kv-wizard-footer cancelenabled="" currentstep="1" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="" showstepbar="">
+        <kv-wizard-footer cancelenabled="" currentstep="1" exportparts="footer-actions-container" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="" showstepbar="">
           <slot name="additional-actions" slot="additional-actions"></slot>
         </kv-wizard-footer>
       </div>
@@ -31,7 +31,7 @@ exports[`Wizard (unit tests) when current step have errors should match the snap
         <slot name="step-content"></slot>
       </div>
       <div class="wizard-footer">
-        <kv-wizard-footer cancelenabled="" currentstep="1" haserror="" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="" showstepbar="">
+        <kv-wizard-footer cancelenabled="" currentstep="1" exportparts="footer-actions-container" haserror="" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="" showstepbar="">
           <slot name="additional-actions" slot="additional-actions"></slot>
         </kv-wizard-footer>
       </div>
@@ -51,7 +51,7 @@ exports[`Wizard (unit tests) when current step have success state should match t
         <slot name="step-content"></slot>
       </div>
       <div class="wizard-footer">
-        <kv-wizard-footer cancelenabled="" completeenabled="" currentstep="1" nextenabled="" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="" showstepbar="">
+        <kv-wizard-footer cancelenabled="" completeenabled="" currentstep="1" exportparts="footer-actions-container" nextenabled="" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="" showstepbar="">
           <slot name="additional-actions" slot="additional-actions"></slot>
         </kv-wizard-footer>
       </div>
@@ -71,7 +71,7 @@ exports[`Wizard (unit tests) when current step is the first one should match the
         <slot name="step-content"></slot>
       </div>
       <div class="wizard-footer">
-        <kv-wizard-footer cancelenabled="" completeenabled="" currentstep="0" nextenabled="" progresspercentage="0" showcancelbtn="" shownextbtn="" showstepbar="">
+        <kv-wizard-footer cancelenabled="" completeenabled="" currentstep="0" exportparts="footer-actions-container" nextenabled="" progresspercentage="0" showcancelbtn="" shownextbtn="" showstepbar="">
           <slot name="additional-actions" slot="additional-actions"></slot>
         </kv-wizard-footer>
       </div>
@@ -91,7 +91,7 @@ exports[`Wizard (unit tests) when current step is the last one should match the 
         <slot name="step-content"></slot>
       </div>
       <div class="wizard-footer">
-        <kv-wizard-footer cancelenabled="" completebtnlabel="Deploy" completeenabled="" currentstep="2" nextenabled="" prevenabled="" progresspercentage="100" showcompletebtn="" showprevbtn="" showstepbar="">
+        <kv-wizard-footer cancelenabled="" completebtnlabel="Deploy" completeenabled="" currentstep="2" exportparts="footer-actions-container" nextenabled="" prevenabled="" progresspercentage="100" showcompletebtn="" showprevbtn="" showstepbar="">
           <slot name="additional-actions" slot="additional-actions"></slot>
         </kv-wizard-footer>
       </div>
@@ -108,7 +108,7 @@ exports[`Wizard (unit tests) when showHeader is false should match the snapshot 
         <slot name="step-content"></slot>
       </div>
       <div class="wizard-footer">
-        <kv-wizard-footer cancelenabled="" currentstep="1" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="" showstepbar="">
+        <kv-wizard-footer cancelenabled="" currentstep="1" exportparts="footer-actions-container" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="" showstepbar="">
           <slot name="additional-actions" slot="additional-actions"></slot>
         </kv-wizard-footer>
       </div>
@@ -128,7 +128,7 @@ exports[`Wizard (unit tests) when showStepBar is false should match the snapshot
         <slot name="step-content"></slot>
       </div>
       <div class="wizard-footer">
-        <kv-wizard-footer cancelenabled="" currentstep="1" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="">
+        <kv-wizard-footer cancelenabled="" currentstep="1" exportparts="footer-actions-container" prevenabled="" progresspercentage="50" shownextbtn="" showprevbtn="">
           <slot name="additional-actions" slot="additional-actions"></slot>
         </kv-wizard-footer>
       </div>

--- a/packages/ui-components/src/components/wizard/wizard.tsx
+++ b/packages/ui-components/src/components/wizard/wizard.tsx
@@ -84,6 +84,7 @@ export class KvWizard implements IWizard, IWizardEvents {
 						onStepClick={this.onStepClick}
 						showStepBar={this.showStepBar}
 						completeBtnLabel={this.completeBtnLabel}
+						exportparts="footer-actions-container"
 						{...this.currentFooter}
 					>
 						<slot slot="additional-actions" name="additional-actions" />


### PR DESCRIPTION
<img width="811" alt="image" src="https://github.com/kelvininc/ui-components/assets/13225555/3e069fae-05b1-4392-ba6b-875d9a7572eb">
<img width="807" alt="image" src="https://github.com/kelvininc/ui-components/assets/13225555/008bb954-6481-4c5f-ba93-58f3e7da4af1">
