### PR TITLE
fix(absolute-time-picker-input): reset input text when user closes dropdown with empty input

### DIFF
--- a/packages/ui-components/src/components/absolute-time-picker-dropdown-input/absolute-time-picker-dropdown-input.utils.ts
+++ b/packages/ui-components/src/components/absolute-time-picker-dropdown-input/absolute-time-picker-dropdown-input.utils.ts
@@ -21,7 +21,7 @@ export const getRangeInputValues = (selectedTime: SelectedTimeState, timezoneNam
 
 	const [from, to] = selectedTime;
 	return {
-		from: dayjs(from).tz(timezoneName).format(DATE_FORMAT),
+		from: isNumber(from) ? dayjs(from).tz(timezoneName).format(DATE_FORMAT) : '',
 		to: isNumber(to) ? dayjs(to).tz(timezoneName).format(DATE_FORMAT) : ''
 	};
 };


### PR DESCRIPTION
This PR changes the behaviour of the component to handle the case where a user sets an input and closes the dropdown, and after that, he opens again and cleans the input. If the time was previously set, we should fill the input again with that value. 
The value of the input only changes when the user sets a new valid time or when it picks a new day in the calendar. 