### PR TITLE
fix(ci): support beta prerelease versions in publish workflow

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -1,4 +1,4 @@
-name: publish-alpha
+name: publish-prerelease
 
 on:
     push:
@@ -41,8 +41,35 @@ jobs:
               with:
                   node-version: ${{ matrix.node }}
 
+            - name: Get Branch Name
+              run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+
+            - name: Validate Branch
+              run: |
+                  if [ "$BRANCH_NAME" != "alpha" ] && [ "$BRANCH_NAME" != "beta" ]; then
+                    echo "Error: This workflow can only run on 'alpha' or 'beta' branches."
+                    echo "Current branch: $BRANCH_NAME"
+                    exit 1
+                  fi
+
+            - name: Set Prerelease Identifier
+              run: |
+                  if [ "$BRANCH_NAME" = "beta" ]; then
+                    echo "PRERELEASE_ID=beta" >> $GITHUB_ENV
+                  else
+                    echo "PRERELEASE_ID=alpha" >> $GITHUB_ENV
+                  fi
+
             - name: Get Tag
-              run: echo "LAST_VERSION=$(git describe --tags `git rev-list --tags --max-count=1` | tr -d v)" >> $GITHUB_ENV
+              run: |
+                  if [ "$BRANCH_NAME" = "beta" ]; then
+                    # On beta branch: exclude alpha tags
+                    LAST_VERSION=$(git tag -l --sort=-version:refname | grep -v '\-alpha' | head -n 1 | tr -d v)
+                  else
+                    # On alpha branch: exclude beta tags
+                    LAST_VERSION=$(git tag -l --sort=-version:refname | grep -v '\-beta' | head -n 1 | tr -d v)
+                  fi
+                  echo "LAST_VERSION=${LAST_VERSION}" >> $GITHUB_ENV
 
             - name: Get Current Version
               run: |
@@ -54,23 +81,23 @@ jobs:
               run: |
                   sed -ie "s/\(\"version\": \"\).[^\"]*/\1$LAST_VERSION/" lerna.json
                   git add lerna.json
-                  git commit -m 'chore(release): publish alpha version [skip ci]'
+                  git commit -m "chore(release): publish $PRERELEASE_ID version [skip ci]"
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Generate Versions (Amend)
               if: env.CURRENT_VERSION != env.LAST_VERSION
               run: |
-                  pnpm lerna version prerelease --yes --conventional-commits --conventional-prerelease --no-changelog --amend --force-publish=*
-                  git push origin alpha --force
+                  pnpm lerna version prerelease --yes --conventional-commits --conventional-prerelease --preid=$PRERELEASE_ID --no-changelog --amend --force-publish=*
+                  git push origin $BRANCH_NAME --force
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Generate Versions
               if: env.CURRENT_VERSION == env.LAST_VERSION
               run: |
-                  pnpm lerna version prerelease --yes --conventional-commits --conventional-prerelease --no-changelog --force-publish=*
-                  git push origin alpha --force
+                  pnpm lerna version prerelease --yes --conventional-commits --conventional-prerelease --preid=$PRERELEASE_ID --no-changelog --force-publish=*
+                  git push origin $BRANCH_NAME --force
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/packages/ui-components/src/components/inline-editable-field/readme.md
+++ b/packages/ui-components/src/components/inline-editable-field/readme.md
@@ -36,14 +36,6 @@ Type: `Promise<void>`
 
 
 
-## CSS Custom Properties
-
-| Name                  | Description                                      |
-| --------------------- | ------------------------------------------------ |
-| `--margin-left-right` | Margin left and right of the editable container. |
-| `--margin-top-bottom` | Margin top and bottom of the editable container. |
-
-
 ## Dependencies
 
 ### Depends on


### PR DESCRIPTION
## Summary
- Add branch name detection and prerelease identifier logic to publish-alpha workflow
- Filter tags to exclude opposite prerelease types (alpha excludes beta tags, beta excludes alpha tags)
- Make git push and lerna version commands dynamic based on branch
- Update commit messages to reflect actual prerelease type

## Changes
- **Get Branch Name**: Extracts the current branch name from `GITHUB_REF`
- **Set Prerelease Identifier**: Sets `PRERELEASE_ID` to `beta` or `alpha` based on branch
- **Get Tag**: Filters tags based on branch to get the correct base version
  - Beta branch: Excludes `-alpha` tags, uses latest stable or beta tag
  - Alpha branch: Excludes `-beta` tags, uses latest stable or alpha tag
- **Dynamic Commands**: Uses `$PRERELEASE_ID` and `$BRANCH_NAME` variables in lerna and git commands

## Result
- Beta branch will now generate versions like `1.2.3-beta.0`, `1.2.3-beta.1`, etc.
- Alpha branch continues to generate versions like `1.2.3-alpha.0`, `1.2.3-alpha.1`, etc.
- Each prerelease track is independent and properly versioned

## Test plan
- [ ] Verify workflow runs successfully on beta branch
- [ ] Verify beta versions are generated correctly (e.g., `1.2.3-beta.0`)
- [ ] Verify workflow still works on alpha branch
- [ ] Verify alpha versions continue to be generated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)