### PR TITLE
fix(modal): add ellipsis to title when width is fixed to prevent overflow

### DIFF
--- a/packages/ui-components/src/components/modal/modal.base.scss
+++ b/packages/ui-components/src/components/modal/modal.base.scss
@@ -63,6 +63,8 @@
 		box-sizing: border-box;
 
 		.title {
+			@include ellipsis();
+
 			@include kv-font-label-small-uppercase-regular;
 			color: var(--modal-topbar-text-color);
 		}


### PR DESCRIPTION
![Screenshot 2023-09-01 at 11 39 24](https://github.com/kelvininc/ui-components/assets/37366547/70d6803f-58d4-456e-baf1-75b649218179)
