### PR TITLE
feat(breadcrumb-item, link, text-area): refactor breadcrumb to use kv-link and migrate text-area to design tokens

### DIFF
--- a/apps/react-storybook/src/components/navigation/breadcrumbs/breadcrumb-list/BreadcrumbList.stories.tsx
+++ b/apps/react-storybook/src/components/navigation/breadcrumbs/breadcrumb-list/BreadcrumbList.stories.tsx
@@ -2,7 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import {
 	KvBreadcrumbList,
-	KvBreadcrumbItem
+	KvBreadcrumbItem,
+	KvLink
 } from "@kelvininc/react-ui-components/client";
 
 const meta = {
@@ -12,7 +13,11 @@ const meta = {
 		<KvBreadcrumbList {...args}>
 			<KvBreadcrumbItem label="First label here"></KvBreadcrumbItem>
 			<KvBreadcrumbItem label="Second label here"></KvBreadcrumbItem>
-			<KvBreadcrumbItem label="Last label here" active></KvBreadcrumbItem>
+			<KvBreadcrumbItem active>
+				<a>
+					<KvLink label="Last label here" />
+				</a>
+			</KvBreadcrumbItem>
 		</KvBreadcrumbList>
 	)
 } satisfies Meta<typeof KvBreadcrumbList>;

--- a/packages/ui-components/src/components/breadcrumb-item/breadcrumb-item.scss
+++ b/packages/ui-components/src/components/breadcrumb-item/breadcrumb-item.scss
@@ -1,34 +1,14 @@
 @use '../../assets/styles' as *;
 
-:host {
-	/**
-	 * @prop --breadcrumb-item-default-color: Breadcrumb's item default color.
-	 * @prop --breadcrumb-item-hover-color: Breadcrumb's item hover color.
-	 * @prop --breadcrumb-item-active-color: Breadcrumb's item active color.
-	 */
-
-	--breadcrumb-item-default-color: #{kv-color('neutral-4')};
-	--breadcrumb-item-hover-color: #{kv-color('neutral-3')};
-	--breadcrumb-item-active-color: #{kv-color('neutral-2')};
-}
-
 .breadcrumb-item {
-	@include body-m-regular();
-	cursor: pointer;
 	user-select: none;
 
-	color: var(--breadcrumb-item-default-color);
-	text-decoration: none;
-
-	&:hover {
-		text-decoration: underline;
-		color: var(--breadcrumb-item-hover-color);
-	}
-
 	&--active {
-		@include body-m-semibold();
-		pointer-events: none;
-
-		color: var(--breadcrumb-item-active-color);
+		kv-link,
+		::slotted(*) {
+			--kv-link-pointer-events: none;
+			--kv-link-cursor: default;
+			--kv-link-font-weight: 600;
+		}
 	}
 }

--- a/packages/ui-components/src/components/breadcrumb-item/breadcrumb-item.tsx
+++ b/packages/ui-components/src/components/breadcrumb-item/breadcrumb-item.tsx
@@ -8,7 +8,7 @@ import { IBreadcrumbItem, IBreadcrumbItemEvents } from './breadcrumb-item.types'
 })
 export class KvBreadcrumbItem implements IBreadcrumbItem, IBreadcrumbItemEvents {
 	/** @inheritdoc */
-	@Prop({ reflect: true }) label!: string;
+	@Prop({ reflect: true }) label: string;
 	/** @inheritdoc */
 	@Prop({ reflect: true }) active?: boolean;
 
@@ -32,7 +32,7 @@ export class KvBreadcrumbItem implements IBreadcrumbItem, IBreadcrumbItemEvents 
 					}}
 					onClick={this.onItemClick}
 				>
-					<slot>{this.label}</slot>
+					<slot>{this.label && <kv-link label={this.label} />}</slot>
 				</div>
 			</Host>
 		);

--- a/packages/ui-components/src/components/breadcrumb-item/breadcrumb-item.types.ts
+++ b/packages/ui-components/src/components/breadcrumb-item/breadcrumb-item.types.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from '@stencil/core';
 
 export interface IBreadcrumbItem {
-	/** (required) The text to display on the breadcrumb */
-	label: string;
+	/** (optional) The text to display on the breadcrumb */
+	label?: string;
 	/** (optional) Sets this breadcrumb styling to be the active one (usually the last one) */
 	active?: boolean;
 }

