### PR TITLE
fix(select-multi-options): prevent potential undefined error in selectOptions access

### DIFF
--- a/packages/ui-components/src/components/single-select-dropdown/single-select-dropdown.tsx
+++ b/packages/ui-components/src/components/single-select-dropdown/single-select-dropdown.tsx
@@ -260,7 +260,7 @@ export class KvSingleSelectDropdown implements ISingleSelectDropdown, ISingleSel
 			return;
 		}
 
-		if (this.selectedOption && this.selectOptions.flatten[this.selectedOption]) {
+		if (this.selectedOption && this.selectOptions?.flatten[this.selectedOption]) {
 			this._selectionDisplayValue = this.selectOptions.flatten[this.selectedOption].label;
 			return;
 		}


### PR DESCRIPTION
The watch methods are running before `componentWillLoad` when the tab isn't active resulting in an error when `calculateLabelValue` is called. 
