### PR TITLE
fix(dropdown): replace click event listener by mousedown

### DIFF
--- a/packages/ui-components/src/components/dropdown-base/dropdown-base.tsx
+++ b/packages/ui-components/src/components/dropdown-base/dropdown-base.tsx
@@ -32,7 +32,7 @@ export class KvDropdownBase implements IDropdownBase, IDropdownBaseEvents {
 
 	@Element() element: HTMLKvDropdownBaseElement;
 
-	@Listen('click', { target: 'window' })
+	@Listen('mousedown', { target: 'window' })
 	checkForClickOutside(event: MouseEvent) {
 		// Check if clicked inside the dropdown
 		if (this.didClickOnDropdownAction(event) || this.didClickOnDropdownList(event)) {


### PR DESCRIPTION
This pr changes the event that can close the dropdown. Using a click, the event listener will only respond to mouse left clicks. Using mousedown will respond to both left and right.