### PR TITLE
feat(description-list): enable component to be more customizable

### DIFF
--- a/apps/react-storybook/src/components/data-display/description-list/DescriptionList.module.scss
+++ b/apps/react-storybook/src/components/data-display/description-list/DescriptionList.module.scss
@@ -1,0 +1,16 @@
+@import "@kelvininc/react-ui-components/assets/styles/globals";
+
+.CustomDescriptionList {
+	--description-list-row-extremes: #{$spacing-3x};
+	--description-list-row-inline-padding: #{$spacing-3x};
+	--description-list-row-align: center;
+
+	border: 1px solid kv-color("neutral-6");
+	border-radius: 4px;
+
+	:global {
+		.row:not(:last-child) {
+			border-bottom: 1px solid kv-color("neutral-6");
+		}
+	}
+}

--- a/apps/react-storybook/src/components/data-display/description-list/DescriptionList.stories.tsx
+++ b/apps/react-storybook/src/components/data-display/description-list/DescriptionList.stories.tsx
@@ -1,9 +1,12 @@
-import type { StoryObj } from "@storybook/react";
+import type { StoryFn, StoryObj } from "@storybook/react";
 
 import {
 	EIconName,
 	KvDescriptionList
 } from "@kelvininc/react-ui-components/client";
+
+import * as styles from "./DescriptionList.module.scss";
+import { ComponentProps } from "react";
 
 const meta = {
 	title: "Data Display/Description List",
@@ -27,6 +30,13 @@ export const Default: Story = {
 			{
 				title: "Kelvin Version",
 				description: "4.2.4"
+			},
+			{
+				title: "Cluster ID",
+				description: "cluster-a-brownie-12345",
+				copiableTextConfig: {
+					copiableText: "cluster-a-brownie-12345"
+				}
 			}
 		]
 	}
@@ -78,4 +88,43 @@ export const WithIconTooltip: Story = {
 			}
 		]
 	}
