### PR TITLE
fix(illustrations): remove added height from illustrations

### DIFF
--- a/packages/ui-components/src/illustrations/illustrations.scss
+++ b/packages/ui-components/src/illustrations/illustrations.scss
@@ -11,7 +11,8 @@
 
 	width: var(--illustration-width);
 	height: var(--illustration-height);
-
+	display: flex;
+	
 	&-full-size {
 		width: 100%;
 		height: 100%;


### PR DESCRIPTION
We were having an additional height on the illustrations that was being added by the generated components. This was causing the illustration to add an additional 4px aprox to the specified size we were defining with the custom css props.