--- a/packages/ui-components/src/components/breadcrumb-item/readme.md
+++ b/packages/ui-components/src/components/breadcrumb-item/readme.md
@@ -22,10 +22,10 @@ export const KvBreadcrumbItemExample: React.FC = () => (
 
 ## Properties
 
-| Property             | Attribute | Description                                                                         | Type      | Default     |
-| -------------------- | --------- | ----------------------------------------------------------------------------------- | --------- | ----------- |
-| `active`             | `active`  | (optional) Sets this breadcrumb styling to be the active one (usually the last one) | `boolean` | `undefined` |
-| `label` _(required)_ | `label`   | (required) The text to display on the breadcrumb                                    | `string`  | `undefined` |
+| Property | Attribute | Description                                                                         | Type      | Default     |
+| -------- | --------- | ----------------------------------------------------------------------------------- | --------- | ----------- |
+| `active` | `active`  | (optional) Sets this breadcrumb styling to be the active one (usually the last one) | `boolean` | `undefined` |
+| `label`  | `label`   | (optional) The text to display on the breadcrumb                                    | `string`  | `undefined` |
 
 
 ## Events
@@ -35,24 +35,21 @@ export const KvBreadcrumbItemExample: React.FC = () => (
 | `breadcrumbItemClick` | Emitted when the user clicks on the breadcrumb | `CustomEvent<IBreadcrumbItem>` |
 
 
-## CSS Custom Properties
-
-| Name                              | Description                      |
-| --------------------------------- | -------------------------------- |
-| `--breadcrumb-item-active-color`  | Breadcrumb's item active color.  |
-| `--breadcrumb-item-default-color` | Breadcrumb's item default color. |
-| `--breadcrumb-item-hover-color`   | Breadcrumb's item hover color.   |
-
-
 ## Dependencies
 
 ### Used by
 
  - [kv-breadcrumb](../breadcrumb)
 
+### Depends on
+
+- [kv-link](../link)
+
 ### Graph
 ```mermaid
 graph TD;
+  kv-breadcrumb-item --> kv-link
+  kv-link --> kv-icon
   kv-breadcrumb --> kv-breadcrumb-item
   style kv-breadcrumb-item fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/ui-components/src/components/breadcrumb-item/test/__snapshots__/breadcrumb-item.spec.tsx.snap
+++ b/packages/ui-components/src/components/breadcrumb-item/test/__snapshots__/breadcrumb-item.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`KvBreadcrumbItem (unit tests) when the component loads should match the
   <template shadowrootmode="open">
     <div class="breadcrumb-item breadcrumb-item--active">
       <slot>
-        Awesome Label
+        <kv-link label="Awesome Label"></kv-link>
       </slot>
     </div>
   </template>

--- a/packages/ui-components/src/components/breadcrumb-list/breadcrumb-list.scss
+++ b/packages/ui-components/src/components/breadcrumb-list/breadcrumb-list.scss
@@ -2,11 +2,11 @@
 
 :host {
 	/**
-	 * @prop --breadcrumb-seperator-color: Breadcrumb's seperator color.
-	 * @prop --breadcrumb-seperator-content: Breadcrumb's seperator content.
+	 * @prop --breadcrumb-separator-color: Breadcrumb's separator color.
+	 * @prop --breadcrumb-separator-content: Breadcrumb's separator content.
 	 */
 
-	--breadcrumb-separator-color: #{kv-color('neutral-4')};
+	--breadcrumb-separator-color: var(--text-surface-neutral-secondary);
 	--breadcrumb-separator-content: '/';
 }
 
@@ -22,7 +22,7 @@
 			@include body-m-regular();
 			display: inline-block;
 			content: var(--breadcrumb-separator-content);
-			margin: 0 $spacing-2x;
+			margin: 0 var(--spacing-md);
 			color: var(--breadcrumb-separator-color);
 		}
 	}

