### PR TITLE
feat(select): migrate to design token system

### DIFF
--- a/packages/ui-components/src/assets/styles/kv-mixins.scss
+++ b/packages/ui-components/src/assets/styles/kv-mixins.scss
@@ -1,5 +1,5 @@
-@use "kv-functions-color" as *;
-@use "kv-spacing" as *;
+@use 'kv-functions-color' as *;
+@use 'kv-spacing' as *;
 
 @mixin ghost-animation($color) {
 	$color-faded: color-mix(in srgb, $color 30%, transparent);
@@ -140,9 +140,24 @@
 	inherits: false;
 }
 
-
 @keyframes rotate-border {
 	to {
 		--rotation: 360deg;
 	}
+}
+
+@mixin kelvin-vertical-divider($color: var(--border-surface-neutral-default)) {
+	content: '';
+	display: flex;
+	flex: 1;
+	width: 1px;
+	background: $color;
+}
+
+@mixin kelvin-horizontal-divider($color: var(--border-surface-neutral-default)) {
+	content: '';
+	display: flex;
+	flex: 1;
+	height: 1px;
+	background: $color;
 }

--- a/packages/ui-components/src/components/MIGRATION_STATUS.md
+++ b/packages/ui-components/src/components/MIGRATION_STATUS.md
@@ -32,6 +32,14 @@ Checklist of all components indicating whether they have been migrated to the ne
 - [x] tab-navigation
 - [x] tag
 - [x] tag-status
+- [x] select
+- [x] select-create-option
+- [x] select-multi-options
+- [x] select-option
+- [x] select-shortcuts-label
+- [x] multi-select-dropdown
+- [x] single-select-dropdown
+
 
 
 
@@ -39,8 +47,6 @@ Checklist of all components indicating whether they have been migrated to the ne
 
 - [ ] alert
 - [ ] input-wrapper
-- [ ] multi-select-dropdown
-- [ ] single-select-dropdown
 - [ ] text-area
 - [ ] toaster
 - [ ] toggle-tip
@@ -73,11 +79,6 @@ Checklist of all components indicating whether they have been migrated to the ne
 - [ ] radio-list-item
 - [ ] range
 - [ ] relative-time-picker
-- [ ] select
-- [ ] select-create-option
-- [ ] select-multi-options
-- [ ] select-option
-- [ ] select-shortcuts-label
 - [ ] state-indicator
 - [ ] step-bar
 - [ ] step-indicator

