### PR TITLE
feat(link): migrate to design token system

### DIFF
--- a/apps/react-storybook/src/components/navigation/link/Link.stories.tsx
+++ b/apps/react-storybook/src/components/navigation/link/Link.stories.tsx
@@ -1,10 +1,24 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { EAnchorTarget, KvLink } from "@kelvininc/react-ui-components/client";
+import {
+	EAnchorTarget,
+	EIconName,
+	KvLink
+} from "@kelvininc/react-ui-components/client";
 
 const meta = {
 	title: "Navigation/Link",
-	component: KvLink
+	component: KvLink,
+	argTypes: {
+		leftIcon: {
+			control: { type: "select" },
+			options: ["", ...Object.values(EIconName)]
+		},
+		rightIcon: {
+			control: { type: "select" },
+			options: ["", ...Object.values(EIconName)]
+		}
+	}
 } satisfies Meta<typeof KvLink>;
 
 export default meta;
@@ -16,11 +30,19 @@ export const LabelOnly: Story = {
 	}
 };
 
-export const LabelWithAnchor: Story = {
+export const LabelWithAnchorAndIcon: Story = {
 	args: {
 		label: "Link Label",
 		href: "https://kelvin.ai",
-		target: EAnchorTarget.NewTab
+		target: EAnchorTarget.NewTab,
+		rightIcon: EIconName.ExternalLink
+	}
+};
+
+export const LabelWithIcon: Story = {
+	args: {
+		label: "Link Label",
+		leftIcon: EIconName.ExternalLink
 	}
 };
 

--- a/packages/ui-components/src/components/MIGRATION_STATUS.md
+++ b/packages/ui-components/src/components/MIGRATION_STATUS.md
@@ -17,6 +17,7 @@ Checklist of all components indicating whether they have been migrated to the ne
 - [x] toggle-button-group
 - [x] radio
 - [x] checkbox
+- [x] link
 
 
 
@@ -28,7 +29,6 @@ Checklist of all components indicating whether they have been migrated to the ne
 - [ ] form-help-text
 - [ ] form-label
 - [ ] input-wrapper
-- [ ] link
 - [ ] multi-select-dropdown
 - [ ] search
 - [ ] single-select-dropdown

--- a/packages/ui-components/src/components/icon/readme.md
+++ b/packages/ui-components/src/components/icon/readme.md
@@ -72,6 +72,7 @@ export const SvgIconExample: React.FC = () => (
  - [kv-form-help-text](../form-help-text)
  - [kv-info-label](../info-label)
  - [kv-input-wrapper](../input-wrapper)
+ - [kv-link](../link)
  - [kv-modal](../modal)
  - [kv-radio](../radio)
  - [kv-select-option](../select-option)
@@ -105,6 +106,7 @@ graph TD;
   kv-form-help-text --> kv-icon
   kv-info-label --> kv-icon
   kv-input-wrapper --> kv-icon
+  kv-link --> kv-icon
   kv-modal --> kv-icon
   kv-radio --> kv-icon
   kv-select-option --> kv-icon

--- a/packages/ui-components/src/components/link/link.scss
+++ b/packages/ui-components/src/components/link/link.scss
@@ -2,25 +2,107 @@
 
 :host {
 	.link-container {
+		width: fit-content;
 		display: flex;
 		flex-direction: column;
 
-		.label {
-			@include body-m-semibold();
-			text-decoration: none;
-			user-select: none;
-			color: kv-color('text');
-			cursor: pointer;
+		&--disabled {
+			@include non-clickable;
+		}
 
-			&:hover {
-				color: kv-color('primary');
+		.label {
+			display: inline-flex;
+			align-items: center;
+			gap: var(--link-gap-default);
+			outline: none;
+
+			@include body-m-semibold;
+			@include clickable;
+
+			color: var(--link-label-default);
+			text-decoration: none;
+			transition: text-decoration 0.2s ease;
+
+			kv-icon,
+			::slotted(kv-icon) {
+				// Required due to browser restrictions on the :visited selector
+				--icon-color: currentColor;
+				--icon-width: var(--link-icon-size-default);
+				--icon-height: var(--link-icon-size-default);
+			}
+
+			&:visited:not(.label--disabled) {
+				color: var(--link-label-visited);
+			}
+
+			&:focus:not(.label--disabled),
+			&:hover:not(.label--disabled) {
+				color: var(--link-label-hover);
 				text-decoration: underline;
+				text-decoration-thickness: var(--link-decoration-thickness-default);
+				text-decoration-color: var(--link-decoration-color-hover);
+
+				kv-icon,
+				::slotted(kv-icon) {
+					--icon-color: var(--link-icon-color-hover);
+				}
+			}
+
+			&--disabled {
+				color: var(--link-label-disabled);
+				pointer-events: none;
+
+				kv-icon,
+				::slotted(kv-icon) {
+					--icon-color: var(--link-icon-color-disabled);
+				}
+			}
+		}
+
+		.label--inline {
+			text-decoration: underline;
+			text-decoration-thickness: var(--inline-link-decoration-thickness-default);
+			text-decoration-color: var(--inline-link-decoration-color-default);
+
+			color: var(--inline-link-label-default);
+
+			kv-icon,
+			::slotted(kv-icon) {
+				--icon-color: currentColor;
+				--icon-width: var(--inline-link-icon-size-default);
+				--icon-height: var(--inline-link-icon-size-default);
+			}
+
+			&:visited:not(.label--disabled) {
+				color: var(--inline-link-label-visited);
+				text-decoration-color: var(--inline-link-decoration-color-visited);
+			}
+
+			&:focus:not(.label--disabled),
+			&:hover:not(.label--disabled) {
+				color: var(--inline-link-label-hover);
+				text-decoration-color: var(--inline-link-decoration-color-hover);
+
+				kv-icon,
+				::slotted(kv-icon) {
+					--icon-color: var(--inline-link-icon-color-hover);
+				}
+			}
+
+			&.label--disabled {
+				color: var(--inline-link-label-disabled);
+				text-decoration-color: var(--inline-link-decoration-color-disabled);
+
+				kv-icon,
+				::slotted(kv-icon) {
+					--icon-color: var(--inline-link-icon-color-disabled);
+				}
 			}
 		}
 
 		.subtitle {
 			@include body-s-regular();
-			color: kv-color('text');
+			color: var(--text-container-neutral-subtle);
 		}
 	}
 }

--- a/packages/ui-components/src/components/link/link.tsx
+++ b/packages/ui-components/src/components/link/link.tsx
@@ -1,9 +1,10 @@
 import { Component, Host, h, Prop, EventEmitter, Event } from '@stencil/core';
 import { ILink } from './link.types';
-import { EAnchorTarget } from '../../types';
+import { EAnchorTarget, EIconName } from '../../types';
 
 /**
  * @part container - The link's container
+ * @part label - The link's label
  */
 @Component({
 	tag: 'kv-link',
@@ -11,13 +12,21 @@ import { EAnchorTarget } from '../../types';
 	shadow: true
 })
 export class KvLink implements ILink {
-	/** (required) Main component label */
+	/** @inheritdoc */
 	@Prop({ reflect: true }) label!: string;
-	/** (optional) Description for the label */
+	/** @inheritdoc */
+	@Prop({ reflect: true }) leftIcon?: EIconName;
+	/** @inheritdoc */
+	@Prop({ reflect: true }) rightIcon?: EIconName;
+	/** @inheritdoc */
 	@Prop({ reflect: true }) subtitle?: string;
-	/** (optional) The link to open when clicking on the tag */
+	/** @inheritdoc */
+	@Prop({ reflect: true }) disabled? = false;
+	/** @inheritdoc */
+	@Prop({ reflect: true }) inline? = false;
+	/** @inheritdoc */
 	@Prop({ reflect: true }) href?: string;
-	/** (optional) The link to open when clicking on the tag */
+	/** @inheritdoc */
 	@Prop({ reflect: true }) target?: EAnchorTarget;
 
 	/** Emitted when clicking the label */
@@ -30,9 +39,28 @@ export class KvLink implements ILink {
 	render() {
 		return (
 			<Host>
-				<div class="link-container" part="container">
-					<a class="label" href={this.href} target={this.target} onClick={this.onLabelClick}>
+				<div
+					class={{
+						'link-container': true,
+						'link-container--disabled': this.disabled
+					}}
+					part="container"
+				>
+					<a
+						tabIndex={this.disabled ? -1 : 0}
+						class={{
+							'label': true,
+							'label--disabled': this.disabled,
+							'label--inline': this.inline
+						}}
+						href={this.href}
+						target={this.target}
+						onClick={this.onLabelClick}
+						part="label"
+					>
+						<slot name="left">{this.leftIcon && <kv-icon name={this.leftIcon} />}</slot>
 						{this.label}
+						<slot name="right">{this.rightIcon && <kv-icon name={this.rightIcon} />}</slot>
 					</a>
 					{this.subtitle && <div class="subtitle">{this.subtitle}</div>}
 				</div>

--- a/packages/ui-components/src/components/link/link.types.ts
+++ b/packages/ui-components/src/components/link/link.types.ts
@@ -1,6 +1,18 @@
-import { EAnchorTarget } from '../../types';
+import { EAnchorTarget, EIconName } from '../../types';
 
 export interface ILink {
+	/** (required) Main component label */
+	label: string;
+	/** (optional) The name of the icon to be rendered on the right side of the label */
+	rightIcon?: EIconName;
+	/** (optional) The name of the icon to be rendered on the left side of the label */
+	leftIcon?: EIconName;
+	/** (optional) Description for the label */
+	subtitle?: string;
+	/** (optional) Defines if the link are disabled. Default: false*/
+	disabled?: boolean;
+	/** (optional) Whether the link is displayed inline. Default: false*/
+	inline?: boolean;
 	/** (optional) The anchor's link to open when clicking */
 	href?: string;
 	/** (optional) The anchor's target */

--- a/packages/ui-components/src/components/link/readme.md
+++ b/packages/ui-components/src/components/link/readme.md
@@ -72,12 +72,16 @@ export class SwichButtonExample {
 
 ## Properties
 
-| Property             | Attribute  | Description                                          | Type                                                                                                | Default     |
-| -------------------- | ---------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------- |
-| `href`               | `href`     | (optional) The link to open when clicking on the tag | `string`                                                                                            | `undefined` |
-| `label` _(required)_ | `label`    | (required) Main component label                      | `string`                                                                                            | `undefined` |
-| `subtitle`           | `subtitle` | (optional) Description for the label                 | `string`                                                                                            | `undefined` |
-| `target`             | `target`   | (optional) The link to open when clicking on the tag | `EAnchorTarget.BrowserDefault \| EAnchorTarget.NewTab \| EAnchorTarget.Parent \| EAnchorTarget.Top` | `undefined` |
+| Property             | Attribute    | Description                                                                   | Type                                                                                                | Default     |
+| -------------------- | ------------ | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------- |
+| `disabled`           | `disabled`   | (optional) Defines if the link are disabled. Default: false                   | `boolean`                                                                                           | `false`     |
+| `href`               | `href`       | (optional) The anchor's link to open when clicking                            | `string`                                                                                            | `undefined` |
+| `inline`             | `inline`     | (optional) Whether the link is displayed inline. Default: false               | `boolean`                                                                                           | `false`     |
+| `label` _(required)_ | `label`      | (required) Main component label                                               | `string`                                                                                            | `undefined` |
+| `leftIcon`           | `left-icon`  | (optional) The name of the icon to be rendered on the left side of the label  | `EIconName`                                                                                         | `undefined` |
+| `rightIcon`          | `right-icon` | (optional) The name of the icon to be rendered on the right side of the label | `EIconName`                                                                                         | `undefined` |
+| `subtitle`           | `subtitle`   | (optional) Description for the label                                          | `string`                                                                                            | `undefined` |
+| `target`             | `target`     | (optional) The anchor's target                                                | `EAnchorTarget.BrowserDefault \| EAnchorTarget.NewTab \| EAnchorTarget.Parent \| EAnchorTarget.Top` | `undefined` |
 
 
 ## Events
@@ -92,6 +96,7 @@ export class SwichButtonExample {
 | Part          | Description          |
 | ------------- | -------------------- |
 | `"container"` | The link's container |
+| `"label"`     | The link's label     |
 
 
 ## Dependencies
@@ -100,9 +105,14 @@ export class SwichButtonExample {
 
  - [kv-radio-list-item](../radio-list-item)
 
+### Depends on
+
+- [kv-icon](../icon)
+
 ### Graph
 ```mermaid
 graph TD;
+  kv-link --> kv-icon
   kv-radio-list-item --> kv-link
   style kv-link fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/ui-components/src/components/radio-list-item/readme.md
+++ b/packages/ui-components/src/components/radio-list-item/readme.md
@@ -104,6 +104,7 @@ graph TD;
   kv-radio-list-item --> kv-radio
   kv-radio-list-item --> kv-link
   kv-radio --> kv-icon
+  kv-link --> kv-icon
   kv-radio-list --> kv-radio-list-item
   style kv-radio-list-item fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/ui-components/src/components/radio-list/readme.md
+++ b/packages/ui-components/src/components/radio-list/readme.md
@@ -76,6 +76,7 @@ graph TD;
   kv-radio-list-item --> kv-radio
   kv-radio-list-item --> kv-link
   kv-radio --> kv-icon
+  kv-link --> kv-icon
   style kv-radio-list fill:#f9f,stroke:#333,stroke-width:4px
 ```
 


### PR DESCRIPTION
- Add leftIcon, rightIcon, disabled and inline props
- Expose label CSS part for external styling
- Use design tokens for colors, spacing and typography across all states (default, hover, focus, visited, disabled) for both standard and inline variants
- Fix icon color in :visited state by using --icon-color: currentColor, working around browser security restrictions that block CSS custom property updates inside :visited
- Update Storybook stories with icon controls and new icon-based story variants