### PR TITLE
feat(tab-item): add icon support to secondary tab items

### DIFF
--- a/apps/react-storybook/src/components/navigation/tabs/tab-item/TabItem.stories.tsx
+++ b/apps/react-storybook/src/components/navigation/tabs/tab-item/TabItem.stories.tsx
@@ -42,6 +42,23 @@ export const Secondary: Story = {
 	}
 };
 
+export const SecondaryWithIcon: Story = {
+	args: {
+		tabKey: "tab1",
+		label: "Tab Item",
+		icon: EIconName.Add,
+		type: ETabItemType.Secondary
+	}
+};
+
+export const SecondaryOnlyIcon: Story = {
+	args: {
+		tabKey: "tab1",
+		icon: EIconName.Add,
+		type: ETabItemType.Secondary
+	}
+};
+
 export const SecondaryWithBadge: Story = {
 	render: function Renderer(args) {
 		return (

--- a/apps/react-storybook/src/components/navigation/tabs/tab-navigation/TabNavigation.stories.tsx
+++ b/apps/react-storybook/src/components/navigation/tabs/tab-navigation/TabNavigation.stories.tsx
@@ -99,3 +99,75 @@ export const SecondaryType: Story = {
 		type: ETabItemType.Secondary
 	}
 };
+
+export const SecondaryTypeOnlyIcon: Story = {
+	args: {
+		tabs: [
+			{
+				tabKey: "device",
+				icon: EIconName.Device
+			},
+			{
+				tabKey: "place",
+				icon: EIconName.Place
+			},
+			{
+				tabKey: "properties",
+				icon: EIconName.Properties,
+				disabled: true
+			},
+			{
+				tabKey: "world",
+				icon: EIconName.World
+			}
+		],
+		selectedTabKey: "device",
+		type: ETabItemType.Secondary
+	}
+};
+
+export const SecondaryTypeOnlyIconVertical: Story = {
+	render: function Renderer(args) {
+		const [, updateArgs] = useArgs();
+
+		const handleTabChange = (event: CustomEvent<string>) => {
+			updateArgs({ selectedTabKey: event.detail });
+		};
+
+		return (
+			<KvTabNavigation
+				style={{
+					"--secondary-tab-list-direction": "column",
+					"--secondary-items-align": "flex-start"
+				}}
+				tabs={args.tabs}
+				selectedTabKey={args.selectedTabKey}
+				type={args.type}
+				onTabChange={handleTabChange}
+			/>
+		);
+	},
+	args: {
+		tabs: [
+			{
+				tabKey: "device",
+				icon: EIconName.Device
+			},
+			{
+				tabKey: "place",
+				icon: EIconName.Place
+			},
+			{
+				tabKey: "properties",
+				icon: EIconName.Properties,
+				disabled: true
+			},
+			{
+				tabKey: "world",
+				icon: EIconName.World
+			}
+		],
+		selectedTabKey: "device",
+		type: ETabItemType.Secondary
+	}
+};

--- a/packages/ui-components/src/components/breadcrumb-list/readme.md
+++ b/packages/ui-components/src/components/breadcrumb-list/readme.md
@@ -40,8 +40,8 @@ export const KvBreadcrumbListExample: React.FC = () => (
 
 | Name                             | Description                     |
 | -------------------------------- | ------------------------------- |
-| `--breadcrumb-seperator-color`   | Breadcrumb's seperator color.   |
-| `--breadcrumb-seperator-content` | Breadcrumb's seperator content. |
+| `--breadcrumb-separator-color`   | Breadcrumb's separator color.   |
+| `--breadcrumb-separator-content` | Breadcrumb's separator content. |
 
 
 ## Dependencies

--- a/packages/ui-components/src/components/icon/readme.md
+++ b/packages/ui-components/src/components/icon/readme.md
@@ -79,6 +79,7 @@ export const SvgIconExample: React.FC = () => (
  - [kv-select-shortcuts-label](../select-shortcuts-label)
  - [kv-step-indicator](../step-indicator)
  - [kv-switch-button](../switch-button)
+ - [kv-tab-item](../tab-item)
  - [kv-tag](../tag)
  - [kv-tag-status](../tag-status)
  - [kv-text-area](../text-area)
@@ -112,6 +113,7 @@ graph TD;
   kv-select-shortcuts-label --> kv-icon
   kv-step-indicator --> kv-icon
   kv-switch-button --> kv-icon
+  kv-tab-item --> kv-icon
   kv-tag --> kv-icon
   kv-tag-status --> kv-icon
   kv-text-area --> kv-icon

--- a/packages/ui-components/src/components/link/readme.md
+++ b/packages/ui-components/src/components/link/readme.md
@@ -93,10 +93,11 @@ export class SwichButtonExample {
 
 ## Shadow Parts
 
-| Part          | Description          |
-| ------------- | -------------------- |
-| `"container"` | The link's container |
-| `"label"`     | The link's label     |
+| Part           | Description          |
+| -------------- | -------------------- |
+| `"container"`  | The link's container |
+| `"label"`      | The link's label     |
+| `"label-text"` |                      |
 
 
 ## Dependencies

--- a/packages/ui-components/src/components/tab-item/readme.md
+++ b/packages/ui-components/src/components/tab-item/readme.md
@@ -43,7 +43,8 @@ export const TabItemExample: React.FC = () => (
 | `customClass`         | `custom-class`      | (optional) Additional classes to apply for custom CSS. If multiple classes are provided they should be separated by spaces. It is also valid to provide CssClassMap with boolean logic. | `CssClassMap \| string \| string[]`              | `''`                   |
 | `customStyle`         | `custom-style`      | (optional) Additional style to apply for custom CSS.                                                                                                                                    | `{ [key: string]: string; }`                     | `undefined`            |
 | `disabled`            | `disabled`          | (optional) To disable this tab                                                                                                                                                          | `boolean`                                        | `false`                |
-| `label` _(required)_  | `label`             | (required) Name to show in UI for this tab                                                                                                                                              | `string`                                         | `undefined`            |
+| `icon`                | `icon`              | (optional) Icon to show in UI for this tab                                                                                                                                              | `EIconName`                                      | `undefined`            |
+| `label`               | `label`             | (optional) Name to show in UI for this tab                                                                                                                                              | `string`                                         | `undefined`            |
 | `selected`            | `selected`          | (optional) To set this tab as the selected one                                                                                                                                          | `boolean`                                        | `false`                |
 | `tabKey` _(required)_ | `tab-key`           | (required) A unique identifier for this tab                                                                                                                                             | `number \| string`                               | `undefined`            |
 | `type`                | `type`              | (optional) Sets this tab item to a different styling configuration                                                                                                                      | `ETabItemType.Primary \| ETabItemType.Secondary` | `ETabItemType.Primary` |
@@ -62,9 +63,14 @@ export const TabItemExample: React.FC = () => (
 
  - [kv-tab-navigation](../tab-navigation)
 
+### Depends on
+
+- [kv-icon](../icon)
+
 ### Graph
 ```mermaid
 graph TD;
+  kv-tab-item --> kv-icon
   kv-tab-navigation --> kv-tab-item
   style kv-tab-item fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/ui-components/src/components/tab-item/tab-item.scss
+++ b/packages/ui-components/src/components/tab-item/tab-item.scss
@@ -37,8 +37,15 @@
 			height: var(--tab-secondary-height-default);
 			padding: var(--tab-secondary-padding-y-default) var(--tab-secondary-padding-x-default);
 			box-sizing: border-box;
-			border-radius: var(--tab-secondary-radius-default, 4px);
+			border: var(--tab-secondary-border-thickness-default) solid var(--transparent); 
+			border-radius: var(--tab-secondary-radius-default);
 			align-self: center;
+
+			kv-icon {
+				--icon-color: var(--icon-tab-icon-color-default);
+				--icon-width: var(--icon-tab-icon-size-default);
+				--icon-height: var(--icon-tab-icon-size-default);
+			}
 
 			.label {
 				@include body-m-semibold;
@@ -48,6 +55,10 @@
 			&:hover:not(.disabled) {
 				background: var(--tab-secondary-background-hover);
 
+				kv-icon {
+					--icon-color: var(--icon-tab-icon-color-hover);
+				}
+
 				.label {
 					color: var(--tab-secondary-label-hover);
 				}
@@ -55,6 +66,11 @@
 
 			&.selected:not(:hover):not(.disabled) {
 				background: var(--tab-secondary-background-selected);
+				border-color: var(--tab-secondary-border-color-default);
+
+				kv-icon {
+					--icon-color: var(--icon-tab-icon-color-selected);
+				}
 
 				.label {
 					color: var(--tab-secondary-label-selected);
@@ -65,9 +81,35 @@
 				cursor: not-allowed;
 				user-select: none;
 				background: var(--tab-secondary-background-disabled);
+				border-color: var(--tab-secondary-border-color-disabled);
+
+				kv-icon {
+					--icon-color: var(--icon-tab-icon-color-disabled);
+				}
 
 				.label {
 					color: var(--tab-secondary-label-disabled);
+				}
+			}
+
+			&.only-icon {
+				height: var(--icon-tab-height-default);
+				padding: var(--icon-tab-padding-y-default) var(--icon-tab-padding-x-default);
+				border: var(--icon-tab-border-thickness-default) solid var(--transparent); 
+				border-radius: var(--icon-tab-radius-default);
+
+				&:hover:not(.disabled) { 
+					background: var(--icon-tab-background-hover);
+				}
+
+				&.selected:not(:hover):not(.disabled) {
+					background: var(--icon-tab-background-selected);
+					border-color: var(--icon-tab-border-color-default);
+				}
+
+				&.disabled {
+					background: var(--icon-tab-background-disabled);
+					border-color: var(--icon-tab-border-color-disabled);
 				}
 			}
 		}

--- a/packages/ui-components/src/components/tab-item/tab-item.tsx
+++ b/packages/ui-components/src/components/tab-item/tab-item.tsx
@@ -2,7 +2,7 @@ import { Component, Host, h, Prop, EventEmitter, Event } from '@stencil/core';
 import { HostAttributes } from '@stencil/core/internal';
 import { throttle } from 'lodash-es';
 import { DEFAULT_THROTTLE_WAIT } from '../../config';
-import { CustomCssClass, ICustomCss } from '../../types';
+import { CustomCssClass, EIconName, ICustomCss } from '../../types';
 import { ETabItemType } from './tab-item.types';
 import { getClassMap } from '../../utils/css-class.helper';
 
@@ -16,8 +16,10 @@ export class KvTabItem implements ICustomCss {
 	@Prop() tabKey!: number | string;
 	/** (optional) Sets this tab item to a different styling configuration */
 	@Prop() type?: ETabItemType = ETabItemType.Primary;
-	/** (required) Name to show in UI for this tab */
-	@Prop() label!: string;
+	/** (optional) Name to show in UI for this tab */
+	@Prop() label?: string;
+	/** (optional) Icon to show in UI for this tab */
+	@Prop() icon?: EIconName;
 	/** (optional) To disable this tab */
 	@Prop() disabled?: boolean = false;
 	/** (optional) To set this tab as the selected one */
@@ -50,6 +52,7 @@ export class KvTabItem implements ICustomCss {
 						'tab-item-container': true,
 						'selected': this.selected,
 						'disabled': this.disabled,
+						'only-icon': this.type === ETabItemType.Secondary && this.icon && !this.label,
 						[this.type]: true,
 						...getClassMap(this.customClass)
 					}}
@@ -57,7 +60,8 @@ export class KvTabItem implements ICustomCss {
 					style={this.customStyle}
 					{...this.customAttributes}
 				>
-					<div class="label">{this.label}</div>
+					{this.icon && this.type === ETabItemType.Secondary && <kv-icon name={this.icon} />}
+					{this.label && <div class="label">{this.label}</div>}
 					<slot name="right-slot"></slot>
 				</div>
 			</Host>

--- a/packages/ui-components/src/components/tab-navigation/readme.md
+++ b/packages/ui-components/src/components/tab-navigation/readme.md
@@ -69,6 +69,7 @@ graph TD;
   kv-tab-navigation --> kv-tab-item
   kv-tab-navigation --> kv-badge
   kv-tab-navigation --> kv-tag-status
+  kv-tab-item --> kv-icon
   kv-tag-status --> kv-icon
   style kv-tab-navigation fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/ui-components/src/components/tab-navigation/tab-navigation.scss
+++ b/packages/ui-components/src/components/tab-navigation/tab-navigation.scss
@@ -12,6 +12,8 @@ $tab-height: 34px;
 	--tab-list-bg-color: transparent;
 	--tab-list-indicator-color: var(--tab-primary-border-color-selected);
 	--tab-list-divider-color: var(--tab-primary-border-color-default);
+	--secondary-tab-list-direction: row;
+	--secondary-items-align: center;
 
 	.primary {
 		position: relative;
@@ -39,7 +41,8 @@ $tab-height: 34px;
 	.secondary {
 		display: flex;
 		gap: var(--spacing-xl);
-		align-items: center;
+		align-items: var(--secondary-items-align);
+		flex-direction: var(--secondary-tab-list-direction);
 	}
 
 	kv-badge {

--- a/packages/ui-components/src/components/tab-navigation/tab-navigation.tsx
+++ b/packages/ui-components/src/components/tab-navigation/tab-navigation.tsx
@@ -85,6 +85,7 @@ export class KvTabNavigation implements ITabNavigationConfig, ITabNavigationEven
 						key={item.tabKey}
 						tabKey={item.tabKey}
 						label={item.label}
+						icon={item.icon}
 						disabled={item.disabled}
 						selected={item.tabKey === this.selectedTabKey}
 						type={this.type}

--- a/packages/ui-components/src/components/tab-navigation/tab-navigation.types.ts
+++ b/packages/ui-components/src/components/tab-navigation/tab-navigation.types.ts
@@ -4,7 +4,8 @@ import { ETabItemType } from '../tab-item/tab-item.types';
 
 export interface ITabNavigationItem {
 	tabKey: number | string;
-	label: string;
+	label?: string;
+	icon?: EIconName;
 	badge?: string;
 	badgeType?: EBadgeType;
 	tagIcon?: EIconName;


### PR DESCRIPTION
- Add optional icon prop to kv-tab-item for secondary type tabs
- Support icon-only mode with dedicated sizing and styling tokens
- Add icon prop to ITabNavigationItem interface
- Expose CSS custom properties for secondary tab list direction and alignment
- Add Storybook stories for icon and icon-only tab variants