### PR TITLE
fix(toaster): watch ttl changes to clear and start new timeout

### DIFF
--- a/packages/react-ui-components/src/components/ToasterContainer/config.ts
+++ b/packages/react-ui-components/src/components/ToasterContainer/config.ts
@@ -1,2 +1,11 @@
+import { EToasterType, IToaster } from '@kelvininc/ui-components';
+
 export const DEFAULT_ROOT_ID = 'toasters-root';
-export const DEFAULT_TOASTER_TTL = 5000;
+
+export const TOASTER_TTL_MS = 5000;
+
+export const TOASTER_CONFIG: IToaster = {
+	header: '',
+	type: EToasterType.Info,
+	ttl: TOASTER_TTL_MS
+};

--- a/packages/react-ui-components/src/components/ToasterContainer/index.tsx
+++ b/packages/react-ui-components/src/components/ToasterContainer/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import type { IToaster, JSX } from '@kelvininc/ui-components';
 
 import { KvToaster } from '../stencil-generated';
-import { DEFAULT_ROOT_ID, DEFAULT_TOASTER_TTL } from './config';
+import { DEFAULT_ROOT_ID, TOASTER_CONFIG } from './config';
 
 export type ToasterContainerProps = {
 	rootId?: string;
@@ -17,14 +17,17 @@ export interface IToasterController {
 	closeToaster: () => void;
 }
 
-export function useToaster(initialConfig: IToaster, initialState = false): IToasterController {
+export function useToaster(initialConfig: IToaster = TOASTER_CONFIG, initialState = false): IToasterController {
 	const [config, setConfig] = useState<IToaster>(initialConfig);
 	const [isOpen, setOpen] = useState(initialState);
 
-	const openToaster = useCallback((newConfig: IToaster) => {
-		setOpen(true);
-		setConfig(newConfig);
-	}, []);
+	const openToaster = useCallback(
+		(newConfig: IToaster) => {
+			setOpen(true);
+			setConfig({ ...initialConfig, ...newConfig });
+		},
+		[initialConfig]
+	);
 
 	const closeToaster = useCallback(() => {
 		setOpen(false);
@@ -44,10 +47,5 @@ export function ToasterContainer({ rootId = DEFAULT_ROOT_ID, isOpen, children, .
 		return null;
 	}
 
-	return ReactDOM.createPortal(
-		<KvToaster ttl={DEFAULT_TOASTER_TTL} {...otherProps}>
-			{children}
-		</KvToaster>,
-		document.getElementById(rootId) as Element
-	);
+	return ReactDOM.createPortal(<KvToaster {...otherProps}>{children}</KvToaster>, document.getElementById(rootId) as Element);
 }

--- a/packages/ui-components/src/components/badge/readme.md
+++ b/packages/ui-components/src/components/badge/readme.md
@@ -73,32 +73,18 @@ export const BadgeExample: React.FC = () => (
 | Name                               | Description                                     |
 | ---------------------------------- | ----------------------------------------------- |
 | `--badge-background-color-error`   | Badge's background color when state is error.   |
-| `--badge-background-color-error`   | Badge's background color when state is error.   |
-| `--badge-background-color-info`    | Badge's background color when state is info.    |
 | `--badge-background-color-info`    | Badge's background color when state is info.    |
 | `--badge-background-color-none`    | Badge's background color when state is none.    |
-| `--badge-background-color-none`    | Badge's background color when state is none.    |
-| `--badge-background-color-success` | Badge's background color when state is success. |
 | `--badge-background-color-success` | Badge's background color when state is success. |
 | `--badge-background-color-warning` | Badge's background color when state is warning. |
-| `--badge-background-color-warning` | Badge's background color when state is warning. |
-| `--badge-height`                   | Badge's height.                                 |
 | `--badge-height`                   | Badge's height.                                 |
 | `--badge-max-width`                | Badge's maximum width.                          |
-| `--badge-max-width`                | Badge's maximum width.                          |
-| `--badge-min-width`                | Badge's minimum width.                          |
 | `--badge-min-width`                | Badge's minimum width.                          |
 | `--badge-text-color-error`         | Badge's text color when state is error.         |
-| `--badge-text-color-error`         | Badge's text color when state is error.         |
-| `--badge-text-color-info`          | Badge's text color when state is info.          |
 | `--badge-text-color-info`          | Badge's text color when state is info.          |
 | `--badge-text-color-none`          | Badge's text color when state is none.          |
-| `--badge-text-color-none`          | Badge's text color when state is none.          |
-| `--badge-text-color-success`       | Badge's text color when state is success.       |
 | `--badge-text-color-success`       | Badge's text color when state is success.       |
 | `--badge-text-color-warning`       | Badge's text color when state is warning.       |
-| `--badge-text-color-warning`       | Badge's text color when state is warning.       |
-| `--badge-warning-text-color`       | Badge's text color when state is warning.       |
 | `--badge-warning-text-color`       | Badge's text color when state is warning.       |
 
 

--- a/packages/ui-components/src/components/calendar-day/readme.md
+++ b/packages/ui-components/src/components/calendar-day/readme.md
@@ -81,32 +81,18 @@ export const KvCalendarDayExample: React.FC = () => (
 | Name                                           | Description                                                   |
 | ---------------------------------------------- | ------------------------------------------------------------- |
 | `--calendar-day-background-color-active`       | Background color when state is active.                        |
-| `--calendar-day-background-color-active`       | Background color when state is active.                        |
-| `--calendar-day-background-color-active-hover` | Background color when state is active and cursor is on hover. |
 | `--calendar-day-background-color-active-hover` | Background color when state is active and cursor is on hover. |
 | `--calendar-day-background-color-default`      | Background color when state is default.                       |
-| `--calendar-day-background-color-default`      | Background color when state is default.                       |
-| `--calendar-day-background-color-disabled`     | Background color when state is disabled.                      |
 | `--calendar-day-background-color-disabled`     | Background color when state is disabled.                      |
 | `--calendar-day-background-color-hover`        | Background color when state is hover.                         |
-| `--calendar-day-background-color-hover`        | Background color when state is hover.                         |
-| `--calendar-day-background-color-in-range`     | Background color when state is in range.                      |
 | `--calendar-day-background-color-in-range`     | Background color when state is in range.                      |
 | `--calendar-day-height`                        | The calendar container height.                                |
-| `--calendar-day-height`                        | The calendar container height.                                |
-| `--calendar-day-text-color-active`             | Text color when state is active.                              |
 | `--calendar-day-text-color-active`             | Text color when state is active.                              |
 | `--calendar-day-text-color-active-hover`       | Text color when state is active and cursor is on hover.       |
-| `--calendar-day-text-color-active-hover`       | Text color when state is active and cursor is on hover.       |
-| `--calendar-day-text-color-default`            | Text color when state is default.                             |
 | `--calendar-day-text-color-default`            | Text color when state is default.                             |
 | `--calendar-day-text-color-disabled`           | Text color when state is disabled.                            |
-| `--calendar-day-text-color-disabled`           | Text color when state is disabled.                            |
-| `--calendar-day-text-color-hover`              | Text color when state is hover.                               |
 | `--calendar-day-text-color-hover`              | Text color when state is hover.                               |
 | `--calendar-day-text-color-in-range`           | Text color when state is in-range.                            |
-| `--calendar-day-text-color-in-range`           | Text color when state is in-range.                            |
-| `--calendar-day-width`                         | The calendar container width.                                 |
 | `--calendar-day-width`                         | The calendar container width.                                 |
 
 

--- a/packages/ui-components/src/components/calendar/readme.md
+++ b/packages/ui-components/src/components/calendar/readme.md
@@ -69,16 +69,10 @@ export const KvCalendarExample: React.FC = () => (
 | Name                                  | Description                                |
 | ------------------------------------- | ------------------------------------------ |
 | `--calendar-background-color`         | The calendar background color.             |
-| `--calendar-background-color`         | The calendar background color.             |
-| `--calendar-horizontal-padding`       | The calendar container horizontal padding. |
 | `--calendar-horizontal-padding`       | The calendar container horizontal padding. |
 | `--calendar-month-title-text-color`   | The calendar month text color.             |
-| `--calendar-month-title-text-color`   | The calendar month text color.             |
-| `--calendar-month-weekday-text-color` | The calendar week day text color.          |
 | `--calendar-month-weekday-text-color` | The calendar week day text color.          |
 | `--calendar-vertical-padding`         | The calendar container vertical padding.   |
-| `--calendar-vertical-padding`         | The calendar container vertical padding.   |
-| `--calendar-width`                    | The calendar container width.              |
 | `--calendar-width`                    | The calendar container width.              |
 
 

--- a/packages/ui-components/src/components/form-label/readme.md
+++ b/packages/ui-components/src/components/form-label/readme.md
@@ -56,7 +56,6 @@ export const FormLabelExample: React.FC = () => (
 | Name            | Description       |
 | --------------- | ----------------- |
 | `--label-color` | Label Text color. |
-| `--label-color` | Label Text color. |
 
 
 ## Dependencies

--- a/packages/ui-components/src/components/info-label/readme.md
+++ b/packages/ui-components/src/components/info-label/readme.md
@@ -99,10 +99,7 @@ export const InfoLabelExample: React.FC = () => (
 | Name                       | Description                     |
 | -------------------------- | ------------------------------- |
 | `--expanded-buttom-color`  | Expandded buttom's color.       |
-| `--expanded-buttom-color`  | Expandded buttom's color.       |
 | `--text-color-description` | Info label's description color. |
-| `--text-color-description` | Info label's description color. |
-| `--text-color-title`       | Info label's title color.       |
 | `--text-color-title`       | Info label's title color.       |
 
 

--- a/packages/ui-components/src/components/modal/readme.md
+++ b/packages/ui-components/src/components/modal/readme.md
@@ -61,26 +61,15 @@ export const ModalOverlayExample: React.FC = (args: ModalOverlayProps) => {
 | Name                          | Description                       |
 | ----------------------------- | --------------------------------- |
 | `--modal-background-color`    | The modal's background color.     |
-| `--modal-background-color`    | The modal's background color.     |
-| `--modal-close-button-height` | The modal's close button height   |
 | `--modal-close-button-height` | The modal's close button height   |
 | `--modal-close-button-width`  | The modal's close button width    |
-| `--modal-close-button-width`  | The modal's close button width    |
-| `--modal-height`              | The modal's height in px.         |
 | `--modal-height`              | The modal's height in px.         |
 | `--modal-min-height`          | The modal's minimum height in px. |
-| `--modal-min-height`          | The modal's minimum height in px. |
-| `--modal-min-width`           | The modal's minimum width in px.  |
 | `--modal-min-width`           | The modal's minimum width in px.  |
 | `--modal-overlay-color`       | The modal's overlay color.        |
-| `--modal-overlay-color`       | The modal's overlay color.        |
-| `--modal-topbar-height`       | The modal's topbar height in px.  |
 | `--modal-topbar-height`       | The modal's topbar height in px.  |
 | `--modal-topbar-text-color`   | The modal's text topbar color.    |
-| `--modal-topbar-text-color`   | The modal's text topbar color.    |
 | `--modal-width`               | The modal's width in px.          |
-| `--modal-width`               | The modal's width in px.          |
-| `--modal-z-index`             | The modal's z-index               |
 | `--modal-z-index`             | The modal's z-index               |
 
 

--- a/packages/ui-components/src/components/radio/readme.md
+++ b/packages/ui-components/src/components/radio/readme.md
@@ -72,14 +72,9 @@ export const RadioExample: React.FC = () => (
 | Name                          | Description                                  |
 | ----------------------------- | -------------------------------------------- |
 | `--input-height-large`        | Text Field's large height.                   |
-| `--input-height-large`        | Text Field's large height.                   |
-| `--input-height-small`        | Text Field's small height.                   |
 | `--input-height-small`        | Text Field's small height.                   |
 | `--radio-input-checked-color` | Radio input color when state is checked.     |
-| `--radio-input-checked-color` | Radio input color when state is checked.     |
 | `--radio-input-default-color` | Radio input color when state is not checked. |
-| `--radio-input-default-color` | Radio input color when state is not checked. |
-| `--radio-label-text-color`    | Radio label color.                           |
 | `--radio-label-text-color`    | Radio label color.                           |
 
 

--- a/packages/ui-components/src/components/range/readme.md
+++ b/packages/ui-components/src/components/range/readme.md
@@ -51,20 +51,12 @@ export const KvRangeExample: React.FC = () => (
 | Name                         | Description                        |
 | ---------------------------- | ---------------------------------- |
 | `--range-height`             | Height of the range slider         |
-| `--range-height`             | Height of the range slider         |
-| `--range-label-color`        | range labels color                 |
 | `--range-label-color`        | range labels color                 |
 | `--range-selector-radius`    | Radius of the range thumb          |
-| `--range-selector-radius`    | Radius of the range thumb          |
-| `--range-width`              | Width of the range slider          |
 | `--range-width`              | Width of the range slider          |
 | `--select-label-color`       | select labels color                |
-| `--select-label-color`       | select labels color                |
-| `--slider-background-empty`  | color of the slider when its empty |
 | `--slider-background-empty`  | color of the slider when its empty |
 | `--slider-background-filled` | color of the slider when its full  |
-| `--slider-background-filled` | color of the slider when its full  |
-| `--thumb-border-color`       | thumb border color                 |
 | `--thumb-border-color`       | thumb border color                 |
 
 

--- a/packages/ui-components/src/components/text-field/readme.md
+++ b/packages/ui-components/src/components/text-field/readme.md
@@ -111,54 +111,29 @@ Type: `Promise<void>`
 | Name                                | Description                                    |
 | ----------------------------------- | ---------------------------------------------- |
 | `--background-color-default`        | Background color when state is default.        |
-| `--background-color-default`        | Background color when state is default.        |
-| `--background-color-disabled`       | Background color when state is disabled.       |
 | `--background-color-disabled`       | Background color when state is disabled.       |
 | `--border-color-default`            | Border color when state is default.            |
-| `--border-color-default`            | Border color when state is default.            |
-| `--border-color-error`              | Border color when state is invalid.            |
 | `--border-color-error`              | Border color when state is invalid.            |
 | `--border-color-focused`            | Border color when state is focused.            |
-| `--border-color-focused`            | Border color when state is focused.            |
-| `--input-height-large`              | Text Field's large height.                     |
 | `--input-height-large`              | Text Field's large height.                     |
 | `--input-height-small`              | Text Field's small height.                     |
-| `--input-height-small`              | Text Field's small height.                     |
-| `--input-max-width`                 | Text Field's max width.                        |
 | `--input-max-width`                 | Text Field's max width.                        |
 | `--input-min-width`                 | Text Field's min width.                        |
-| `--input-min-width`                 | Text Field's min width.                        |
-| `--input-width`                     | Text Field's width.                            |
 | `--input-width`                     | Text Field's width.                            |
 | `--text-color-action-icon-default`  | Action icon color when state is default.       |
-| `--text-color-action-icon-default`  | Action icon color when state is default.       |
-| `--text-color-action-icon-disabled` | Action icon color when state is disabled.      |
 | `--text-color-action-icon-disabled` | Action icon color when state is disabled.      |
 | `--text-color-action-icon-focused`  | Action icon color when state is focused.       |
-| `--text-color-action-icon-focused`  | Action icon color when state is focused.       |
-| `--text-color-help-text-default`    | Help Text color when state is default.         |
 | `--text-color-help-text-default`    | Help Text color when state is default.         |
 | `--text-color-help-text-error`      | Help Text color when state is invalid.         |
-| `--text-color-help-text-error`      | Help Text color when state is invalid.         |
-| `--text-color-icon-default`         | Icon color when state is default.              |
 | `--text-color-icon-default`         | Icon color when state is default.              |
 | `--text-color-icon-disabled`        | Icon color when state is disabled.             |
-| `--text-color-icon-disabled`        | Icon color when state is disabled.             |
-| `--text-color-icon-focused`         | Icon color when state is focused.              |
 | `--text-color-icon-focused`         | Icon color when state is focused.              |
 | `--text-color-input-default`        | Input text color when state is default.        |
-| `--text-color-input-default`        | Input text color when state is default.        |
-| `--text-color-input-disabled`       | Input text color when state is disabled.       |
 | `--text-color-input-disabled`       | Input text color when state is disabled.       |
 | `--text-color-input-focused`        | Input Text color when state is focused.        |
-| `--text-color-input-focused`        | Input Text color when state is focused.        |
-| `--text-color-label`                | Label Text color.                              |
 | `--text-color-label`                | Label Text color.                              |
 | `--text-color-placeholder-default`  | Placeholder text color when state is default.  |
-| `--text-color-placeholder-default`  | Placeholder text color when state is default.  |
 | `--text-color-placeholder-disabled` | Placeholder text color when state is disabled. |
-| `--text-color-placeholder-disabled` | Placeholder text color when state is disabled. |
-| `--text-color-placeholder-focused`  | Placeholder text color when state is focused.  |
 | `--text-color-placeholder-focused`  | Placeholder text color when state is focused.  |
 
 

--- a/packages/ui-components/src/components/toaster/toaster.tsx
+++ b/packages/ui-components/src/components/toaster/toaster.tsx
@@ -35,10 +35,17 @@ export class KvToaster implements IToaster, IToasterEvents {
 	@State() fadeOutActive: boolean = false;
 	/** Icon of the toaster */
 	@State() iconType: EToasterIconTypeClass = TYPE_ICONS[this.type];
+
 	/** Case the type changes, the toaster updates the icon displayed */
 	@Watch('type')
 	updateIconType(value: string) {
 		this.iconType = TYPE_ICONS[value];
+	}
+	/** Case the ttl changes, the toaster should clear the current setTimeout */
+	@Watch('ttl')
+	handleTimeout() {
+		this.clearTTL();
+		this.createTTL();
 	}
 
 	private clearTTL = () => {

--- a/packages/ui-components/src/components/tree-item/readme.md
+++ b/packages/ui-components/src/components/tree-item/readme.md
@@ -137,64 +137,34 @@ export const TreeItemExample: React.FC = () => (
 | Name                             | Description                                         |
 | -------------------------------- | --------------------------------------------------- |
 | `--background-color-default`     | Background color when state is default.             |
-| `--background-color-default`     | Background color when state is default.             |
-| `--background-color-disabled`    | Background color when state is disabled.            |
 | `--background-color-disabled`    | Background color when state is disabled.            |
 | `--background-color-focused`     | Background color when state is focused.             |
-| `--background-color-focused`     | Background color when state is focused.             |
-| `--background-color-highlighted` | Background color when state is highlighted.         |
 | `--background-color-highlighted` | Background color when state is highlighted.         |
 | `--border-color-default`         | Border color when state is default.                 |
-| `--border-color-default`         | Border color when state is default.                 |
-| `--border-color-disabled`        | Border color when state is disabled.                |
 | `--border-color-disabled`        | Border color when state is disabled.                |
 | `--border-color-highlighted`     | Border color when state is highlighted.             |
-| `--border-color-highlighted`     | Border color when state is highlighted.             |
-| `--border-color-selected`        | Border color when state is selected.                |
 | `--border-color-selected`        | Border color when state is selected.                |
 | `--children-margin-left`         | Margin left of the children in px.                  |
-| `--children-margin-left`         | Margin left of the children in px.                  |
-| `--children-margin-top`          | Margin top of children in px.                       |
 | `--children-margin-top`          | Margin top of children in px.                       |
 | `--children-offset`              | Offset of the child nodes in px.                    |
-| `--children-offset`              | Offset of the child nodes in px.                    |
-| `--children-padding-left`        | Padding left of the children in px.                 |
 | `--children-padding-left`        | Padding left of the children in px.                 |
 | `--connector-lines-color`        | Line color of children's connectors.                |
-| `--connector-lines-color`        | Line color of children's connectors.                |
-| `--icon-color-default`           | Node icon color when node state is default.         |
 | `--icon-color-default`           | Node icon color when node state is default.         |
 | `--icon-color-disabled`          | Node icon color when node state is disabled.        |
-| `--icon-color-disabled`          | Node icon color when node state is disabled.        |
-| `--icon-color-no-filled`         | Node icon color when node state is no-filled.       |
 | `--icon-color-no-filled`         | Node icon color when node state is no-filled.       |
 | `--icon-color-selected`          | Node icon color when node state is selected.        |
-| `--icon-color-selected`          | Node icon color when node state is selected.        |
-| `--node-gap`                     | Gap between child nodes in px.                      |
 | `--node-gap`                     | Gap between child nodes in px.                      |
 | `--node-height`                  | Tree Node height.                                   |
-| `--node-height`                  | Tree Node height.                                   |
-| `--node-icon-height`             | Node icon height in px.                             |
 | `--node-icon-height`             | Node icon height in px.                             |
 | `--node-icon-width`              | Node icon width in px.                              |
-| `--node-icon-width`              | Node icon width in px.                              |
-| `--node-width`                   | Tree Node height.                                   |
 | `--node-width`                   | Tree Node height.                                   |
 | `--sub-title-color-default`      | Node sub-title color when node state is default.    |
-| `--sub-title-color-default`      | Node sub-title color when node state is default.    |
-| `--sub-title-color-disabled`     | Node sub-title color when node state is disabled.   |
 | `--sub-title-color-disabled`     | Node sub-title color when node state is disabled.   |
 | `--sub-title-color-no-filled`    | Node sub-title color when node state is not filled. |
-| `--sub-title-color-no-filled`    | Node sub-title color when node state is not filled. |
-| `--title-color-default`          | Node title color when node state is default.        |
 | `--title-color-default`          | Node title color when node state is default.        |
 | `--title-color-disabled`         | Node title color when node state is disabled.       |
-| `--title-color-disabled`         | Node title color when node state is disabled.       |
-| `--title-color-no-filled`        | Node title color when node state is not filled.     |
 | `--title-color-no-filled`        | Node title color when node state is not filled.     |
 | `--title-color-selected`         | Node title color when node state is selected.       |
-| `--title-color-selected`         | Node title color when node state is selected.       |
-| `--vertical-lines-height`        | Line height of children's connectors.               |
 | `--vertical-lines-height`        | Line height of children's connectors.               |
 
 

--- a/packages/ui-components/src/components/tree/readme.md
+++ b/packages/ui-components/src/components/tree/readme.md
@@ -141,14 +141,9 @@ export const TreeExample: React.FC = () => (
 | Name                           | Description                             |
 | ------------------------------ | --------------------------------------- |
 | `--tree-children-offset`       | Offset of the child nodes in px.        |
-| `--tree-children-offset`       | Offset of the child nodes in px.        |
-| `--tree-children-padding-left` | Left padding for the child nodes in px. |
 | `--tree-children-padding-left` | Left padding for the child nodes in px. |
 | `--tree-node-gap`              | Gap between child nodes in px.          |
-| `--tree-node-gap`              | Gap between child nodes in px.          |
 | `--tree-node-height`           | Tree Node height.                       |
-| `--tree-node-height`           | Tree Node height.                       |
-| `--tree-node-width`            | Tree Node height.                       |
 | `--tree-node-width`            | Tree Node height.                       |
 
 


### PR DESCRIPTION
When the toaster is open and a TTL appears that resets the value to `0` and after a moment appears another data, the toaster doesn't use the default TTL. 