### PR TITLE
fix(form-help-text): text wrapping under the icon

### DIFF
--- a/packages/ui-components/src/components/form-help-text/form-help-text.scss
+++ b/packages/ui-components/src/components/form-help-text/form-help-text.scss
@@ -12,8 +12,6 @@
 
 .help-text-container {
 	width: 100%;
-	display: flex;
-	flex-wrap: wrap;
 	overflow: hidden;
 	margin: $spacing 0 0 $spacing-2x;
 	color: var(--help-text-default-color);
@@ -35,6 +33,8 @@
 
 		align-items: center;
 		margin-right: $spacing-2x;
+		float: left;
+		margin-top: 2px;
 	}
 
 	&.invalid {


### PR DESCRIPTION
![image](https://github.com/kelvininc/ui-components/assets/6940723/a34e057a-b50c-43cf-b046-59bc09805b56)