+};
+
+const CustomDescriptionListTemplate: StoryFn<
+	ComponentProps<typeof KvDescriptionList>
+> = (args) => {
+	return (
+		<KvDescriptionList
+			{...args}
+			customClass={styles.CustomDescriptionList}
+		/>
+	);
+};
+
+export const WithCustomDescriptionList: Story = {
+	args: {
+		items: [
+			{
+				title: "Gigant Title",
+				description:
+					"lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+			},
+			{
+				title: "Kubernetes Version",
+				description: "1.20.5"
+			},
+			{
+				title: "Kelvin Version",
+				description: "4.2.4"
+			},
+			{
+				title: "Cluster ID",
+				description: "cluster-a-brownie-12345",
+				copiableTextConfig: {
+					copiableText: "cluster-a-brownie-12345"
+				}
+			}
+		]
+	},
+	render: CustomDescriptionListTemplate
 };

--- a/packages/ui-components/src/components/copy-to-clipboard/readme.md
+++ b/packages/ui-components/src/components/copy-to-clipboard/readme.md
@@ -67,6 +67,10 @@ export const KvCopyToClipboardExample: React.FC = () => (
 
 ## Dependencies
 
+### Used by
+
+ - [kv-description-list](../description-list)
+
 ### Depends on
 
 - [kv-tooltip](../tooltip)
@@ -79,6 +83,7 @@ graph TD;
   kv-copy-to-clipboard --> kv-icon
   kv-tooltip --> kv-portal
   kv-tooltip --> kv-tooltip-text
+  kv-description-list --> kv-copy-to-clipboard
   style kv-copy-to-clipboard fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/ui-components/src/components/description-list/description-list.scss
+++ b/packages/ui-components/src/components/description-list/description-list.scss
@@ -1,11 +1,46 @@
 @import '../../assets/styles/globals';
 
+kv-description-list {
+	/**
+		@prop --description-list-gap: The gap between the title and description
+	**/
+	--description-list-row-gap: #{$spacing-3x};
+	/**
+		@prop --description-list-row-extremes: The gap for the first and last row
+	**/
+	--description-list-row-extremes: 0;
+	/**
+		@prop --description-list-row-inline-padding: The horizontal padding for each row
+	**/
+	--description-list-row-inline-padding: 0;
+	/**
+		@prop --description-list-row-align: The alignment for the rows
+	**/
+	--description-list-row-align: baseline;
+}
+
 .description-list-container {
 	display: grid;
 	grid-template-columns: max-content 1fr;
-	gap: $spacing-5x $spacing-7x;
+	column-gap: $spacing-7x;
 	word-break: break-all;
-	align-items: baseline;
+
+	.row {
+		display: grid;
+		grid-template-columns: subgrid;
+		grid-column: 1 / -1;
+		align-items: var(--description-list-row-align);
+		padding-block: var(--description-list-row-gap);
+		padding-inline: var(--description-list-row-inline-padding);
+
+		&:first-child {
+			padding-block-start: var(--description-list-row-extremes);
+		}
+
+		&:last-child {
+			padding-block-end: var(--description-list-row-extremes);
+		}
+	}
 
 	.title {
 		@include kv-font-label-small-uppercase-regular;
@@ -25,6 +60,11 @@
 			display: inline-block;
 			vertical-align: text-top;
 			margin-left: $spacing-2x;
+		}
+
+		kv-copy-to-clipboard {
+			--container-padding: 0;
+			--icon-start-opacity: 1;
 		}
 	}
 }

--- a/packages/ui-components/src/components/description-list/description-list.tsx
+++ b/packages/ui-components/src/components/description-list/description-list.tsx
@@ -6,6 +6,9 @@ import { ComputePositionConfig } from '@floating-ui/dom';
 import { CustomCssClass } from '../../types';
 import { getClassMap } from '../../utils/css-class.helper';
 
+/**
+ * @part row - The description list row element.
+ */
 @Component({
 	tag: 'kv-description-list',
 	styleUrl: 'description-list.scss',
@@ -21,6 +24,25 @@ export class KvDescriptionList implements IDescriptionList {
 	/** @inheritdoc */
 	@Prop({ reflect: true }) customClass?: CustomCssClass = '';
 
+	customRenderDescription({ description, popoverInfo, copiableTextConfig }: IDescriptionListItem) {
+		if (copiableTextConfig) {
+			return <kv-copy-to-clipboard {...copiableTextConfig}>{description}</kv-copy-to-clipboard>;
+		}
+
+		return (
+			<Fragment>
+				<kv-tooltip text={getTooltipText(popoverInfo)} options={this.descriptionTooltipConfig} customClass="description-list-tooltip-container">
+					{description}
+				</kv-tooltip>
+				{popoverInfo?.icon && (
+					<kv-toggle-tip text={popoverInfo.text} {...this.iconToggletipConfig} customClass="description-list-tooltip-container">
+						<kv-icon name={popoverInfo.icon} customClass="icon-16" slot="open-element-slot" />
+					</kv-toggle-tip>
+				)}
+			</Fragment>
+		);
+	}
+
 	render() {
 		return (
 			<Host>
@@ -30,20 +52,11 @@ export class KvDescriptionList implements IDescriptionList {
 						...getClassMap(this.customClass)
 					}}
 				>
-					{this.items?.map(({ title, description, popoverInfo }) => (
-						<Fragment>
-							<div class="title">{title}</div>
-							<div class="description">
-								<kv-tooltip text={getTooltipText(popoverInfo)} options={this.descriptionTooltipConfig} customClass="description-list-tooltip-container">
-									{description}
-								</kv-tooltip>
-								{popoverInfo?.icon && (
-									<kv-toggle-tip text={popoverInfo.text} {...this.iconToggletipConfig} customClass="description-list-tooltip-container">
-										<kv-icon name={popoverInfo.icon} customClass="icon-16" slot="open-element-slot" />
-									</kv-toggle-tip>
-								)}
-							</div>
-						</Fragment>
+					{this.items?.map(item => (
+						<div class="row" part="row">
+							<div class="title">{item.title}</div>
+							<div class="description">{this.customRenderDescription(item)}</div>
+						</div>
 					))}
 				</div>
 			</Host>

--- a/packages/ui-components/src/components/description-list/description-list.types.ts
+++ b/packages/ui-components/src/components/description-list/description-list.types.ts
@@ -1,5 +1,5 @@
 import { ComputePositionConfig } from '@floating-ui/dom';
-import { EIconName, ETooltipPosition } from '../../types';
+import { EIconName, ETooltipPosition, ICopyToClipboard } from '../../types';
 import { ICustomCss } from '../../utils/types/components';
 
 export interface IDescriptionListItemToggletipConfig {
@@ -16,6 +16,7 @@ export interface IDescriptionListItem {
 	title: string;
 	description: string;
 	popoverInfo?: IDescriptionListItemPopover;
+	copiableTextConfig?: ICopyToClipboard;
 }
 
 export interface IDescriptionList extends ICustomCss {

--- a/packages/ui-components/src/components/description-list/readme.md
+++ b/packages/ui-components/src/components/description-list/readme.md
@@ -96,10 +96,28 @@ export const KvDescriptionListExample: React.FC = () => (
 | `items` _(required)_       | `items`                      | (required) The array of items to display in the list                                                                                                                                    | `IDescriptionListItem[]`                                                                                                                                                                                                                                                                                                                                                       | `undefined`                     |
 
 
+## Shadow Parts
+
+| Part    | Description                       |
+| ------- | --------------------------------- |
+| `"row"` | The description list row element. |
+
+
+## CSS Custom Properties
+
+| Name                                    | Description                               |
+| --------------------------------------- | ----------------------------------------- |
+| `--description-list-gap`                | The gap between the title and description |
+| `--description-list-row-align`          | The alignment for the rows                |
+| `--description-list-row-extremes`       | The gap for the first and last row        |
+| `--description-list-row-inline-padding` | The horizontal padding for each row       |
+
+
 ## Dependencies
 
 ### Depends on
 
+- [kv-copy-to-clipboard](../copy-to-clipboard)
 - [kv-tooltip](../tooltip)
 - [kv-toggle-tip](../toggle-tip)
 - [kv-icon](../icon)
@@ -107,9 +125,12 @@ export const KvDescriptionListExample: React.FC = () => (
 ### Graph
 ```mermaid
 graph TD;
+  kv-description-list --> kv-copy-to-clipboard
   kv-description-list --> kv-tooltip
   kv-description-list --> kv-toggle-tip
   kv-description-list --> kv-icon
+  kv-copy-to-clipboard --> kv-tooltip
+  kv-copy-to-clipboard --> kv-icon
   kv-tooltip --> kv-portal
   kv-tooltip --> kv-tooltip-text
   kv-toggle-tip --> kv-portal

--- a/packages/ui-components/src/components/description-list/test/__snapshots__/description-list.spec.tsx.snap
+++ b/packages/ui-components/src/components/description-list/test/__snapshots__/description-list.spec.tsx.snap
@@ -3,32 +3,38 @@
 exports[`Description List (unit tests) when rendering with an item with icon tooltip should match the snapshot 1`] = `
 <kv-description-list custom-class="">
   <div class="description-list-container">
-    <div class="title">
-      Name ID
+    <div class="row" part="row">
+      <div class="title">
+        Name ID
+      </div>
+      <div class="description">
+        <kv-tooltip customclass="description-list-tooltip-container" text="">
+          cluster-a-brownie
+        </kv-tooltip>
+        <kv-toggle-tip customclass="description-list-tooltip-container" position="bottom-start" text="This name cannot be changed">
+          <kv-icon customclass="icon-16" name="kv-info" slot="open-element-slot"></kv-icon>
+        </kv-toggle-tip>
+      </div>
     </div>
-    <div class="description">
-      <kv-tooltip customclass="description-list-tooltip-container" text="">
-        cluster-a-brownie
-      </kv-tooltip>
-      <kv-toggle-tip customclass="description-list-tooltip-container" position="bottom-start" text="This name cannot be changed">
-        <kv-icon customclass="icon-16" name="kv-info" slot="open-element-slot"></kv-icon>
-      </kv-toggle-tip>
+    <div class="row" part="row">
+      <div class="title">
+        Kubernetes Version
+      </div>
+      <div class="description">
+        <kv-tooltip customclass="description-list-tooltip-container" text="">
+          1.20.5
+        </kv-tooltip>
+      </div>
     </div>
-    <div class="title">
-      Kubernetes Version
-    </div>
-    <div class="description">
-      <kv-tooltip customclass="description-list-tooltip-container" text="">
-        1.20.5
-      </kv-tooltip>
-    </div>
-    <div class="title">
-      Kelvin Version
-    </div>
-    <div class="description">
-      <kv-tooltip customclass="description-list-tooltip-container" text="">
-        4.2.4
-      </kv-tooltip>
+    <div class="row" part="row">
+      <div class="title">
+        Kelvin Version
+      </div>
+      <div class="description">
+        <kv-tooltip customclass="description-list-tooltip-container" text="">
+          4.2.4
+        </kv-tooltip>
+      </div>
     </div>
   </div>
 </kv-description-list>
@@ -37,29 +43,35 @@ exports[`Description List (unit tests) when rendering with an item with icon too
 exports[`Description List (unit tests) when rendering with an item with text tooltip should match the snapshot 1`] = `
 <kv-description-list custom-class="">
   <div class="description-list-container">
-    <div class="title">
-      Name ID
+    <div class="row" part="row">
+      <div class="title">
+        Name ID
+      </div>
+      <div class="description">
+        <kv-tooltip customclass="description-list-tooltip-container" text="This name cannot be changed">
+          cluster-a-brownie
+        </kv-tooltip>
+      </div>
     </div>
-    <div class="description">
-      <kv-tooltip customclass="description-list-tooltip-container" text="This name cannot be changed">
-        cluster-a-brownie
-      </kv-tooltip>
+    <div class="row" part="row">
+      <div class="title">
+        Kubernetes Version
+      </div>
+      <div class="description">
+        <kv-tooltip customclass="description-list-tooltip-container" text="">
+          1.20.5
+        </kv-tooltip>
+      </div>
     </div>
-    <div class="title">
-      Kubernetes Version
-    </div>
-    <div class="description">
-      <kv-tooltip customclass="description-list-tooltip-container" text="">
-        1.20.5
-      </kv-tooltip>
-    </div>
-    <div class="title">
-      Kelvin Version
-    </div>
-    <div class="description">
-      <kv-tooltip customclass="description-list-tooltip-container" text="">
-        4.2.4
-      </kv-tooltip>
+    <div class="row" part="row">
+      <div class="title">
+        Kelvin Version
+      </div>
+      <div class="description">
+        <kv-tooltip customclass="description-list-tooltip-container" text="">
+          4.2.4
+        </kv-tooltip>
+      </div>
     </div>
   </div>
 </kv-description-list>
@@ -68,29 +80,35 @@ exports[`Description List (unit tests) when rendering with an item with text too
 exports[`Description List (unit tests) when rendering with required item props should match the snapshot 1`] = `
 <kv-description-list custom-class="">
   <div class="description-list-container">
-    <div class="title">
-      Name ID
+    <div class="row" part="row">
+      <div class="title">
+        Name ID
+      </div>
+      <div class="description">
+        <kv-tooltip customclass="description-list-tooltip-container" text="">
+          cluster-a-brownie
+        </kv-tooltip>
+      </div>
     </div>
-    <div class="description">
-      <kv-tooltip customclass="description-list-tooltip-container" text="">
-        cluster-a-brownie
-      </kv-tooltip>
+    <div class="row" part="row">
+      <div class="title">
+        Kubernetes Version
+      </div>
+      <div class="description">
+        <kv-tooltip customclass="description-list-tooltip-container" text="">
+          1.20.5
+        </kv-tooltip>
+      </div>
     </div>
-    <div class="title">
-      Kubernetes Version
-    </div>
-    <div class="description">
-      <kv-tooltip customclass="description-list-tooltip-container" text="">
-        1.20.5
-      </kv-tooltip>
-    </div>
-    <div class="title">
-      Kelvin Version
-    </div>
-    <div class="description">
-      <kv-tooltip customclass="description-list-tooltip-container" text="">
-        4.2.4
-      </kv-tooltip>
+    <div class="row" part="row">
+      <div class="title">
+        Kelvin Version
+      </div>
+      <div class="description">
+        <kv-tooltip customclass="description-list-tooltip-container" text="">
+          4.2.4
+        </kv-tooltip>
+      </div>
     </div>
   </div>
 </kv-description-list>


### PR DESCRIPTION
<img width="698" height="288" alt="Screenshot 2025-09-12 at 18 12 25" src="https://github.com/user-attachments/assets/6cddc598-84dd-4c5d-84b7-175e2eb683d4" />


### What has been done
- added subgrid row option to enable style costumization (eg: border-bottom)
- integrated kv-copy-to-clipboard component
