### PR TITLE
fix(inline-editable-field): use componentDidLoad and fix null safety issues

### DIFF
--- a/packages/ui-components/src/components/inline-editable-field/inline-editable-field.tsx
+++ b/packages/ui-components/src/components/inline-editable-field/inline-editable-field.tsx
@@ -83,6 +83,8 @@ export class KvInlineEditableField {
 
 	@Watch('disabled')
 	handleDisableChange(state) {
+		if (!this.slotEl) return;
+
 		if (state) {
 			this.destroyEditableContent();
 		} else {
@@ -157,20 +159,26 @@ export class KvInlineEditableField {
 		this.slotEl.removeEventListener('input', this.checkSaveBtnDisabled);
 	}
 
-	connectedCallback() {
+	componentDidLoad() {
 		if (this.disabled) {
 			return;
 		}
 
-		if (this.el.children.length !== 1) {
-			throw new Error('Inline editable field must have exactly one child element to be editable');
+		// Filter out the actions div and ensure exactly one editable child element exists
+		const children = Array.from(this.el.children);
+		const slottedElements = children.filter(child => !child.classList.contains('inline-editable-field-actions'));
+
+		if (slottedElements.length !== 1) {
+			console.warn('Inline editable field must have exactly one child element to be editable');
+			return;
 		}
 
-		this.slotEl = this.el.children[0] as HTMLElement;
+		this.slotEl = slottedElements[0] as HTMLElement;
 		this.initializeEditableContent();
 	}
 
 	disconnectedCallback() {
+		clearTimeout(this.timeoutID);
 		this.destroyEditableContent();
 	}
 


### PR DESCRIPTION
## Summary

- Changed lifecycle method from `connectedCallback` to `componentDidLoad` for proper DOM initialization timing
- Improved slot element detection to filter out the internally-rendered actions div
- Added defensive null checks to prevent race conditions and crashes
- Fixed memory leak by clearing timeout on component cleanup
- Improved code comment clarity

## Changes

### Lifecycle Fix
- **Before**: Used `connectedCallback` which runs before first render
- **After**: Uses `componentDidLoad` which runs after DOM is ready
- **Why**: In light DOM components, the actions div is rendered alongside slotted content, so we need to wait for render to complete

### Slot Detection
- **Before**: `this.el.children.length !== 1` (counted all children)
- **After**: Filters out elements with class `inline-editable-field-actions` 
- **Why**: The component renders its own actions div, so we need to find only the slotted content

### Null Safety
- Added null check in `handleDisableChange` watcher to prevent errors if disabled changes before initialization
- Added `clearTimeout` in `disconnectedCallback` to prevent memory leaks from pending blur timeouts

### Error Handling
- Changed from throwing error to `console.warn` for better framework compatibility
- Allows graceful degradation instead of crashing the application

## Test plan

- [ ] Component initializes correctly with one child element
- [ ] Component warns (doesn't crash) with invalid structure
- [ ] Disabled prop changes don't cause errors
- [ ] No memory leaks when component is destroyed during blur timeout
- [ ] Works correctly in React/framework environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)