### PR TITLE
feat(text-area): add counterAlwaysVisible property

### DIFF
--- a/packages/ui-components/src/components/inline-editable-field/readme.md
+++ b/packages/ui-components/src/components/inline-editable-field/readme.md
@@ -36,6 +36,14 @@ Type: `Promise<void>`
 
 
 
+## CSS Custom Properties
+
+| Name                  | Description                                      |
+| --------------------- | ------------------------------------------------ |
+| `--margin-left-right` | Margin left and right of the editable container. |
+| `--margin-top-bottom` | Margin top and bottom of the editable container. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/ui-components/src/components/text-area/readme.md
+++ b/packages/ui-components/src/components/text-area/readme.md
@@ -53,14 +53,15 @@ export const TextAreaExample: React.FC = () => (
 
 ## Properties
 
-| Property        | Attribute         | Description                                                          | Type        | Default     |
-| --------------- | ----------------- | -------------------------------------------------------------------- | ----------- | ----------- |
-| `counter`       | `counter`         | (optional) If `true` the chars counter is displayed. Default: `true` | `boolean`   | `true`      |
-| `disabled`      | `disabled`        | (optional) If `true` the text area is disabled. Default: `false`.    | `boolean`   | `false`     |
-| `icon`          | `icon`            | (optional) Icon to show to the left of the text field                | `EIconName` | `undefined` |
-| `maxCharLength` | `max-char-length` | (optional) The maximum number of characters allowed                  | `number`    | `undefined` |
-| `placeholder`   | `placeholder`     | (optional) The placeholder to show in the text area                  | `string`    | `undefined` |
-| `text`          | `text`            | (optional) The text to show inside the text area                     | `string`    | `undefined` |
+| Property               | Attribute                | Description                                                                              | Type        | Default     |
+| ---------------------- | ------------------------ | ---------------------------------------------------------------------------------------- | ----------- | ----------- |
+| `counter`              | `counter`                | (optional) If `true` the chars counter is displayed. Default: `true`                     | `boolean`   | `true`      |
+| `counterAlwaysVisible` | `counter-always-visible` | (optional) If `true` the counter is always visible (not only on focus). Default: `false` | `boolean`   | `false`     |
+| `disabled`             | `disabled`               | (optional) If `true` the text area is disabled. Default: `false`.                        | `boolean`   | `false`     |
+| `icon`                 | `icon`                   | (optional) Icon to show to the left of the text field                                    | `EIconName` | `undefined` |
+| `maxCharLength`        | `max-char-length`        | (optional) The maximum number of characters allowed                                      | `number`    | `undefined` |
+| `placeholder`          | `placeholder`            | (optional) The placeholder to show in the text area                                      | `string`    | `undefined` |
+| `text`                 | `text`                   | (optional) The text to show inside the text area                                         | `string`    | `undefined` |
 
 
 ## Events

--- a/packages/ui-components/src/components/text-area/test/text-area.e2e.ts
+++ b/packages/ui-components/src/components/text-area/test/text-area.e2e.ts
@@ -46,4 +46,70 @@ describe('Text Area (end-to-end)', () => {
 			});
 		});
 	});
