### PR TITLE
fix(absolute-time-picker-input): change input focus when user selects a date

### DIFF
--- a/packages/ui-components/src/components/absolute-time-picker-dropdown-input/absolute-time-picker-dropdown-input.tsx
+++ b/packages/ui-components/src/components/absolute-time-picker-dropdown-input/absolute-time-picker-dropdown-input.tsx
@@ -82,6 +82,30 @@ export class KvAbsoluteTimePickerDropdownInput implements IAbsoluteTimePickerDro
 		}
 	};
 
+	private getValidSelectedRangeFromUserClick = (parsedDate: dayjs.Dayjs): TimeRange => {
+		if (this.focusedInput === EInputSource.From) {
+			if (isNumber(this.minimumFromInputDate) && parsedDate.isBefore(this.minimumFromInputDate)) {
+				return { ...this.rangeInputValues, from: dayjs(this.minimumFromInputDate).format(DATE_FORMAT) };
+			}
+
+			if (!isEmpty(this.rangeInputValues?.to) && dayjs(this.rangeInputValues?.to, DATE_FORMAT).isBefore(parsedDate)) {
+				return { from: parsedDate.format(DATE_FORMAT), to: parsedDate.format(DATE_FORMAT) };
+			}
+
+			return { ...this.rangeInputValues, from: parsedDate.format(DATE_FORMAT) };
+		} else {
+			if (isNumber(this.minimumToInputDate) && parsedDate.isBefore(this.minimumToInputDate)) {
+				return { ...this.rangeInputValues, to: dayjs(this.minimumToInputDate).format(DATE_FORMAT) };
+			}
+
+			if (!isEmpty(this.rangeInputValues?.from) && dayjs(this.rangeInputValues?.from, DATE_FORMAT).isAfter(parsedDate)) {
+				return { from: parsedDate.format(DATE_FORMAT), to: parsedDate.format(DATE_FORMAT) };
+			}
+
+			return { ...this.rangeInputValues, to: parsedDate.format(DATE_FORMAT) };
+		}
+	};
+
 	private onClickDate = ({ detail }: CustomEvent<IClickDateEvent>): void => {
 		let clickedDate = fromISO(detail.date);
 
@@ -94,18 +118,15 @@ export class KvAbsoluteTimePickerDropdownInput implements IAbsoluteTimePickerDro
 			return;
 		}
 
-		if (this.focusedInput === EInputSource.From) {
-			if (isNumber(this.minimumFromInputDate) && dayjs(clickedDate).isBefore(this.minimumFromInputDate)) {
-				clickedDate = dayjs(this.minimumFromInputDate);
-			}
+		const validSelectedRange = this.getValidSelectedRangeFromUserClick(clickedDate);
+		this.rangeInputValues = validSelectedRange;
 
-			this.rangeInputValues = { ...this.rangeInputValues, from: clickedDate.format(DATE_FORMAT) };
-		} else {
-			if (isNumber(this.minimumToInputDate) && dayjs(clickedDate).isBefore(this.minimumToInputDate)) {
-				clickedDate = dayjs(this.minimumToInputDate);
-			}
+		if (this.focusedInput === EInputSource.From && isEmpty(this.rangeInputValues?.to)) {
+			this.focusedInput = EInputSource.To;
+		}
 
-			this.rangeInputValues = { ...this.rangeInputValues, to: clickedDate.format(DATE_FORMAT) };
+		if (this.focusedInput === EInputSource.To && isEmpty(this.rangeInputValues?.from)) {
+			this.focusedInput = EInputSource.From;
 		}
 	};
 

--- a/packages/ui-components/src/components/date-time-input/date-time-input.scss
+++ b/packages/ui-components/src/components/date-time-input/date-time-input.scss
@@ -1,6 +1,8 @@
 @import '../../assets/styles/globals';
 
 kv-form-label {
+	user-select: none;
+
 	--label-color: #{kv-color('neutral-4')};
 }
 

--- a/packages/ui-components/src/components/info-label/info-label.tsx
+++ b/packages/ui-components/src/components/info-label/info-label.tsx
@@ -6,6 +6,9 @@ import { EIconName } from '../icon/icon.types';
 import { DEFAULT_DESCRIPTION_COLLAPSED_TEXT, DEFAULT_DESCRIPTION_OPENED_TEXT } from './info-label.config';
 import { COPY_TOOLTIP } from './info-label.types';
 
+/**
+ * @part title - Label title.
+ */
 @Component({
 	tag: 'kv-info-label',
 	styleUrls: {

--- a/packages/ui-components/src/components/info-label/readme.md
+++ b/packages/ui-components/src/components/info-label/readme.md
@@ -89,9 +89,9 @@ export const InfoLabelExample: React.FC = () => (
 
 ## Shadow Parts
 
-| Part      | Description |
-| --------- | ----------- |
-| `"title"` |             |
+| Part      | Description  |
+| --------- | ------------ |
+| `"title"` | Label title. |
 
 
 ## CSS Custom Properties

--- a/packages/ui-components/src/components/toggle-button-group/readme.md
+++ b/packages/ui-components/src/components/toggle-button-group/readme.md
@@ -25,9 +25,9 @@
 
 ## Shadow Parts
 
-| Part                        | Description |
-| --------------------------- | ----------- |
-| `"toggle-button-container"` |             |
+| Part                        | Description                 |
+| --------------------------- | --------------------------- |
+| `"toggle-button-container"` | Container of toggle button. |
 
 
 ## Dependencies

--- a/packages/ui-components/src/components/toggle-button-group/toggle-button-group.tsx
+++ b/packages/ui-components/src/components/toggle-button-group/toggle-button-group.tsx
@@ -3,6 +3,9 @@ import { IToggleButton } from '../toggle-button/toggle-button.types';
 import { IToggleButtonGroup, IToggleButtonGroupEvents } from './toggle-button-group.types';
 import { EComponentSize } from '../../types';
 
+/**
+ * @part toggle-button-container - Container of toggle button.
+ */
 @Component({
 	tag: 'kv-toggle-button-group',
 	styleUrl: 'toggle-button-group.scss',


### PR DESCRIPTION
This pr changes the behaviour of the calendar.
- When the user selects a date, the selected input shifts to the other input if  the input is empty.
- Setting same from and to date when the user clicks in a date which is not valid, for example if he selects a "from" date after the "to" date.

This pr also adds missing documentation that was emitting some warnings in the console.