--- a/packages/ui-components/src/components/action-button-text/readme.md
+++ b/packages/ui-components/src/components/action-button-text/readme.md
@@ -72,6 +72,7 @@ export const ActionButtonTextExample: React.FC = () => (
  - [kv-absolute-time-picker-dropdown](../absolute-time-picker-dropdown)
  - [kv-action-button-magic](../action-button-magic)
  - [kv-action-button-split](../action-button-split)
+ - [kv-select](../select)
  - [kv-time-picker](../time-picker)
  - [kv-wizard-footer](../wizard-footer)
 
@@ -88,6 +89,7 @@ graph TD;
   kv-absolute-time-picker-dropdown --> kv-action-button-text
   kv-action-button-magic --> kv-action-button-text
   kv-action-button-split --> kv-action-button-text
+  kv-select --> kv-action-button-text
   kv-time-picker --> kv-action-button-text
   kv-wizard-footer --> kv-action-button-text
   style kv-action-button-text fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/ui-components/src/components/multi-select-dropdown/readme.md
+++ b/packages/ui-components/src/components/multi-select-dropdown/readme.md
@@ -151,7 +151,10 @@ graph TD;
   kv-action-button-icon --> kv-action-button
   kv-action-button-icon --> kv-icon
   kv-select --> kv-search
+  kv-select --> kv-action-button-text
   kv-search --> kv-text-field
+  kv-action-button-text --> kv-action-button
+  kv-action-button-text --> kv-icon
   kv-illustration-message --> kv-illustration
   kv-select-create-option --> kv-text-field
   kv-select-create-option --> kv-action-button-icon

--- a/packages/ui-components/src/components/relative-time-picker/readme.md
+++ b/packages/ui-components/src/components/relative-time-picker/readme.md
@@ -117,7 +117,10 @@ graph TD;
   kv-select-multi-options --> kv-select-create-option
   kv-select-multi-options --> kv-select-shortcuts-label
   kv-select --> kv-search
+  kv-select --> kv-action-button-text
   kv-search --> kv-text-field
+  kv-action-button-text --> kv-action-button
+  kv-action-button-text --> kv-icon
   kv-illustration-message --> kv-illustration
   kv-select-create-option --> kv-text-field
   kv-select-create-option --> kv-action-button-icon

--- a/packages/ui-components/src/components/select-create-option/select-create-option.scss
+++ b/packages/ui-components/src/components/select-create-option/select-create-option.scss
@@ -3,7 +3,7 @@
 .select-create-option {
 	display: flex;
 	align-items: flex-start;
-	gap: $spacing-3x;
+	gap: var(--spacing-xl, #{$spacing-3x});
 }
 
 .form {
@@ -14,5 +14,5 @@
 .actions {
 	display: flex;
 	align-items: center;
-	gap: $spacing;
+	gap: var(--spacing-xs, #{$spacing});
 }

--- a/packages/ui-components/src/components/select-multi-options/readme.md
+++ b/packages/ui-components/src/components/select-multi-options/readme.md
@@ -135,6 +135,7 @@ graph TD;
   kv-action-button-icon --> kv-action-button
   kv-action-button-icon --> kv-icon
   kv-select --> kv-search
+  kv-select --> kv-action-button-text
   kv-search --> kv-text-field
   kv-text-field --> kv-tooltip
   kv-text-field --> kv-form-label
@@ -143,6 +144,8 @@ graph TD;
   kv-text-field --> kv-badge
   kv-text-field --> kv-form-help-text
   kv-form-help-text --> kv-icon
+  kv-action-button-text --> kv-action-button
+  kv-action-button-text --> kv-icon
   kv-illustration-message --> kv-illustration
   kv-select-create-option --> kv-text-field
   kv-select-create-option --> kv-action-button-icon

--- a/packages/ui-components/src/components/select-multi-options/select-multi-options.scss
+++ b/packages/ui-components/src/components/select-multi-options/select-multi-options.scss
@@ -28,14 +28,14 @@ kv-select {
 .selected-items-label {
 	@include ellipsis;
 	@include body-s-regular;
-	color: kv-color('neutral-4');
+	color: var(--text-container-neutral-subtle, #{kv-color('neutral-4')});
 	text-wrap: nowrap;
 }
 
 .counter {
 	display: flex;
 	align-items: center;
-	color: kv-color('neutral-4');
+	color: var(--text-container-neutral-subtle, #{kv-color('neutral-4')});
 	@include body-xs-regular;
 }
 
@@ -43,22 +43,22 @@ kv-select {
 	position: absolute;
 	top: 0;
 	left: 0;
-	border-radius: 4px;
-	border: 1px solid kv-color('neutral-6');
+	border-radius: var(--slider-radius-default, #{$spacing});
+	border: var(--slider-border-thickness-default, 1px) solid var(--slider-border-color-default, #{kv-color('neutral-6')});
 	width: calc(100% - 2px);
 	height: calc(100% - 2px);
-	background: kv-color('neutral-7', 'base', 0.8);
+	background: var(--overlay-surface-default, #{kv-color('neutral-7', 'base', 0.8)});
 	z-index: 1;
 
 	&.has-shortcuts .create-new-option-form {
 		bottom: 36px;
-		border-bottom: 1px solid kv-color('neutral-6');
+		border-bottom: var(--slider-border-thickness-default, 1px) solid var(--slider-border-color-default, #{kv-color('neutral-6')});
 	}
 }
 
 .form-container {
-	background: kv-color('neutral-7');
-	padding: $spacing-3x $spacing-4x;
+	background: var(--slider-background-default, #{kv-color('neutral-7')});
+	padding: var(--spacing-xl, #{$spacing-3x}) var(--spacing-2xl, #{$spacing-4x});
 }
 
 .create-new-option-form {
@@ -66,12 +66,12 @@ kv-select {
 	position: absolute;
 	bottom: 0;
 	left: 0;
-	border-top: 1px solid kv-color('neutral-6');
+	border-top: var(--slider-border-thickness-default, 1px) solid var(--slider-border-color-default, #{kv-color('neutral-6')});
 }
 
 .create-new-option-button {
-	border-top: 1px solid kv-color('neutral-6');
-	padding: $spacing-3x 0;
+	border-top: var(--slider-border-thickness-default, 1px) solid var(--slider-border-color-default, #{kv-color('neutral-6')});
+	padding: var(--spacing-xl, #{$spacing-3x}) 0;
 }
 
 .no-results-found,
@@ -81,7 +81,7 @@ kv-select {
 
 	.illustration-message {
 		max-width: 292px;
-		padding: $spacing-8x $spacing-3x;
+		padding: var(--spacing-5xl, #{$spacing-8x}) var(--spacing-xl, #{$spacing-3x});
 		align-self: center;
 	}
 }

--- a/packages/ui-components/src/components/select-option/select-option.scss
+++ b/packages/ui-components/src/components/select-option/select-option.scss
@@ -25,23 +25,38 @@
 	--select-option-height: 32px;
 	--select-option-transition-duration: 100ms;
 
-	--select-option-background-color: #{kv-color('neutral-7')};
-	--select-option-background-color-selected: #{kv-color('neutral-6')};
-	--select-option-background-color-highlighted: #{kv-color('neutral-6')};
-	--select-option-background-color-hover: #{kv-color('neutral-6')};
+	--select-option-background-color: var(--transparent, #{kv-color('neutral-7')});
+	--select-option-background-color-selected: var(--background-interactive-slider-list-selected, #{kv-color('neutral-6')});
+	--select-option-background-color-highlighted: var(--background-interactive-slider-list-hover, #{kv-color('neutral-6')});
+	--select-option-background-color-hover: var(--background-interactive-slider-list-hover, #{kv-color('neutral-6')});
+	--select-option-background-color-disabled: var(--transparent, #{kv-color('neutral-7')});
 
-	--select-option-label-color: #{kv-color('neutral-4')};
-	--select-option-label-color-selected: #{kv-color('neutral-1')};
-	--select-option-label-color-highlighted: #{kv-color('neutral-2')};
-	--select-option-label-color-hover: #{kv-color('neutral-2')};
-	--select-option-description-color: #{kv-color('neutral-4')};
-	--select-option-description-color-selected: #{kv-color('neutral-4')};
-	--select-option-description-color-highlighted: #{kv-color('neutral-4')};
-	--select-option-description-color-hover: #{kv-color('neutral-4')};
-	--select-option-icon-size: 16px;
-	--select-option-icon-color: #{kv-color('neutral-0')};
-	--select-option-right-icon-size: 16px;
-	--select-option-right-icon-color: #{kv-color('neutral-4')};
+	--select-option-label-color: var(--text-interactive-slider-list-default, #{kv-color('neutral-4')});
+	--select-option-label-color-selected: var(--text-interactive-slider-list-selected, #{kv-color('neutral-1')});
+	--select-option-label-color-highlighted: var(--text-interactive-slider-list-hover, #{kv-color('neutral-2')});
+	--select-option-label-color-hover: var(--text-interactive-slider-list-hover, #{kv-color('neutral-2')});
+	--select-option-label-color-disabled: var(--text-interactive-slider-list-disabled, #{kv-color('neutral-6')});
+
+	--select-option-description-color: var(--text-on-color-neutral-tertiary, #{kv-color('neutral-4')});
+	--select-option-description-color-selected: var(--text-on-color-neutral-tertiary, #{kv-color('neutral-4')});
+	--select-option-description-color-highlighted: var(--text-on-color-neutral-tertiary, #{kv-color('neutral-4')});
+	--select-option-description-color-hover: var(--text-on-color-neutral-tertiary, #{kv-color('neutral-4')});
+	--select-option-description-color-disabled: var(--text-on-color-neutral-disabled, #{kv-color('neutral-6')});
+
+	--select-option-icon-color: var(--icon-interactive-slider-list-default, #{kv-color('neutral-0')});
+	--select-option-icon-color-selected: var(--icon-interactive-slider-list-selected, #{kv-color('neutral-0')});
+	--select-option-icon-color-highlighted: var(--icon-interactive-slider-list-hover, #{kv-color('neutral-0')});
+	--select-option-icon-color-hover: var(--icon-interactive-slider-list-hover, #{kv-color('neutral-0')});
+	--select-option-icon-color-disabled: var(--icon-interactive-slider-list-disabled, #{kv-color('neutral-6')});
+
+	--select-option-right-icon-color: var(--icon-interactive-slider-list-default, #{kv-color('neutral-4')});
+	--select-option-right-icon-color-selected: var(--icon-interactive-slider-list-selected, #{kv-color('neutral-4')});
+	--select-option-right-icon-color-highlighted: var(--icon-interactive-slider-list-hover, #{kv-color('neutral-4')});
+	--select-option-right-icon-color-hover: var(--icon-interactive-slider-list-hover, #{kv-color('neutral-4')});
+	--select-option-right-icon-color-disabled: var(--icon-interactive-slider-list-disabled, #{kv-color('neutral-6')});
+
+	--select-option-icon-size: var(--size-default, 16px);
+	--select-option-right-icon-size: var(--size-default, 16px);
 }
 
 .select-option {
@@ -53,15 +68,15 @@
 	cursor: pointer;
 	background-color: var(--select-option-background-color);
 	transition: background-color var(--select-option-transition-duration) linear;
-	padding-right: $spacing-4x;
-	padding-left: calc(var(--level-padding-offset) + #{$spacing-4x});
+	padding-right: var(--spacing-2xl, #{$spacing-4x});
+	padding-left: calc(var(--level-padding-offset) + var(--spacing-2xl, #{$spacing-4x}));
 
 	.text-container {
 		flex: 1;
 		min-width: 0;
 		display: flex;
 		align-items: center;
-		gap: $spacing-2x;
+		gap: var(--spacing-md, #{$spacing-2x});
 	}
 
 	.left-content {
@@ -69,17 +84,17 @@
 		min-width: 0;
 		display: flex;
 		align-items: center;
-		gap: $spacing;
+		gap: var(--spacing-xs, #{$spacing});
 	}
 
 	.right-content {
 		display: flex;
 		align-items: center;
-		gap: $spacing-2x;
+		gap: var(--spacing-md, #{$spacing-2x});
 	}
 
 	.icon-container {
-		margin-right: $spacing-2x;
+		margin-right: var(--spacing-md, #{$spacing-2x});
 
 		kv-icon {
 			--icon-width: var(--select-option-icon-size);
@@ -107,7 +122,7 @@
 	.group {
 		display: flex;
 		flex-direction: row;
-		gap: $spacing;
+		gap: var(--spacing-xs, #{$spacing});
 		align-items: center;
 	}
 
@@ -120,8 +135,15 @@
 		}
 
 		.item-description {
-			@include body-s-semibold;
 			color: var(--select-option-description-color-selected);
+		}
+
+		.icon-container kv-icon {
+			--icon-color: var(--select-option-icon-color-selected);
+		}
+
+		.item-right-icon kv-icon {
+			--icon-color: var(--select-option-right-icon-color-selected);
 		}
 	}
 
@@ -135,6 +157,14 @@
 		.item-description {
 			color: var(--select-option-description-color-hover);
 		}
+
+		.icon-container kv-icon {
+			--icon-color: var(--select-option-icon-color-hover);
+		}
+
+		.item-right-icon kv-icon {
+			--icon-color: var(--select-option-right-icon-color-hover);
+		}
 	}
 
 	&--highlighted {
@@ -146,14 +176,37 @@
 		}
 
 		.item-description {
-			@include body-s-semibold;
 			color: var(--select-option-description-color-highlighted);
+		}
+
+		.icon-container kv-icon {
+			--icon-color: var(--select-option-icon-color-highlighted);
+		}
+
+		.item-right-icon kv-icon {
+			--icon-color: var(--select-option-right-icon-color-highlighted);
 		}
 	}
 
 	&--disabled {
-		cursor: not-allowed;
-		opacity: 0.5;
+		@include non-clickable;
+		background-color: var(--select-option-background-color-disabled);
+
+		.item-label {
+			color: var(--select-option-label-color-disabled);
+		}
+
+		.item-description {
+			color: var(--select-option-description-color-disabled);
+		}
+
+		.icon-container kv-icon {
+			--icon-color: var(--select-option-icon-color-disabled);
+		}
+
+		.item-right-icon kv-icon {
+			--icon-color: var(--select-option-right-icon-color-disabled);
+		}
 	}
 
 	&:not(.select-option--selectable) {
@@ -163,23 +216,20 @@
 
 	&--heading {
 		.item-label {
-			@include heading-xs-semibold-caps;
-			color: kv-color('neutral-2');
+			@include body-m-regular;
+			color: var(--text-on-color-neutral-tertiary, #{kv-color('neutral-2')});
 		}
 
 		.text-container .left-content::after {
-			content: '';
-			display: flex;
-			flex: 1;
-			height: 1px;
-			background: kv-color('neutral-6');
-			margin-left: $spacing-2x;
+			@include kelvin-horizontal-divider(var(--border-on-color-neutral-default, #{kv-color('neutral-6')}));
+
+			margin-left: var(--spacing-md, #{$spacing-2x});
 		}
 	}
 
 	&--with-checkbox {
 		padding-left: var(--spacing-md);
-		
+
 		kv-checkbox {
 			margin-right: var(--spacing-xs);
 		}

--- a/packages/ui-components/src/components/select-option/select-option.tsx
+++ b/packages/ui-components/src/components/select-option/select-option.tsx
@@ -123,31 +123,33 @@ export class KvSelectOption implements ISelectOption, ISelectOptionEvents {
 									{this.label}
 								</div>
 							</div>
-							<div class="right-content">
-								{(this.description || this.rightIcon) && (
-									<div class="group">
-										{this.rightIcon && (
-											<kv-tooltip text={this.rightIconTooltipText}>
-												<div class="item-right-icon" part="right-icon">
-													<kv-icon name={this.rightIcon} />
-												</div>
-											</kv-tooltip>
-										)}
-										{this.description && <div class="item-description">{this.description}</div>}
-									</div>
-								)}
-								{this.action && (
-									<div class="group">
-										<kv-action-button-icon
-											type={EActionButtonType.Tertiary}
-											icon={this.action.icon}
-											onClickButton={this.action.onClick}
-											active={this.action.active}
-											onClick={event => event.stopPropagation()}
-										/>
-									</div>
-								)}
-							</div>
+							{(this.description || this.rightIcon || this.action) && (
+								<div class="right-content">
+									{(this.description || this.rightIcon) && (
+										<div class="group">
+											{this.rightIcon && (
+												<kv-tooltip text={this.rightIconTooltipText}>
+													<div class="item-right-icon" part="right-icon">
+														<kv-icon name={this.rightIcon} />
+													</div>
+												</kv-tooltip>
+											)}
+											{this.description && <div class="item-description">{this.description}</div>}
+										</div>
+									)}
+									{this.action && (
+										<div class="group">
+											<kv-action-button-icon
+												type={EActionButtonType.Tertiary}
+												icon={this.action.icon}
+												onClickButton={this.action.onClick}
+												active={this.action.active}
+												onClick={event => event.stopPropagation()}
+											/>
+										</div>
+									)}
+								</div>
+							)}
 						</div>
 					</div>
 					<slot />

--- a/packages/ui-components/src/components/select-option/test/__snapshots__/select-option.spec.tsx.snap
+++ b/packages/ui-components/src/components/select-option/test/__snapshots__/select-option.spec.tsx.snap
@@ -11,7 +11,6 @@ exports[`KvSelectOption (unit tests) when rendering with bottom slot flag \`true
               Option 1
             </div>
           </div>
-          <div class="right-content"></div>
         </div>
       </div>
       <slot></slot>
@@ -31,7 +30,6 @@ exports[`KvSelectOption (unit tests) when rendering with default props when the 
               Option 1
             </div>
           </div>
-          <div class="right-content"></div>
         </div>
       </div>
       <slot></slot>

--- a/packages/ui-components/src/components/select-shortcuts-label/select-shortcuts-label.scss
+++ b/packages/ui-components/src/components/select-shortcuts-label/select-shortcuts-label.scss
@@ -1,48 +1,50 @@
 @use '../../assets/styles' as *;
 
 .shortcuts {
-	background: kv-color('neutral-6');
+	background: var(--background-container-neutral-default, #{kv-color('neutral-6')});
 	display: flex;
 	justify-content: space-between;
-	padding: $spacing-2x $spacing-4x;
+	padding: var(--spacing-sm, #{$spacing-2x}) var(--spacing-2xl, #{$spacing-4x});
 	user-select: none;
 }
 
 .left-items {
 	display: flex;
-	gap: $spacing-5x;
+	gap: var(--spacing-5xl, #{$spacing-5x});
 }
 
 .group {
 	display: flex;
 	align-items: center;
-	gap: $spacing-2x;
+	gap: var(--spacing-md, #{$spacing-2x});
 }
 
 .icons {
 	display: flex;
 	align-items: center;
-	gap: $spacing;
+	gap: var(--spacing-xs, #{$spacing});
 }
 
 .label {
-	color: kv-color('neutral-4');
+	color: var(--text-on-color-neutral-tertiary, #{kv-color('neutral-4')});
 	@include body-xs-regular;
 }
 
 .icon {
-	border-radius: 4px;
-	background: kv-color('neutral-5');
-	color: kv-color('neutral-2');
+	border-radius: var(--radius-sm, 4px);
+	background: var(--background-container-neutral-subtlest, #{kv-color('neutral-5')});
+	color: var(--text-container-neutral-default, #{kv-color('neutral-2')});
 	@include body-xs-regular;
 	text-align: center;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	height: 20px;
-	width: 20px;
+	height: var(--size-lg, 20px);
+	width: var(--size-lg, 20px);
 
 	kv-icon {
-		--icon-color: #{kv-color('neutral-2')};
+		--icon-width: var(--size-default, 16px);
+		--icon-height: var(--size-default, 16px);
+		--icon-color: var(--icon-container-neutral-subtle, #{kv-color('neutral-2')});
 	}
 }

--- a/packages/ui-components/src/components/select/readme.md
+++ b/packages/ui-components/src/components/select/readme.md
@@ -100,11 +100,13 @@ Type: `Promise<void>`
 ### Depends on
 
 - [kv-search](../search)
+- [kv-action-button-text](../action-button-text)
 
 ### Graph
 ```mermaid
 graph TD;
   kv-select --> kv-search
+  kv-select --> kv-action-button-text
   kv-search --> kv-text-field
   kv-text-field --> kv-tooltip
   kv-text-field --> kv-form-label
@@ -116,6 +118,8 @@ graph TD;
   kv-tooltip --> kv-tooltip-text
   kv-dirty-dot --> kv-icon
   kv-form-help-text --> kv-icon
+  kv-action-button-text --> kv-action-button
+  kv-action-button-text --> kv-icon
   kv-select-multi-options --> kv-select
   style kv-select fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/ui-components/src/components/select/select.scss
+++ b/packages/ui-components/src/components/select/select.scss
@@ -13,19 +13,23 @@
 	--select-min-height: auto;
 	--select-max-width: auto;
 	--select-min-width: max-content;
-	--select-background-color: #{kv-color('neutral-7')};
-	--select-border: 1px solid #{kv-color('neutral-6')};
-	--select-inner-border: 1px solid #{kv-color('neutral-6')};
-	--select-border-radius: #{$spacing};
+	--select-background-color: var(--slider-background-default, #{kv-color('neutral-7')});
+	--select-border: var(--slider-border-thickness-default, 1px) solid var(--slider-border-color-default, #{kv-color('neutral-6')});
+	--select-inner-border: 1px solid var(--border-on-color-neutral-default, #{kv-color('neutral-6')});
+	--select-border-radius: var(--slider-radius-default, #{$spacing});
 }
 
 .select-container {
+	display: flex;
+	flex-direction: column;
 	max-width: var(--select-max-width);
 	min-width: var(--select-min-width);
 	border: var(--select-border);
 	border-radius: var(--select-border-radius);
 	overflow: hidden;
 	background-color: var(--select-background-color);
+	gap: var(--slider-gap-default);
+	padding-top: var(--slider-padding-default);
 }
 
 .select-options-container {
@@ -33,16 +37,17 @@
 	min-height: var(--select-min-height);
 
 	::slotted(kv-virtualized-list)  {
-		--virtualized-list-max-height: #{calc(var(--select-max-height) - $spacing-3x * 2)};
+		--virtualized-list-max-height: #{var(--select-max-height)};
 		--virtualized-list-min-height: #{var(--select-min-height)};
+		--virtualized-list-padding: 0;
 	}
 }
 
 .select-header-container {
 	display: flex;
 	flex-direction: column;
-	gap: $spacing-3x;
-	padding: $spacing-3x $spacing-4x;
+	gap: var(--spacing-md, #{$spacing-3x});
+	padding: 0 var(--spacing-xl, #{$spacing-4x}) var(--spacing-md, #{$spacing-3x});
 	border-bottom: var(--select-inner-border);
 }
 
@@ -50,32 +55,23 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	gap: $spacing-3x;
+	gap: var(--spacing-xl, #{$spacing-3x});
 
 	.footer-actions {
 		@include body-s-regular;
 		display: flex;
 		flex-direction: row;
 		align-items: center;
-		gap: calc($spacing-2x);
-		color: kv-color('neutral-4');
-	}
-
-	.action {
-		user-select: none;
-		cursor: pointer;
-		position: relative;
-		text-wrap: nowrap;
-
-		&--disabled {
-			pointer-events: none;
-			color: kv-color('neutral-5');
-		}
+		gap: var(--spacing-xs, #{$spacing-2x});
+		color: var(--text-container-neutral-subtle, #{kv-color('neutral-4')});
 	}
 
 	.divider {
-		height: 12px;
-		width: 1px;
-		background-color: kv-color('neutral-6');
+		display: flex;
+		height: 100%;
+
+		&::after {
+			@include kelvin-vertical-divider(var(--text-on-color-neutral-muted, #{kv-color('neutral-6')}));
+		}
 	}
 }

--- a/packages/ui-components/src/components/select/select.tsx
+++ b/packages/ui-components/src/components/select/select.tsx
@@ -3,7 +3,7 @@ import { isNil, omitBy } from 'lodash-es';
 import { CLEAR_SELECTION_LABEL, SELECT_ALL_LABEL } from './select.config';
 import { ISelect, ISelectEvents } from './select.types';
 import { isElementVisible } from './select.helper';
-import { EComponentSize } from '../../types';
+import { EActionButtonType, EComponentSize } from '../../types';
 
 /**
  * @part select - The select container.
@@ -113,28 +113,22 @@ export class KvSelect implements ISelect, ISelectEvents {
 								<div class="search-footer">
 									<div class="footer-actions">
 										{this.selectionAll && (
-											<div
-												class={{
-													'action': true,
-													'action--disabled': !this.selectionAllEnabled
-												}}
+											<kv-action-button-text
+												type={EActionButtonType.Text}
+												text={this.selectAllLabel}
 												onClick={this.onSelectAll}
-											>
-												{this.selectAllLabel}
-											</div>
+												disabled={!this.selectionAllEnabled}
+											/>
 										)}
 										{this.selectionClearable && (
 											<Fragment>
 												{this.selectionAll && <div class="divider" />}
-												<div
-													class={{
-														'action': true,
-														'action--disabled': !this.selectionClearEnabled
-													}}
+												<kv-action-button-text
+													type={EActionButtonType.Text}
+													text={this.clearSelectionLabel}
 													onClick={this.onClearSelection}
-												>
-													{this.clearSelectionLabel}
-												</div>
+													disabled={!this.selectionClearEnabled}
+												/>
 												{this.hasActionsSlot && <div class="divider" />}
 											</Fragment>
 										)}

--- a/packages/ui-components/src/components/single-select-dropdown/readme.md
+++ b/packages/ui-components/src/components/single-select-dropdown/readme.md
@@ -163,7 +163,10 @@ graph TD;
   kv-action-button-icon --> kv-action-button
   kv-action-button-icon --> kv-icon
   kv-select --> kv-search
+  kv-select --> kv-action-button-text
   kv-search --> kv-text-field
+  kv-action-button-text --> kv-action-button
+  kv-action-button-text --> kv-icon
   kv-illustration-message --> kv-illustration
   kv-select-create-option --> kv-text-field
   kv-select-create-option --> kv-action-button-icon

--- a/packages/ui-components/src/components/single-select-dropdown/single-select-dropdown.scss
+++ b/packages/ui-components/src/components/single-select-dropdown/single-select-dropdown.scss
@@ -16,6 +16,6 @@
 .counter {
 	display: flex;
 	align-items: center;
-	color: kv-color('neutral-4');
+	color: var(--text-container-neutral-subtle, #{kv-color('neutral-4')});
 	@include body-xs-regular;
 }

--- a/packages/ui-components/src/components/time-picker/readme.md
+++ b/packages/ui-components/src/components/time-picker/readme.md
@@ -112,7 +112,10 @@ graph TD;
   kv-select-multi-options --> kv-select-create-option
   kv-select-multi-options --> kv-select-shortcuts-label
   kv-select --> kv-search
+  kv-select --> kv-action-button-text
   kv-search --> kv-text-field
+  kv-action-button-text --> kv-action-button
+  kv-action-button-text --> kv-icon
   kv-illustration-message --> kv-illustration
   kv-select-create-option --> kv-text-field
   kv-select-create-option --> kv-action-button-icon
@@ -126,8 +129,6 @@ graph TD;
   kv-calendar --> kv-icon
   kv-calendar --> kv-calendar-day
   kv-switch-button --> kv-icon
-  kv-action-button-text --> kv-action-button
-  kv-action-button-text --> kv-icon
   style kv-time-picker fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/ui-components/src/components/virtualized-list/virtualized-list.scss
+++ b/packages/ui-components/src/components/virtualized-list/virtualized-list.scss
@@ -7,6 +7,7 @@
 	 */
 	--virtualized-list-max-height: auto;
 	--virtualized-list-min-height: auto;
+	--virtualized-list-padding: var(--spacing-xl, #{$spacing-3x}) 0;
 
 	display: block;
 	height: 100%;
@@ -16,7 +17,7 @@
 		max-height: var(--virtualized-list-max-height);
 		min-height: var(--virtualized-list-min-height);
 
-		padding: $spacing-3x 0;
+		padding: var(--virtualized-list-padding);
 		height: 100%;
 		width: 100%;
 		display: block;


### PR DESCRIPTION
Components:
- Migrate select, select-option, select-create-option, select-multi-options, select-shortcuts-label, multi-select-dropdown and single-select-dropdown to design tokens
- Replace select footer action divs with kv-action-button-text component
- Conditionally render select-option right-content only when it has content

Mixins:
- Add kelvin-vertical-divider and kelvin-horizontal-divider mixins

Design tokens:
- Add new semantic tokens for select, virtualized-list and slider-list
- Add background-persistent-tab, border-persistent-tab and icon-persistent-tab tokens
- Add text-on-color-alert tokens
- Add spacing tokens (spacing-none, spacing-3xs)
- Add color primitives: teal-400, gray-850