+
+	describe('when rendering with counter', () => {
+		describe('and counter is not always visible (default behavior)', () => {
+			beforeEach(async () => {
+				page = await newE2EPage({
+					html: '<kv-text-area max-char-length="100" counter="true" />'
+				});
+			});
+
+			it('should not display counter when not focused', async () => {
+				const counterElement = await page.find('kv-text-area >>> .character-counter');
+				const isVisible = await counterElement.isVisible();
+				expect(isVisible).toBe(false);
+			});
+
+			it('should display counter when focused', async () => {
+				const textAreaInputEl = await page.find('kv-text-area >>> .input');
+				await textAreaInputEl.focus();
+				await page.waitForChanges();
+
+				const counterElement = await page.find('kv-text-area >>> .character-counter');
+				const isVisible = await counterElement.isVisible();
+				expect(isVisible).toBe(true);
+			});
+		});
+
+		describe('and counter is always visible', () => {
+			beforeEach(async () => {
+				page = await newE2EPage({
+					html: '<kv-text-area max-char-length="100" counter="true" counter-always-visible="true" />'
+				});
+			});
+
+			it('should display counter when not focused', async () => {
+				const counterElement = await page.find('kv-text-area >>> .character-counter');
+				const isVisible = await counterElement.isVisible();
+				expect(isVisible).toBe(true);
+			});
+
+			it('should display counter when focused', async () => {
+				const textAreaInputEl = await page.find('kv-text-area >>> .input');
+				await textAreaInputEl.focus();
+				await page.waitForChanges();
+
+				const counterElement = await page.find('kv-text-area >>> .character-counter');
+				const isVisible = await counterElement.isVisible();
+				expect(isVisible).toBe(true);
+			});
+
+			it('should update counter as user types', async () => {
+				const textAreaInputEl = await page.find('kv-text-area >>> .input');
+				await textAreaInputEl.type('Hello');
+				await page.waitForChanges();
+
+				const counterElement = await page.find('kv-text-area >>> .character-counter');
+				const counterText = await counterElement.innerText;
+				expect(counterText).toContain('5/100');
+			});
+
+			it('should have counter-always-visible class on container', async () => {
+				const containerElement = await page.find('kv-text-area >>> .text-area-container');
+				const hasClass = containerElement.classList.contains('counter-always-visible');
+				expect(hasClass).toBe(true);
+			});
+		});
+	});
 });

--- a/packages/ui-components/src/components/text-area/text-area.scss
+++ b/packages/ui-components/src/components/text-area/text-area.scss
@@ -79,6 +79,14 @@
 		}
 	}
 