--- a/packages/ui-components/src/components/breadcrumb/readme.md
+++ b/packages/ui-components/src/components/breadcrumb/readme.md
@@ -56,6 +56,8 @@ export const KvBreadcrumbExample: React.FC = (props) => (
 graph TD;
   kv-breadcrumb --> kv-breadcrumb-list
   kv-breadcrumb --> kv-breadcrumb-item
+  kv-breadcrumb-item --> kv-link
+  kv-link --> kv-icon
   style kv-breadcrumb fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/ui-components/src/components/link/link.scss
+++ b/packages/ui-components/src/components/link/link.scss
@@ -16,8 +16,13 @@
 			gap: var(--link-gap-default);
 			outline: none;
 
-			@include body-m-semibold;
+			@include body-m-regular;
 			@include clickable;
+
+			//Required due the breadcrumb item active state
+			font-weight: var(--kv-link-font-weight, var(--font-weight-regular));
+			pointer-events: var(--kv-link-pointer-events, all);
+			cursor: var(--kv-link-cursor, pointer);
 
 			color: var(--link-label-default);
 			text-decoration: none;

--- a/packages/ui-components/src/components/link/link.tsx
+++ b/packages/ui-components/src/components/link/link.tsx
@@ -59,7 +59,7 @@ export class KvLink implements ILink {
 						part="label"
 					>
 						<slot name="left">{this.leftIcon && <kv-icon name={this.leftIcon} />}</slot>
-						{this.label}
+						{this.label && <span part="label-text">{this.label}</span>}
 						<slot name="right">{this.rightIcon && <kv-icon name={this.rightIcon} />}</slot>
 					</a>
 					{this.subtitle && <div class="subtitle">{this.subtitle}</div>}

--- a/packages/ui-components/src/components/link/readme.md
+++ b/packages/ui-components/src/components/link/readme.md
@@ -103,6 +103,7 @@ export class SwichButtonExample {
 
 ### Used by
 
+ - [kv-breadcrumb-item](../breadcrumb-item)
  - [kv-radio-list-item](../radio-list-item)
 
 ### Depends on
@@ -113,6 +114,7 @@ export class SwichButtonExample {
 ```mermaid
 graph TD;
   kv-link --> kv-icon
+  kv-breadcrumb-item --> kv-link
   kv-radio-list-item --> kv-link
   style kv-link fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/ui-components/src/components/link/test/__snapshots__/link.spec.tsx.snap
+++ b/packages/ui-components/src/components/link/test/__snapshots__/link.spec.tsx.snap
@@ -6,7 +6,9 @@ exports[`KvLink (unit tests) when label and subtitle is provided should match th
     <div class="link-container" part="container">
       <a class="label" part="label" tabindex="0">
         <slot name="left"></slot>
-        Hello
+        <span part="label-text">
+          Hello
+        </span>
         <slot name="right"></slot>
       </a>
       <div class="subtitle">
@@ -23,7 +25,9 @@ exports[`KvLink (unit tests) when only label is provided should match the snapsh
     <div class="link-container" part="container">
       <a class="label" part="label" tabindex="0">
         <slot name="left"></slot>
-        Hello
+        <span part="label-text">
+          Hello
+        </span>
         <slot name="right"></slot>
       </a>
     </div>

--- a/packages/ui-components/src/components/text-area/test/__snapshots__/text-area.spec.tsx.snap
+++ b/packages/ui-components/src/components/text-area/test/__snapshots__/text-area.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`Text Area (unit tests) when initialized with icon should match the snap
 <kv-text-area counter="" icon="kv-notes" max-char-length="100">
   <template shadowrootmode="open">
     <div class="text-area-container">
-      <kv-icon class="left-icon" customclass="icon-20" name="kv-notes"></kv-icon>
+      <kv-icon name="kv-notes"></kv-icon>
       <div class="text-area">
         <div class="text-area-wrapper">
           <div class="input placeholder" contenteditable=""></div>

--- a/packages/ui-components/src/components/text-area/text-area.scss
+++ b/packages/ui-components/src/components/text-area/text-area.scss
@@ -5,17 +5,21 @@
 	* @prop --height-default: The height of the text area when is not focused.
 	* @prop --height-active: The height of the text are when is focused.
 	*/
-	--height-default: 36px;
+	--height-default: var(--text-area-height-default, 36px);
 	--height-active: 100px;
 }
 
 .text-area-container {
 	display: flex;
-	gap: $spacing-2x;
+	gap: var(--text-area-gap-default);
 	align-items: flex-start;
 
-	.left-icon {
-		margin-top: $spacing-2x;
+	kv-icon {
+		--icon-color: var(--text-area-icon-color-default);
+		--icon-width: var(--text-area-icon-size-default);
+		--icon-height: var(--text-area-icon-size-default);
+
+		margin-top: var(--text-area-gap-default);
 	}
 
 	.text-area {
@@ -24,12 +28,12 @@
 		display: flex;
 		flex-direction: column;
 		flex: 1;
-		gap: $spacing-2x;
+		gap: var(--spacing-md);
 
 		.text-area-wrapper {
-			padding: $spacing-2x $spacing-3x;
-			border: 1px solid kv-color('neutral-7');
-			border-radius: 4px;
+			padding: var(--text-area-padding-y-default) var(--text-area-padding-x-default);
+			border: var(--text-area-border-thickness-default) solid var(--text-area-border-color-default);
+			border-radius: var(--text-area-radius-default);
 			height: var(--height-default);
 			overflow: auto;
 			transition: height 0.25s ease-in-out;
@@ -38,7 +42,7 @@
 				@include body-m-regular;
 				outline: none;
 				height: inherit;
-				color: kv-color('neutral-4');
+				color: var(--text-area-text-default);
 				overflow-wrap: anywhere;
 
 				&.placeholder::before {
@@ -46,19 +50,29 @@
 				}
 			}
 
-			&:hover,
-			&:has(.input:focus),
 			&.has-text {
-				border: 1px solid kv-color('neutral-6');
+				height: var(--height-active);
+				border-color: var(--text-area-border-color-filled);
 
 				.input {
-					color: kv-color('neutral-2');
+					color: var(--text-area-text-filled);
 				}
 			}
 
-			&:has(.input:focus),
-			&.has-text {
-				height: var(--height-active);
+			&:hover {
+				border-color: var(--text-area-border-color-hover);
+
+				.input {
+					color: var(--text-area-text-hover);
+				}
+			}
+
+			&:has(.input:focus) {
+				border-color: var(--text-area-border-color-selected);
+
+				.input {
+					color: var(--text-area-text-selected);
+				}
 			}
 
 			&:hover:not(:has(.input:focus)) {
@@ -66,32 +80,27 @@
 			}
 		}
 
-
 		&:has(.input:focus) .character-counter {
 			display: block;
 		}
 
 		.character-counter {
 			@include body-s-regular;
-			color: kv-color('neutral-4');
-			margin-left: $spacing-3x;
+			color: var(--text-area-helper-text-default);
+			margin-left: var(--spacing-xl);
 			display: none;
 		}
 	}
 
-	&.disabled {
-		.text-area {
-			.text-area-wrapper {
-				border-color: kv-color('neutral-5');
+	&.disabled .text-area .text-area-wrapper {
+		border-color: var(--border-interactive-input-disabled);
 
-				.input {
-					color: kv-color('neutral-5');
-				}
+		.input {
+			color: var(--text-interactive-input-disabled);
+		}
 
-				&:hover:not(:has(.input:focus)) {
-					cursor: not-allowed;
-				}
-			}
+		&:hover:not(:has(.input:focus)) {
+			cursor: not-allowed;
 		}
 	}
 }

--- a/packages/ui-components/src/components/text-area/text-area.tsx
+++ b/packages/ui-components/src/components/text-area/text-area.tsx
@@ -93,7 +93,7 @@ export class KvTextArea implements ITextArea, ITextAreaEvents {
 		return (
 			<Host>
 				<div class={{ 'text-area-container': true, 'disabled': this.disabled }}>
-					{this.icon && <kv-icon name={this.icon} customClass="icon-20" class="left-icon" />}
+					{this.icon && <kv-icon name={this.icon} />}
 					<div class="text-area" onClick={this.focusTextArea}>
 						<div
 							class={{


### PR DESCRIPTION
- Refactor kv-breadcrumb-item to render kv-link internally and support slotted content
- Make label prop optional on breadcrumb-item
- Add CSS custom properties (--kv-link-pointer-events, --kv-link-cursor, --kv-link-font-weight) to kv-link for external styling through shadow DOM
- Migrate kv-text-area styles from legacy kv-color/spacing to design token system
- Migrate kv-breadcrumb-list separator to semantic tokens