+	&.counter-always-visible {
+		.text-area {
+			.character-counter {
+				display: block;
+			}
+		}
+	}
+
 	&.disabled {
 		.text-area {
 			.text-area-wrapper {

--- a/packages/ui-components/src/components/text-area/text-area.tsx
+++ b/packages/ui-components/src/components/text-area/text-area.tsx
@@ -20,6 +20,8 @@ export class KvTextArea implements ITextArea, ITextAreaEvents {
 	/** @inheritdoc */
 	@Prop({ reflect: true }) counter?: boolean = true;
 	/** @inheritdoc */
+	@Prop({ reflect: true }) counterAlwaysVisible?: boolean = false;
+	/** @inheritdoc */
 	@Prop({ reflect: true }) disabled: boolean = false;
 
 	/** @inheritdoc */
@@ -39,7 +41,7 @@ export class KvTextArea implements ITextArea, ITextAreaEvents {
 	@State() curCharLength = getUTF8StringLength(this.text);
 	@State() showPlaceholder = !this.text ? true : false;
 
-	syncTextValues(text?: string) {
+	private syncTextValues(text?: string) {
 		if (text != null) {
 			this.inputRef.innerText = text;
 		}
@@ -92,7 +94,7 @@ export class KvTextArea implements ITextArea, ITextAreaEvents {
 	render() {
 		return (
 			<Host>
-				<div class={{ 'text-area-container': true, 'disabled': this.disabled }}>
+				<div class={{ 'text-area-container': true, 'disabled': this.disabled, 'counter-always-visible': this.counterAlwaysVisible }}>
 					{this.icon && <kv-icon name={this.icon} customClass="icon-20" class="left-icon" />}
 					<div class="text-area" onClick={this.focusTextArea}>
 						<div

--- a/packages/ui-components/src/components/text-area/types.ts
+++ b/packages/ui-components/src/components/text-area/types.ts
@@ -12,6 +12,8 @@ export interface ITextArea {
 	maxCharLength?: number;
 	/** (optional) If `true` the chars counter is displayed. Default: `true` */
 	counter?: boolean;
+	/** (optional) If `true` the counter is always visible (not only on focus). Default: `false` */
+	counterAlwaysVisible?: boolean;
 	/** (optional) If `true` the text area is disabled. Default: `false`. */
 	disabled?: boolean;
 }

--- a/packages/ui-components/src/components/text-field/readme.md
+++ b/packages/ui-components/src/components/text-field/readme.md
@@ -94,6 +94,7 @@ Type: `Promise<void>`
 | ------------------- | ------------------------------------------------------ |
 | `"badge"`           | badge rendered at the right of the text field          |
 | `"input-container"` | container that includes the input, right and left slot |
+| `"input-text"`      |                                                        |
 
 
 ## CSS Custom Properties

--- a/packages/ui-components/src/components/text-field/test/__snapshots__/text-field.spec.tsx.snap
+++ b/packages/ui-components/src/components/text-field/test/__snapshots__/text-field.spec.tsx.snap
@@ -11,9 +11,9 @@ exports[`Text Field (unit tests) when has a label should match the snapshot 1`] 
             <slot name="left-slot"></slot>
           </div>
           <div class="resize-container">
-            <span class="resize-text"></span>
+            <span class="resize-text" part="input-text"></span>
             <slot name="input">
-              <input class="resize-input" placeholder="" type="text" value="">
+              <input class="resize-input" part="input-text" placeholder="" type="text" value="">
             </slot>
           </div>
           <div class="right-slot-container">
@@ -38,9 +38,9 @@ exports[`Text Field (unit tests) when is disabled should match the snapshot 1`] 
             <slot name="left-slot"></slot>
           </div>
           <div class="resize-container">
-            <span class="resize-text"></span>
+            <span class="resize-text" part="input-text"></span>
             <slot name="input">
-              <input class="resize-input" disabled="" placeholder="" type="text" value="">
+              <input class="resize-input" disabled="" part="input-text" placeholder="" type="text" value="">
             </slot>
           </div>
           <div class="disabled right-slot-container">
@@ -65,9 +65,9 @@ exports[`Text Field (unit tests) when uses default props should match the snapsh
             <slot name="left-slot"></slot>
           </div>
           <div class="resize-container">
-            <span class="resize-text"></span>
+            <span class="resize-text" part="input-text"></span>
             <slot name="input">
-              <input class="resize-input" placeholder="" type="text" value="">
+              <input class="resize-input" part="input-text" placeholder="" type="text" value="">
             </slot>
           </div>
           <div class="right-slot-container">

--- a/packages/ui-components/src/components/text-field/text-field.tsx
+++ b/packages/ui-components/src/components/text-field/text-field.tsx
@@ -337,7 +337,11 @@ export class KvTextField implements ITextField, ITextFieldEvents {
 									{value && this.valuePrefix && <div class="value-prefix">{this.valuePrefix}</div>}
 								</div>
 								<div class="resize-container">
-									{this.fitContent && <span class="resize-text">{value || this.placeholder}</span>}
+									{this.fitContent && (
+										<span class="resize-text" part="input-text">
+											{value || this.placeholder}
+										</span>
+									)}
 									<slot name="input">
 										<input
 											ref={input => (this.nativeInput = input as HTMLInputElement)}
@@ -357,6 +361,7 @@ export class KvTextField implements ITextField, ITextFieldEvents {
 											onPaste={this.onPasteHandler}
 											class={{ 'resize-input': true, 'forced-focus': this.focused }}
 											readonly={this.inputReadonly}
+											part="input-text"
 										/>
 									</slot>
 								</div>


### PR DESCRIPTION
## Summary

- Add new `counterAlwaysVisible` prop to `kv-text-area` to force counter visibility regardless of focus state
- Add CSS modifier class `.counter-always-visible` for styling
- Add comprehensive E2E tests for both default and always-visible behaviors  
- Update text-area types and documentation
- Fix text-field `part` attribute for better CSS targeting
- Make `syncTextValues` method private for better encapsulation

## Test Plan

- [x] E2E tests pass for text-area component
- [x] Default behavior (counter only on focus) still works
- [x] New behavior (counter always visible) works as expected
- [x] Counter updates correctly as user types
- [x] CSS class is applied correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)