### PR TITLE
feat(design-tokens)! add stylelint custom properties validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-.vscode/*
 .DS_Store
 lerna-debug.log
 packages/**/dist

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	"recommendations": [
+		"SomewhatStationery.some-sass",
+		"stylelint.vscode-stylelint",
+		"vunguyentuan.vscode-css-variables"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,31 @@
+{
+	"editor.codeActionsOnSave": {
+		"source.fixAll.eslint": "explicit",
+		"source.fixAll.stylelint": "explicit",
+		"source.organizeImports": "never"
+	},
+	"[json]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.formatOnSave": true
+	},
+	"[javascript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.formatOnSave": true
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.formatOnSave": true
+	},
+	"[scss]": {
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.formatOnSave": true,
+		"editor.formatOnPaste": true
+	},
+	"stylelint.validate": ["css", "scss"],
+	"stylelint.snippet": ["css", "scss"],
+	"cssVariables.lookupFiles": [
+		"packages/ui-components/src/assets/styles/style-dictionary/tokens/core.css",
+		"packages/ui-components/src/assets/styles/style-dictionary/tokens/component_semantics.css",
+		"packages/ui-components/src/assets/styles/style-dictionary/tokens/themes/dark.css"
+	]
+}

--- a/apps/react-storybook/.storybook/preview-head.html
+++ b/apps/react-storybook/.storybook/preview-head.html
@@ -9,17 +9,25 @@
 <style>
 	:root {
 		color-scheme: dark;
+		font-family: Proxima Nova;
+		font-weight: 400;
+		font-size: 14px;
+		line-height: 20px;
+		letter-spacing: 0;
 	}
 
 	body {
+		--kv-primary-font: var(--font-family-proxima-nova, 'proxima-nova');
+
 		margin: 0;
 		box-sizing: border-box;
 		padding: 10px;
-		background-color: var(--background-surface-neutral-default, #202020);
-		--kv-primary-font: var(--font-family-proxima-nova, 'proxima-nova');
+		background-color: var(--background-surface-neutral-default);
+		color: var(--text-surface-neutral-primary);
 	}
 
 	.docs-story {
-		background-color: var(--background-surface-neutral-default, #202020);
+		background-color: var(--background-surface-neutral-default);
+		color: var(--text-surface-neutral-primary);
 	}
 </style>

--- a/apps/react-storybook/src/components/data-display/copy-to-clipboard/CopyToClipboard.stories.tsx
+++ b/apps/react-storybook/src/components/data-display/copy-to-clipboard/CopyToClipboard.stories.tsx
@@ -4,11 +4,7 @@ import { ComponentProps } from "react";
 
 const CopyToClipboardTemplate: StoryFn<
 	ComponentProps<typeof KvCopyToClipboard>
-> = (args) => (
-	<div style={{ color: "white", fontFamily: "Proxima Nova" }}>
-		<KvCopyToClipboard {...args}>{QUOTE}</KvCopyToClipboard>
-	</div>
-);
+> = (args) => <KvCopyToClipboard {...args}>{QUOTE}</KvCopyToClipboard>;
 
 const meta = {
 	title: "Data Display/Copy To Clipboard",

--- a/apps/react-storybook/src/components/inputs/inline-editable-field/InlineEditableField.stories.tsx
+++ b/apps/react-storybook/src/components/inputs/inline-editable-field/InlineEditableField.stories.tsx
@@ -18,24 +18,22 @@ const KvInlineEditableFieldTemplate: StoryFn<
 	};
 
 	return (
-		<div style={containerStyle}>
-			<KvInlineEditableField
-				{...args}
-				ref={ref}
-				value={title}
-				onContentEdited={onContentEdited}
+		<KvInlineEditableField
+			{...args}
+			ref={ref}
+			value={title}
+			onContentEdited={onContentEdited}
+		>
+			<div
+				style={{
+					fontSize: 32,
+					fontWeight: 600,
+					lineHeight: "48px"
+				}}
 			>
-				<div
-					style={{
-						fontSize: 32,
-						fontWeight: 600,
-						lineHeight: "48px"
-					}}
-				>
-					{title}
-				</div>
-			</KvInlineEditableField>
-		</div>
+				{title}
+			</div>
+		</KvInlineEditableField>
 	);
 };
 
@@ -52,16 +50,6 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
-
-const containerStyle: CSSProperties = {
-	display: "flex",
-	flexDirection: "column",
-	gap: "16px",
-	color: "white",
-	fontFamily: "Proxima Nova",
-	padding: "32px",
-	backgroundColor: "black"
-};
 
 export const Default: Story = {
 	args: {

--- a/packages/react-ui-components/.stylelintrc
+++ b/packages/react-ui-components/.stylelintrc
@@ -1,0 +1,56 @@
+{
+	"extends": [
+		"stylelint-config-standard-scss",
+		"stylelint-config-prettier-scss"
+	],
+	"plugins": [
+		"stylelint-value-no-unknown-custom-properties"
+	],
+	"rules": {
+		"value-keyword-case": "lower",
+		"selector-class-pattern": "[a-z]+(--[a-z]+)?(__[a-z]+)?",
+		"custom-property-pattern": "[a-z]+(--[a-z]+)?(__[a-zA-Z]+)?(-[a-zA-Z]+)?",
+		"selector-max-class": 5,
+		"selector-max-id": 2,
+		"selector-max-pseudo-class": 3,
+		"function-url-no-scheme-relative": true,
+		"selector-type-no-unknown": null,
+		"declaration-block-no-shorthand-property-overrides": true,
+		"declaration-no-important": true,
+		"declaration-block-no-duplicate-properties": [
+			true,
+			{
+				"ignore": ["consecutive-duplicates"]
+			}
+		],
+		"scss/at-import-partial-extension": "always",
+		"property-disallowed-list": ["float"],
+		"declaration-property-unit-allowed-list": {
+			"height": ["vh", "%", "px"],
+			"font-size": ["rem", "px"]
+		},
+		"function-no-unknown": [
+			true,
+			{
+				"ignoreFunctions": ["/^(#{)?kv-/", "map-get", "get-color-dark"]
+			}
+		],
+		"selector-pseudo-class-no-unknown": [
+			true,
+			{
+				"ignorePseudoClasses": ["global"]
+			}
+		],
+		"csstools/value-no-unknown-custom-properties": [
+			true,
+			{
+				"importFrom": [
+					"../ui-components/src/assets/styles/style-dictionary/tokens/index.css"
+				]
+			}
+		]
+	},
+	"ignoreFiles": [
+		"dist/**"
+	]
+}

--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -39,8 +39,10 @@
 		"rollup": "rollup -c",
 		"rollup:watch": "rollup -w -c",
 		"lint": "pnpm lint:check",
-		"lint:check": "pnpm eslint:check",
-		"lint:fix": "pnpm eslint:lint",
+		"lint:check": "pnpm eslint:check && pnpm stylelint:check",
+		"lint:fix": "pnpm eslint:lint && pnpm stylelint:fix",
+		"stylelint:check": "stylelint 'src/**/*.{css,scss}'",
+		"stylelint:fix": "stylelint 'src/**/*.{css,scss}' --fix",
 		"eslint:check": "eslint src --ext .js,.jsx,.ts,.tsx --quiet --cache",
 		"eslint:lint": "eslint src --ext .js,.jsx,.ts,.tsx --quiet --cache --fix"
 	},
@@ -114,6 +116,10 @@
 		"rollup-plugin-postcss": "^4.0.2",
 		"rollup-preserve-directives": "^1.1.3",
 		"sass": "^1.79.4",
+		"stylelint": "^15.0.0",
+		"stylelint-config-prettier-scss": "^1.0.0",
+		"stylelint-config-standard-scss": "^11.1.0",
+		"stylelint-value-no-unknown-custom-properties": "5.0.0",
 		"tslib": "^2.7.0",
 		"typescript": "^5.6.2"
 	},

--- a/packages/react-ui-components/src/components/SchemaForm/SchemaForm.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/SchemaForm.module.scss
@@ -11,8 +11,8 @@
 	--schema-form-x-padding: 0;
 	--schema-form-y-padding: 0;
 	--schema-form-max-width: 100%;
-	--schema-form-fields-x-gap: #{$spacing-5x};
-	--schema-form-fields-y-gap: #{$spacing-5x};
+	--schema-form-fields-x-gap: var(--spacing-3xl);
+	--schema-form-fields-y-gap: var(--spacing-3xl);
 	--schema-form-background: inherit;
 
 	width: 100%;
@@ -49,16 +49,16 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: end;
-		padding: $spacing-4x var(--schema-form-x-padding) 0 var(--schema-form-x-padding);
+		padding: var(--spacing-2xl) var(--schema-form-x-padding) 0 var(--schema-form-x-padding);
 
 		&.Scrolling {
-			border-top: 1px solid kv-color('neutral-6');
+			border-top: 1px solid var(--modal-divider-strong);
 		}
 
 		.LeftFooter,
 		.RightFooter {
 			display: flex;
-			gap: $spacing-3x;
+			gap: var(--spacing-xl);
 		}
 	}
 
@@ -66,13 +66,13 @@
 		display: flex;
 		flex-direction: row;
 		align-items: center;
-		gap: $spacing-2x;
+		gap: var(--spacing-md);
 		position: absolute;
 		top: var(--schema-form-y-padding);
 		right: var(--schema-form-x-padding);
 
 		.Text {
-			color: kv-color('neutral-2');
+			color: var(--text-container-neutral-default);
 			@include body-s-regular;
 		}
 	}
@@ -85,6 +85,6 @@ body {
 
 	/* stylelint-disable-next-line no-descending-specificity */
 	.FormFooter.Scrolling {
-		border-color: kv-color('neutral-6');
+		border-color: var(--modal-divider-strong);
 	}
 }

--- a/packages/react-ui-components/src/components/SchemaForm/SchemaForm.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/SchemaForm.module.scss
@@ -1,4 +1,5 @@
 @use 'node_modules/@kelvininc/ui-components/dist/assets/styles' as *;
+
 .FormContainer {
 	/**
 	* @prop --schema-form-x-padding: horizontal form padding
@@ -7,8 +8,8 @@
 	* @prop --schema-form-fields-x-gap: horizontal gap between fields
 	* @prop --schema-form-fields-y-gap: vertical gap between fields
 	*/
-	--schema-form-x-padding: 0px;
-	--schema-form-y-padding: 0px;
+	--schema-form-x-padding: 0;
+	--schema-form-y-padding: 0;
 	--schema-form-max-width: 100%;
 	--schema-form-fields-x-gap: #{$spacing-5x};
 	--schema-form-fields-y-gap: #{$spacing-5x};
@@ -18,7 +19,6 @@
 	height: 100%;
 	display: flex;
 	flex-direction: column;
-	position: relative;
 	padding: var(--schema-form-y-padding) 0;
 	box-sizing: border-box;
 	position: relative;
@@ -40,8 +40,7 @@
 
 	form > div[class^='FieldTemplate'] {
 		height: 100%;
-		overflow-y: auto;
-		overflow-x: hidden;
+		overflow: hidden auto;
 		box-sizing: border-box;
 		padding: 0 var(--schema-form-x-padding);
 	}
@@ -83,6 +82,8 @@ body {
 	.FormContainer form {
 		@include kelvin-scrollbar;
 	}
+
+	/* stylelint-disable-next-line no-descending-specificity */
 	.FormFooter.Scrolling {
 		border-color: kv-color('neutral-6');
 	}

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/ArrayFieldItemTemplate/ArrayFieldItemTemplate.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/ArrayFieldItemTemplate/ArrayFieldItemTemplate.module.scss
@@ -1,4 +1,5 @@
 @use 'node_modules/@kelvininc/ui-components/dist/assets/styles' as *;
+
 .ArrayItemContainer [class*='ArrayFieldTemplate_ArrayFieldTemplate'] {
 	border: 1px solid kv-color('neutral-6');
 	border-width: 0 1px;
@@ -13,6 +14,7 @@
 
 	.ItemPrefix {
 		@include body-m-semibold;
+		
 		margin-right: $spacing-6x;
 		white-space: nowrap;
 	}
@@ -58,6 +60,7 @@ body {
 		border-color: kv-color('neutral-6');
 	}
 
+	/* stylelint-disable-next-line no-descending-specificity */
 	.ArrayItemContainer .ItemPrefix {
 		color: kv-color('neutral-2');
 	}

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/ArrayFieldItemTemplate/ArrayFieldItemTemplate.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/ArrayFieldItemTemplate/ArrayFieldItemTemplate.module.scss
@@ -1,10 +1,10 @@
 @use 'node_modules/@kelvininc/ui-components/dist/assets/styles' as *;
 
 .ArrayItemContainer [class*='ArrayFieldTemplate_ArrayFieldTemplate'] {
-	border: 1px solid kv-color('neutral-6');
+	border: 1px solid var(--border-container-divider-default);
 	border-width: 0 1px;
-	padding: 0 $spacing-5x;
-	margin-left: $spacing-2x;
+	padding: 0 var(--spacing-3xl);
+	margin-left: var(--spacing-md);
 }
 
 .ArrayItemContainer {
@@ -15,41 +15,41 @@
 	.ItemPrefix {
 		@include body-m-semibold;
 		
-		margin-right: $spacing-6x;
+		margin-right: var(--spacing-4xl);
 		white-space: nowrap;
 	}
 
 	.ToolbarContainer {
 		display: flex;
-		padding-left: $spacing-5x;
-		gap: $spacing;
+		padding-left: var(--spacing-3xl);
+		gap: var(--spacing-xs);
 	}
 }
 
 .FieldsetStyle {
-	padding: $spacing-6x $spacing-3x $spacing-3x;
-	margin-top: $spacing-6x;
-	border: 1px solid kv-color('neutral-6');
+	padding: var(--spacing-4xl) var(--spacing-xl) var(--spacing-xl);
+	margin-top: var(--spacing-4xl);
+	border: 1px solid var(--border-container-divider-default);
 	position: relative;
 
 	.ArrayItemContainer {
 		.ItemPrefix {
 			position: absolute;
 			top: 0;
-			left: $spacing-3x;
+			left: var(--spacing-xl);
 			transform: translateY(-50%);
 			background-color: inherit;
-			padding: 0 $spacing;
+			padding: 0 var(--spacing-xs);
 			margin: 0;
 		}
 
 		.ToolbarContainer {
 			position: absolute;
 			top: 0;
-			right: $spacing-3x;
+			right: var(--spacing-xl);
 			transform: translateY(-50%);
 			background-color: inherit;
-			padding: 0 $spacing;
+			padding: 0 var(--spacing-xs);
 			margin: 0;
 		}
 	}
@@ -57,11 +57,11 @@
 
 body {
 	.ArrayItemContainer [class*='ArrayFieldTemplate_ArrayFieldTemplate'] {
-		border-color: kv-color('neutral-6');
+		border-color: var(--border-container-divider-default);
 	}
 
 	/* stylelint-disable-next-line no-descending-specificity */
 	.ArrayItemContainer .ItemPrefix {
-		color: kv-color('neutral-2');
+		color: var(--text-container-neutral-default);
 	}
 }

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/ArrayFieldTemplate/ArrayFieldTemplate.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/ArrayFieldTemplate/ArrayFieldTemplate.module.scss
@@ -1,7 +1,9 @@
 @use 'node_modules/@kelvininc/ui-components/dist/assets/styles' as *;
+
 .ArrayItemList {
 	display: flex;
 	flex-direction: column;
+	/* stylelint-disable-next-line csstools/value-no-unknown-custom-properties -- vars defined by parent component */
 	gap: var(--schema-form-fields-y-gap) var(--schema-form-fields-x-gap);
 }
 

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/DescriptionFieldTemplate/DescriptionFieldTemplate.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/DescriptionFieldTemplate/DescriptionFieldTemplate.module.scss
@@ -1,5 +1,5 @@
 @use 'node_modules/@kelvininc/ui-components/dist/assets/styles' as *;
 
 .DescriptionContainer {
-	margin-bottom: $spacing-2x;
+	margin-bottom: var(--spacing-md);
 }

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/DescriptionFieldTemplate/DescriptionFieldTemplate.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/DescriptionFieldTemplate/DescriptionFieldTemplate.module.scss
@@ -1,4 +1,5 @@
 @use 'node_modules/@kelvininc/ui-components/dist/assets/styles' as *;
+
 .DescriptionContainer {
 	margin-bottom: $spacing-2x;
 }

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/ErrorListTemplate/ErrorListTemplate.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/ErrorListTemplate/ErrorListTemplate.module.scss
@@ -1,7 +1,7 @@
 @use 'node_modules/@kelvininc/ui-components/dist/assets/styles' as *;
 
 .ErrorListContainer {
-	border-bottom: 1px solid kv-color('neutral-6');
-	padding: 0 $spacing-3x $spacing-3x $spacing-2x;
-	margin-bottom: $spacing-3x;
+	border-bottom: 1px solid var(--border-container-divider-default);
+	padding: 0 var(--spacing-xl) var(--spacing-xl) var(--spacing-md);
+	margin-bottom: var(--spacing-xl);
 }

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/ErrorListTemplate/ErrorListTemplate.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/ErrorListTemplate/ErrorListTemplate.module.scss
@@ -1,4 +1,5 @@
 @use 'node_modules/@kelvininc/ui-components/dist/assets/styles' as *;
+
 .ErrorListContainer {
 	border-bottom: 1px solid kv-color('neutral-6');
 	padding: 0 $spacing-3x $spacing-3x $spacing-2x;

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/FieldTemplate/FieldTemplate.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/FieldTemplate/FieldTemplate.module.scss
@@ -1,4 +1,5 @@
 @use 'node_modules/@kelvininc/ui-components/dist/assets/styles' as *;
+
 .FieldWrapper {
 	width: 100%;
 	display: flex;

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/FieldTemplate/FieldTemplate.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/FieldTemplate/FieldTemplate.module.scss
@@ -6,6 +6,6 @@
 	flex-direction: column;
 
 	.TopDescription {
-		padding-bottom: $spacing-4x;
+		padding-bottom: var(--spacing-2xl);
 	}
 }

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/ObjectFieldTemplate/ObjectFieldTemplate.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/ObjectFieldTemplate/ObjectFieldTemplate.module.scss
@@ -1,14 +1,16 @@
 @use 'node_modules/@kelvininc/ui-components/dist/assets/styles' as *;
+
 .PropsContainer {
 	display: flex;
 	flex-direction: column;
 	width: 100%;
+	/* stylelint-disable csstools/value-no-unknown-custom-properties -- vars defined by parent component */
 	max-width: var(--schema-form-max-width);
 	gap: var(--schema-form-fields-y-gap) var(--schema-form-fields-x-gap);
+	/* stylelint-enable csstools/value-no-unknown-custom-properties -- vars defined by parent component */
 
 	&.Inline {
-		flex-direction: row;
-		flex-wrap: wrap;
+		flex-flow: row wrap;
 	}
 
 	.PropRow.Hidden {

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/SubmitButton/SubmitButton.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/SubmitButton/SubmitButton.module.scss
@@ -1,4 +1,5 @@
 @use 'node_modules/@kelvininc/ui-components/dist/assets/styles' as *;
+
 .ResetButtonStyle {
 	@include reset-button-style;
 }

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/TitleFieldTemplate/TitleFieldTemplate.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/TitleFieldTemplate/TitleFieldTemplate.module.scss
@@ -1,7 +1,7 @@
 @use 'node_modules/@kelvininc/ui-components/dist/assets/styles' as *;
 
 .TitleContainer {
-	margin-bottom: $spacing;
+	margin-bottom: var(--spacing-xs);
 	display: flex;
 
 	kv-info-label::part(title) {
@@ -16,19 +16,19 @@
 		kv-info-label::part(title) {
 			@include body-m-semibold;
 
-			color: kv-color('neutral-2');
-			padding-bottom: $spacing-3x;
+			color: var(--text-container-neutral-default);
+			padding-bottom: var(--spacing-xl);
 		}
 	}
 
 	.Required {
 		@include heading-xs-semibold-caps;
 
-		color: kv-color('error');
-		margin: 0 $spacing;
+		color: var(--input-text-required-default);
+		margin: 0 var(--spacing-xs);
 	}
 
 	.ToggleTip {
-		margin-left: $spacing-2x;
+		margin-left: var(--spacing-md);
 	}
 }

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.module.scss
@@ -8,10 +8,10 @@
 
 	.InputContainer {
 		width: 100%;
-		padding-right: $spacing-5x;
+		padding-right: var(--spacing-3xl);
 	}
 
 	.DeleteButton {
-		padding-top: $spacing-6x;
+		padding-top: var(--spacing-4xl);
 	}
 }

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/FileWidget/FileWidget.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/FileWidget/FileWidget.module.scss
@@ -51,14 +51,14 @@
 				min-width: 0;
 
 				.Label {
-					@include ellipsis();
+					@include ellipsis;
 					@include heading-xs-semibold-caps;
 
 					color: kv-color('neutral-2');
 				}
 
 				.FileName {
-					@include ellipsis();
+					@include ellipsis;
 					@include body-m-semibold;
 
 					color: kv-color('neutral-5');
@@ -69,6 +69,8 @@
 				kv-icon {
 					--icon-color: #{kv-color('neutral-2')};
 				}
+
+				/* stylelint-disable-next-line selector-max-class */
 				.FileDetails .FileName {
 					color: kv-color('neutral-4');
 				}

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/FileWidget/FileWidget.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/FileWidget/FileWidget.module.scss
@@ -3,7 +3,7 @@
 .FileWidgetContainer {
 	display: flex;
 	justify-content: space-between;
-	gap: $spacing-3x;
+	gap: var(--spacing-xl);
 	align-items: center;
 
 	.FilesInfo {
@@ -13,7 +13,7 @@
 
 	.ActionsContainer {
 		display: flex;
-		gap: $spacing-2x;
+		gap: var(--spacing-md);
 		align-items: center;
 	}
 
@@ -21,25 +21,26 @@
 		width: 100%;
 		display: flex;
 		flex-direction: column;
-		gap: $spacing-3x;
+		gap: var(--spacing-xl);
 
 		.FileInfo {
 			display: flex;
-			border-radius: $spacing;
-			background-color: kv-color('neutral-7');
-			padding: $spacing-3x;
-			gap: $spacing-2x;
+			border-radius: var(--radius-md);
+			background-color: var(--background-container-neutral-subtle);
+			border: 1px solid var(--input-border-color-default);
+			padding: var(--spacing-xl);
+			gap: var(--spacing-md);
 			justify-content: space-between;
 
 			.LeftContent {
 				display: flex;
 				flex: 1;
 				min-width: 0;
-				gap: $spacing-2x;
+				gap: var(--spacing-md);
 			}
 
 			kv-icon {
-				--icon-color: #{kv-color('neutral-5')};
+				--icon-color: var(--icon-surface-neutral-disabled);
 				--icon-height: 40px;
 				--icon-width: 40px;
 			}
@@ -54,30 +55,30 @@
 					@include ellipsis;
 					@include heading-xs-semibold-caps;
 
-					color: kv-color('neutral-2');
+					color: var(--text-container-neutral-default);
 				}
 
 				.FileName {
 					@include ellipsis;
 					@include body-m-semibold;
 
-					color: kv-color('neutral-5');
+					color: var(--text-surface-neutral-disabled);
 				}
 			}
 
 			&.HasValue {
 				kv-icon {
-					--icon-color: #{kv-color('neutral-2')};
+					--icon-color: var(--icon-surface-neutral-secondary);
 				}
 
 				/* stylelint-disable-next-line selector-max-class */
 				.FileDetails .FileName {
-					color: kv-color('neutral-4');
+					color: var(--text-surface-neutral-secondary);
 				}
 			}
 
 			&.HasError {
-				border: 1px solid kv-color('error');
+				border: 1px solid var(--input-border-color-error);
 			}
 		}
 	}

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/RadioListWidget/RadioListWidget.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/RadioListWidget/RadioListWidget.module.scss
@@ -2,9 +2,8 @@
 
 .RadioListContainer {
 	display: flex;
-	flex-direction: column;
+	flex-flow: column wrap;
 	gap: $spacing-2x;
-	flex-wrap: wrap;
 	margin-left: $spacing;
 
 	&.Inline {

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/RadioListWidget/RadioListWidget.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/RadioListWidget/RadioListWidget.module.scss
@@ -3,8 +3,8 @@
 .RadioListContainer {
 	display: flex;
 	flex-flow: column wrap;
-	gap: $spacing-2x;
-	margin-left: $spacing;
+	gap: var(--spacing-md);
+	margin-left: var(--spacing-xs);
 
 	&.Inline {
 		flex-direction: row;

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/RadioWidget/RadioWidget.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/RadioWidget/RadioWidget.module.scss
@@ -2,9 +2,8 @@
 
 .RadioListContainer {
 	display: flex;
-	flex-direction: column;
+	flex-flow: column wrap;
 	column-gap: $spacing-5x;
-	flex-wrap: wrap;
 
 	&.Inline {
 		flex-direction: row;

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/RadioWidget/RadioWidget.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/RadioWidget/RadioWidget.module.scss
@@ -3,32 +3,22 @@
 .RadioListContainer {
 	display: flex;
 	flex-flow: column wrap;
-	column-gap: $spacing-5x;
+	gap: var(--spacing-3xl);
 
 	&.Inline {
 		flex-direction: row;
-		column-gap: $spacing-2x;
+		gap: var(--spacing-md);
 	}
 
-	.RadioOption {
+	kv-radio-list-item {
+		--radio-list-item-background: var(--input-background-default);
+	}
+
+	.Item {
 		flex: 1;
-		background-color: kv-color('neutral-7');
-		border-radius: 4px;
-		padding: 0 $spacing-4x 0 $spacing;
-		border: 1px solid transparent;
-		
-		@include clickable;
-
-		&.Checked {
-			border: 1px solid kv-color('neutral-0');
-		}
-
-		&.Disabled {
-			@include non-clickable;
-
-			&.Checked {
-				border-color: kv-color('neutral-6');
-			}
-		}
+	}
+	
+	.Label {
+		@include body-m-semibold;
 	}
 }

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/RadioWidget/RadioWidget.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/RadioWidget/RadioWidget.tsx
@@ -1,7 +1,7 @@
 import { EComponentSize } from '@kelvininc/ui-components';
 import React, { useCallback, useMemo } from 'react';
 import { FormContextType, RJSFSchema, StrictRJSFSchema, WidgetProps } from '@rjsf/utils';
-import { KvRadio } from '../../../../stencil-generated';
+import { KvRadioListItem } from '../../../../stencil-generated';
 import styles from './RadioWidget.module.scss';
 import classNames from 'classnames';
 import { useFormState } from '../../contexts';
@@ -38,14 +38,20 @@ const RadioWidget = <T, S extends StrictRJSFSchema = RJSFSchema, F extends FormC
 					const isDisabled = disabled || itemDisabled || readonly;
 
 					return (
-						<div
-							key={i}
-							className={classNames(styles.RadioOption, { [styles.Checked]: checked, [styles.Disabled]: isDisabled })}
-							onClick={_ => handleChange(option.value, checked)}
-							onFocus={() => markFieldAsTouched(id)}
-							onBlur={() => markFieldAsTouched(id)}
-						>
-							<KvRadio size={EComponentSize.Large} id={option.label} label={option.label} disabled={isDisabled} checked={checked} />
+						<div key={i} className={styles.Item}>
+							<KvRadioListItem
+								size={EComponentSize.Small}
+								optionId={option.label}
+								disabled={isDisabled}
+								checked={checked}
+								onOptionClick={_ => handleChange(option.value, checked)}
+								onFocus={() => markFieldAsTouched(id)}
+								onBlur={() => markFieldAsTouched(id)}
+							>
+								<span slot="label" className={styles.Label}>
+									{option.label}
+								</span>
+							</KvRadioListItem>
 						</div>
 					);
 				})}

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/ReadOnlyValueWidget/ReadOnlyValueWidget.module.scss
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/ReadOnlyValueWidget/ReadOnlyValueWidget.module.scss
@@ -6,6 +6,6 @@
 
 body {
 	.ValueLabel {
-		color: kv-color('neutral-2');
+		color: var(--text-container-neutral-default);
 	}
 }

--- a/packages/ui-components/.stylelintrc
+++ b/packages/ui-components/.stylelintrc
@@ -1,5 +1,8 @@
 {
 	"extends": "stylelint-config-sass-guidelines",
+	"plugins": [
+		"stylelint-value-no-unknown-custom-properties"
+	],
 	"rules": {
 		"selector-max-compound-selectors": 4,
 		"max-nesting-depth": [
@@ -10,7 +13,15 @@
 				]
 			}
 		],
-		"selector-no-qualifying-type": null
+		"selector-no-qualifying-type": null,
+		"csstools/value-no-unknown-custom-properties": [
+			true,
+			{
+				"importFrom": [
+					"src/assets/styles/style-dictionary/tokens/index.css"
+				]
+			}
+		]
 	},
 	"ignoreFiles": [
 		"src/assets/fonts/*.scss"

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -131,6 +131,7 @@
 		"style-dictionary": "^5.2.0",
 		"stylelint": "^15.0.0",
 		"stylelint-config-sass-guidelines": "^10.0.0",
+		"stylelint-value-no-unknown-custom-properties": "^5.0.0",
 		"svg-parser": "^2.0.4",
 		"svgo": "^3.2.0",
 		"typescript": "^5.6.2"

--- a/packages/ui-components/src/assets/styles/kv-mixins.scss
+++ b/packages/ui-components/src/assets/styles/kv-mixins.scss
@@ -98,7 +98,7 @@
 }
 
 @mixin kelvin-scrollbar {
-	@include custom-scrollbar(var(--scrollbar-thumb-default, kv-color('neutral-6')));
+	@include custom-scrollbar(var(--scrollbar-thumb-default));
 }
 
 /// @deprecated Use kelvin-scrollbar instead
@@ -107,8 +107,7 @@
 	@include custom-scrollbar(kv-color('neutral-6'));
 }
 
-///TODO: Fix (--border-animation-1, --border-animation-2) with CSS Variables from Design Tokens
-@mixin rotate-border-animation($border-radius: var(--radius-md, $spacing-2x), $border-width: 2px, $inset: 0) {
+@mixin rotate-border-animation($border-radius: var(--radius-md), $border-width: 2px, $inset: 0) {
 	position: relative;
 
 	&::before {
@@ -122,9 +121,9 @@
 		border-radius: $border-radius;
 		background-image: conic-gradient(
 			from var(--rotation),
-			var(--border-animation-1, kv-color('secondary-5')),
-			var(--border-animation-2, kv-color('secondary-2')),
-			var(--border-animation-1, kv-color('secondary-5'))
+			var(--color-teal-500),
+			var(--color-teal-600),
+			var(--color-teal-500)
 		);
 		background-origin: border-box;
 		mask: linear-gradient(#000, #000), linear-gradient(#000, #000);

--- a/packages/ui-components/src/assets/styles/style-dictionary/tokens/component_semantics.css
+++ b/packages/ui-components/src/assets/styles/style-dictionary/tokens/component_semantics.css
@@ -240,7 +240,7 @@ body {
   --alert-background-primary-warning: var(--background-container-status-warning-strong);
   --alert-background-primary-error: var(--background-container-status-danger-strong);
   --alert-background-primary-info: var(--background-container-status-info-strong);
-  --alert-background-secondary-default: var(--background-container-neutral-subtlest);
+  --alert-background-secondary-default: var(--background-container-alert-secondary-default);
   --alert-padding-x-default: var(--spacing-2xl);
   --alert-padding-x-small: var(--spacing-xl);
   --alert-padding-y-default: var(--spacing-2xl);

--- a/packages/ui-components/src/assets/styles/style-dictionary/tokens/themes/dark.css
+++ b/packages/ui-components/src/assets/styles/style-dictionary/tokens/themes/dark.css
@@ -8,7 +8,7 @@ body[mode="night"] {
   --background-surface-neutral-default: var(--color-gray-900);
   --background-surface-neutral-subtle: var(--color-gray-800);
   --background-surface-neutral-inverse: var(--color-gray-50);
-  --background-surface-sidebar-default: var(--color-gray-800);
+  --background-surface-sidebar-default: var(--color-gray-900);
   --background-surface-sidebar-strong: var(--color-gray-700);
   --background-surface-skeleton-highlight: var(--color-gray-500);
   --background-surface-skeleton-base: var(--color-gray-600);
@@ -55,6 +55,7 @@ body[mode="night"] {
   --background-container-account-accent: var(--color-purple-500);
   --background-container-card-recommendation-default: var(--color-gray-900);
   --background-container-card-recommendation-subtle: var(--color-gray-800);
+  --background-container-alert-secondary-default: var(--color-gray-700);
   --background-interactive-neutral-hover: var(--color-gray-600);
   --background-interactive-neutral-pressed: var(--color-gray-500);
   --background-interactive-neutral-disabled: var(--color-gray-700);
@@ -100,7 +101,15 @@ body[mode="night"] {
   --background-interactive-table-pin-pressed: var(--color-gray-600);
   --background-interactive-card-hover: var(--color-gray-700);
   --background-interactive-card-selected: var(--color-gray-600);
-  --background-interactive-card-default: var(--color-gray-700);
+  --background-interactive-card-default: var(--color-gray-800);
+  --background-interactive-card-application-default: var(--color-gray-900);
+  --background-interactive-card-application-hover: var(--color-gray-800);
+  --background-interactive-column-bar-active: var(--color-gray-700);
+  --background-interactive-column-bar-hidden: var(--color-gray-900);
+  --background-interactive-column-bar-hover: var(--color-gray-600);
+  --background-interactive-column-bar-drag: var(--color-gray-500);
+  --background-interactive-column-bar-locked: var(--color-gray-800);
+  --background-interactive-column-bar-empty: var(--color-gray-800);
   --background-persistent-control-on-defaullt: var(--color-brand-500);
   --background-persistent-control-on-subtle: var(--color-gray-600);
   --background-persistent-control-off-neutral: var(--color-gray-600);
@@ -224,9 +233,13 @@ body[mode="night"] {
   --border-interactive-accordion-default: var(--color-gray-500);
   --border-interactive-accordion-disabled: var(--color-gray-500);
   --border-container-status-success-default: var(--color-green-500);
+  --border-container-status-success-subtle: rgba(7, 213, 113, 0);
   --border-container-status-warning-default: var(--color-yellow-500);
+  --border-container-status-warning-subtle: rgba(255, 228, 168, 0);
   --border-container-status-danger-default: var(--color-red-500);
+  --border-container-status-danger-subtle: rgba(255, 184, 173, 0);
   --border-container-status-info-default: var(--color-blue-500);
+  --border-container-status-info-subtle: rgba(184, 208, 249, 0);
   --border-container-elevated-default: var(--color-gray-700);
   --border-container-neutral-default: var(--color-gray-700);
   --border-container-neutral-selected: var(--color-gray-50);
@@ -238,6 +251,7 @@ body[mode="night"] {
   --border-container-navigation-row-selected: rgba(64, 64, 64, 0);
   --border-container-accent-teal-default: var(--color-teal-500);
   --border-container-accent-purple-default: var(--color-purple-500);
+  --border-container-accent-purple-subtle: rgba(198, 178, 255, 0);
   --border-container-table-default: rgba(51, 51, 51, 0);
   --border-container-table-inverse: var(--color-gray-700);
   --border-container-card-default: rgba(64, 64, 64, 0);
@@ -246,6 +260,11 @@ body[mode="night"] {
   --border-container-card-failed: var(--color-red-500);
   --border-container-card-divider: var(--color-gray-600);
   --border-container-graphic-recommendation-default: rgba(64, 64, 64, 0);
+  --border-container-radio-selected-hover: var(--color-gray-50);
+  --border-container-radio-selected-selected: var(--color-gray-50);
+  --border-container-tag-neutral-subtle: rgba(191, 191, 191, 0);
+  --border-container-tag-brand-subtle: rgba(178, 212, 255, 0);
+  --border-container-column-bar-default: rgba(26, 26, 26, 0);
   --border-persistent-control-off: var(--color-gray-600);
   --border-persistent-control-on: var(--color-gray-300);
   --border-persistent-control-disabled: var(--color-gray-700);

--- a/packages/ui-components/src/assets/styles/style-dictionary/tokens/themes/light.css
+++ b/packages/ui-components/src/assets/styles/style-dictionary/tokens/themes/light.css
@@ -55,6 +55,7 @@ body[mode="light"] {
   --background-container-account-accent: var(--color-purple-500);
   --background-container-card-recommendation-default: var(--color-gray-50);
   --background-container-card-recommendation-subtle: var(--color-gray-100);
+  --background-container-alert-secondary-default: var(--color-gray-200);
   --background-interactive-neutral-hover: var(--color-gray-500);
   --background-interactive-neutral-pressed: var(--color-gray-600);
   --background-interactive-neutral-disabled: var(--color-gray-300);
@@ -100,7 +101,15 @@ body[mode="light"] {
   --background-interactive-table-pin-pressed: var(--color-brand-100);
   --background-interactive-card-hover: var(--color-gray-200);
   --background-interactive-card-selected: var(--color-brand-100);
-  --background-interactive-card-default: var(--color-gray-200);
+  --background-interactive-card-default: var(--color-gray-50);
+  --background-interactive-card-application-default: var(--color-gray-50);
+  --background-interactive-card-application-hover: var(--color-gray-200);
+  --background-interactive-column-bar-active: var(--color-gray-50);
+  --background-interactive-column-bar-hidden: var(--color-gray-200);
+  --background-interactive-column-bar-hover: var(--color-gray-50);
+  --background-interactive-column-bar-drag: var(--color-brand-100);
+  --background-interactive-column-bar-locked: var(--color-gray-200);
+  --background-interactive-column-bar-empty: var(--color-gray-200);
   --background-persistent-control-on-defaullt: var(--color-brand-500);
   --background-persistent-control-on-subtle: var(--color-brand-100);
   --background-persistent-control-off-neutral: var(--color-gray-600);
@@ -224,9 +233,13 @@ body[mode="light"] {
   --border-interactive-accordion-default: var(--color-gray-400);
   --border-interactive-accordion-disabled: var(--color-gray-400);
   --border-container-status-success-default: var(--color-green-500);
+  --border-container-status-success-subtle: var(--color-green-400);
   --border-container-status-warning-default: var(--color-yellow-500);
+  --border-container-status-warning-subtle: var(--color-yellow-200);
   --border-container-status-danger-default: var(--color-red-500);
+  --border-container-status-danger-subtle: var(--color-red-200);
   --border-container-status-info-default: var(--color-blue-500);
+  --border-container-status-info-subtle: var(--color-blue-200);
   --border-container-elevated-default: var(--color-gray-400);
   --border-container-neutral-default: var(--color-gray-400);
   --border-container-neutral-selected: var(--color-gray-950);
@@ -238,6 +251,7 @@ body[mode="light"] {
   --border-container-navigation-row-selected: var(--color-brand-200);
   --border-container-accent-teal-default: var(--color-teal-500);
   --border-container-accent-purple-default: var(--color-purple-500);
+  --border-container-accent-purple-subtle: var(--color-purple-200);
   --border-container-table-default: var(--color-gray-400);
   --border-container-table-inverse: rgba(191, 191, 191, 0);
   --border-container-card-default: var(--color-gray-400);
@@ -246,6 +260,11 @@ body[mode="light"] {
   --border-container-card-failed: var(--color-red-500);
   --border-container-card-divider: var(--color-gray-400);
   --border-container-graphic-recommendation-default: var(--color-gray-300);
+  --border-container-radio-selected-hover: var(--color-gray-950);
+  --border-container-radio-selected-selected: var(--color-gray-950);
+  --border-container-tag-neutral-subtle: var(--color-gray-400);
+  --border-container-tag-brand-subtle: var(--color-brand-200);
+  --border-container-column-bar-default: var(--color-gray-300);
   --border-persistent-control-off: var(--color-gray-300);
   --border-persistent-control-on: var(--color-brand-200);
   --border-persistent-control-disabled: var(--color-gray-300);

--- a/packages/ui-components/src/components/MIGRATION_STATUS.md
+++ b/packages/ui-components/src/components/MIGRATION_STATUS.md
@@ -64,6 +64,7 @@ Checklist of all components indicating whether they have been migrated to the ne
 - [x] copy-to-clipboard
 - [x] description-list
 - [x] inline-editable-field
+- [x] schema-form
 
 ## Not Migrated (tokens defined but not yet consumed)
 
@@ -85,3 +86,4 @@ Checklist of all components indicating whether they have been migrated to the ne
 - [ ] illustrations
 - [ ] loader
 - [ ] range
+- [ ] code-editor

--- a/packages/ui-components/src/components/MIGRATION_STATUS.md
+++ b/packages/ui-components/src/components/MIGRATION_STATUS.md
@@ -59,14 +59,19 @@ Checklist of all components indicating whether they have been migrated to the ne
 - [x] step-bar
 - [x] step-indicator
 - [x] step-progress-bar
+- [x] radio-list
+- [x] radio-list-item
+- [x] copy-to-clipboard
+- [x] description-list
+- [x] inline-editable-field
 
 ## Not Migrated (tokens defined but not yet consumed)
 
 - [ ] alert
-- [ ] input-wrapper
 
 ## No Tokens Defined
 
+- [ ] input-wrapper
 - [ ] absolute-time-picker
 - [ ] absolute-time-picker-dropdown
 - [ ] absolute-time-picker-dropdown-input
@@ -77,12 +82,6 @@ Checklist of all components indicating whether they have been migrated to the ne
 - [ ] date-time-input
 - [ ] relative-time-picker
 
-- [ ] alert
-- [ ] copy-to-clipboard
-- [ ] description-list
 - [ ] illustrations
-- [ ] inline-editable-field
 - [ ] loader
-- [ ] radio-list
-- [ ] radio-list-item
 - [ ] range

--- a/packages/ui-components/src/components/action-button-icon/action-button-icon.scss
+++ b/packages/ui-components/src/components/action-button-icon/action-button-icon.scss
@@ -8,11 +8,11 @@
 	 * @prop --button-size-small: Button's height and width size when size is small.
 	 */
 
-	--button-icon-large-size: var(--icon-button-primary-icon-size-regular, 24px);
-	--button-icon-small-size: var(--icon-button-primary-icon-size-compact, 20px);
+	--button-icon-large-size: var(--icon-button-primary-icon-size-regular);
+	--button-icon-small-size: var(--icon-button-primary-icon-size-compact);
 
-	--button-size-large: var(--icon-button-height-regular, 36px);
-	--button-size-small: var(--icon-button-height-compact, 28px);
+	--button-size-large: var(--icon-button-height-regular);
+	--button-size-small: var(--icon-button-height-compact);
 
 	position: relative;
 }
@@ -35,86 +35,50 @@ kv-action-button {
 	// sizing
 	--button-height-large: var(--button-size-large);
 	--button-height-small: var(--button-size-small);
-	--button-padding-x-large: var(--icon-button-padding-x-regular, 0);
-	--button-padding-y-large: var(--icon-button-padding-y-regular, 0);
-	--button-padding-x-small: var(--icon-button-padding-x-compact, 0);
-	--button-padding-y-small: var(--icon-button-padding-y-compact, 0);
-	--button-border-thickness: var(--icon-button-secondary-border-thickness-default, 1px);
-	--button-border-radius-large: var(--icon-button-radius-regular, 4px);
-	--button-border-radius-small: var(--icon-button-radius-compact, 4px);
+	--button-padding-x-large: var(--icon-button-padding-x-regular);
+	--button-padding-y-large: var(--icon-button-padding-y-regular);
+	--button-padding-x-small: var(--icon-button-padding-x-compact);
+	--button-padding-y-small: var(--icon-button-padding-y-compact);
+	--button-border-thickness: var(--icon-button-secondary-border-thickness-default);
+	--button-border-radius-large: var(--icon-button-radius-regular);
+	--button-border-radius-small: var(--icon-button-radius-compact);
 
-	--button-icon-size-primary-large: var(--button-icon-large-size, --icon-button-primary-icon-size-regular, 16px);
-	--button-icon-size-primary-small: var(--button-icon-small-size, --icon-button-primary-icon-size-compact, 16px);
-	--button-icon-size-secondary-large: var(--button-icon-large-size, --icon-button-secondary-icon-size-regular, 16px);
-	--button-icon-size-secondary-small: var(--button-icon-small-size, --icon-button-secondary-icon-size-compact, 16px);
-	--button-icon-size-tertiary-large: var(--button-icon-large-size, --icon-button-tertiary-icon-size-regular, 16px);
-	--button-icon-size-tertiary-small: var(--button-icon-small-size, --icon-button-tertiary-icon-size-compact, 16px);
-	--button-icon-size-text-large: var(--button-icon-large-size, --icon-button-text-icon-size-regular, 16px);
-	--button-icon-size-text-small: var(--button-icon-small-size, --icon-button-text-icon-size-compact, 16px);
-	--button-icon-size-danger-large: var(--button-icon-large-size, --icon-button-danger-icon-size-regular, 16px);
-	--button-icon-size-danger-small: var(--button-icon-small-size, --icon-button-danger-icon-size-compact, 16px);
+	--button-icon-size-primary-large: var(--button-icon-large-size, --icon-button-primary-icon-size-regular);
+	--button-icon-size-primary-small: var(--button-icon-small-size, --icon-button-primary-icon-size-compact);
+	--button-icon-size-secondary-large: var(--button-icon-large-size, --icon-button-secondary-icon-size-regular);
+	--button-icon-size-secondary-small: var(--button-icon-small-size, --icon-button-secondary-icon-size-compact);
+	--button-icon-size-tertiary-large: var(--button-icon-large-size, --icon-button-tertiary-icon-size-regular);
+	--button-icon-size-tertiary-small: var(--button-icon-small-size, --icon-button-tertiary-icon-size-compact);
+	--button-icon-size-text-large: var(--button-icon-large-size, --icon-button-text-icon-size-regular);
+	--button-icon-size-text-small: var(--button-icon-small-size, --icon-button-text-icon-size-compact);
+	--button-icon-size-danger-large: var(--button-icon-large-size, --icon-button-danger-icon-size-regular);
+	--button-icon-size-danger-small: var(--button-icon-small-size, --icon-button-danger-icon-size-compact);
 
 	//icon colors
 	--icon-color-default-primary: var(--icon-button-primary-icon-color-default);
 	--icon-color-default-secondary: var(--icon-button-secondary-icon-color-default);
 	--icon-color-default-tertiary: var(--icon-button-tertiary-icon-color-default);
-	--icon-color-default-text: var(--icon-button-text-icon-color-default);
 	--icon-color-default-danger: var(--icon-button-danger-icon-color-default);
 
 	--icon-color-hover-primary: var(--icon-button-primary-icon-color-default);
 	--icon-color-hover-secondary: var(--icon-button-secondary-icon-color-subtle);
 	--icon-color-hover-tertiary: var(--icon-button-tertiary-icon-color-subtle);
-	--icon-color-hover-text: var(--icon-button-text-icon-color-default);
 	--icon-color-hover-danger: var(--icon-button-danger-icon-color-default);
 
 	--icon-color-focus-primary: var(--icon-button-primary-icon-color-default);
 	--icon-color-focus-secondary: var(--icon-button-secondary-icon-color-default);
 	--icon-color-focus-tertiary: var(--icon-button-tertiary-icon-color-default);
-	--icon-color-focus-text: var(--icon-button-text-icon-color-default);
 	--icon-color-focus-danger: var(--icon-button-danger-icon-color-default);
 
 	--icon-color-disabled-primary: var(--icon-button-primary-icon-color-disabled);
 	--icon-color-disabled-secondary: var(--icon-button-secondary-icon-color-disabled);
 	--icon-color-disabled-tertiary: var(--icon-button-tertiary-icon-color-disabled);
-	--icon-color-disabled-text: var(--icon-button-text-icon-color-disabled);
 	--icon-color-disabled-danger: var(--icon-button-danger-icon-color-disabled);
 
 	--icon-color-active-primary: var(--icon-button-primary-icon-color-default);
 	--icon-color-active-secondary: var(--icon-button-secondary-icon-color-subtle);
 	--icon-color-active-tertiary: var(--icon-button-tertiary-icon-color-subtle);
-	--icon-color-active-text: var(--icon-button-text-icon-color-default);
 	--icon-color-active-danger: var(--icon-button-danger-icon-color-default);
-
-	// text colors
-	--text-color-default-primary: var(--icon-button-primary-label-default);
-	--text-color-default-secondary: var(--icon-button-secondary-label-default);
-	--text-color-default-tertiary: var(--icon-button-tertiary-label-default);
-	--text-color-default-text: var(--icon-button-text-label-default);
-	--text-color-default-danger: var(--icon-button-danger-label-default);
-
-	--text-color-hover-primary: var(--icon-button-primary-label-default);
-	--text-color-hover-secondary: var(--icon-button-secondary-label-subtle);
-	--text-color-hover-tertiary: var(--icon-button-tertiary-label-subtle);
-	--text-color-hover-text: var(--icon-button-text-label-default);
-	--text-color-hover-danger: var(--icon-button-danger-label-default);
-
-	--text-color-focus-primary: var(--icon-button-primary-label-default);
-	--text-color-focus-secondary: var(--icon-button-secondary-label-default);
-	--text-color-focus-tertiary: var(--icon-button-tertiary-label-default);
-	--text-color-focus-text: var(--icon-button-text-label-default);
-	--text-color-focus-danger: var(--icon-button-danger-label-default);
-
-	--text-color-disabled-primary: var(--icon-button-primary-label-disabled);
-	--text-color-disabled-secondary: var(--icon-button-secondary-label-disabled);
-	--text-color-disabled-tertiary: var(--icon-button-tertiary-label-disabled);
-	--text-color-disabled-text: var(--icon-button-text-label-disabled);
-	--text-color-disabled-danger: var(--icon-button-danger-label-disabled);
-
-	--text-color-active-primary: var(--icon-button-primary-label-default);
-	--text-color-active-secondary: var(--icon-button-secondary-label-subtle);
-	--text-color-active-tertiary: var(--icon-button-tertiary-label-subtle);
-	--text-color-active-text: var(--icon-button-text-label-default);
-	--text-color-active-danger: var(--icon-button-danger-label-default);
 
 	// background colors
 	--background-color-default-primary: var(--icon-button-primary-background-default);

--- a/packages/ui-components/src/components/action-button-split/action-button-split.scss
+++ b/packages/ui-components/src/components/action-button-split/action-button-split.scss
@@ -10,14 +10,14 @@
 	 * @prop --button-split-icon-height: Split button icon height.
 	 */
 
-	--button-split-height-large: var(--button-height-regular, 36px);
-	--button-split-height-small: var(--button-height-compact, 28px);
-	--button-split-padding-x-large: var(--icon-button-padding-x-regular, #{$spacing-2x});
-	--button-split-padding-y-large: var(--icon-button-padding-y-regular, #{$spacing-2x});
-	--button-split-padding-x-small: var(--icon-button-padding-x-compact, #{$spacing});
-	--button-split-padding-y-small: var(--icon-button-padding-y-compact, #{$spacing});
-	--button-split-icon-width: var(--icon-button-primary-icon-size-regular, 24px);
-	--button-split-icon-height: var(--icon-button-primary-icon-size-regular, 24px);
+	--button-split-height-large: var(--button-height-regular);
+	--button-split-height-small: var(--button-height-compact);
+	--button-split-padding-x-large: var(--icon-button-padding-x-regular);
+	--button-split-padding-y-large: var(--icon-button-padding-y-regular);
+	--button-split-padding-x-small: var(--icon-button-padding-x-compact);
+	--button-split-padding-y-small: var(--icon-button-padding-y-compact);
+	--button-split-icon-width: var(--icon-button-primary-icon-size-regular);
+	--button-split-icon-height: var(--icon-button-primary-icon-size-regular);
 }
 
 .action-button-split {

--- a/packages/ui-components/src/components/action-button/action-button.scss
+++ b/packages/ui-components/src/components/action-button/action-button.scss
@@ -1,158 +1,7 @@
 @use 'sass:map';
 @use '../../assets/styles' as *;
 
-$btn-text-colors: (
-	default: (
-		primary: kv-color('text'),
-		secondary: kv-color('text'),
-		tertiary: kv-color('text'),
-		text: kv-color('text'),
-		danger: kv-color('text')
-	),
-	hover: (
-		primary: kv-color('text'),
-		secondary: kv-color('text'),
-		tertiary: kv-color('neutral-2'),
-		text: kv-color('neutral-2'),
-		danger: kv-color('text')
-	),
-	focus: (
-		primary: kv-color('text'),
-		secondary: kv-color('text'),
-		tertiary: kv-color('text'),
-		text: kv-color('text'),
-		danger: kv-color('text')
-	),
-	disabled: (
-		primary: kv-color('neutral-5'),
-		secondary: kv-color('neutral-5'),
-		tertiary: kv-color('neutral-5'),
-		text: kv-color('neutral-5'),
-		danger: kv-color('text')
-	),
-	active: (
-		primary: kv-color('text'),
-		secondary: kv-color('text'),
-		tertiary: kv-color('neutral-2'),
-		text: kv-color('neutral-2'),
-		danger: kv-color('text')
-	)
-);
-$btn-background-colors: (
-	default: (
-		primary: kv-color('primary'),
-		secondary: kv-color('neutral-6'),
-		tertiary: transparent,
-		text: transparent,
-		danger: kv-color('error')
-	),
-	hover: (
-		primary: kv-color('primary', 'dark'),
-		secondary: kv-color('neutral-5'),
-		tertiary: transparent,
-		text: kv-color('neutral-7'),
-		danger: kv-color('error', 'dark')
-	),
-	focus: (
-		primary: kv-color('primary'),
-		secondary: kv-color('neutral-6'),
-		tertiary: transparent,
-		text: kv-color('neutral-7'),
-		danger: kv-color('error')
-	),
-	disabled: (
-		primary: kv-color('neutral-3'),
-		secondary: kv-color('neutral-3'),
-		tertiary: transparent,
-		text: transparent,
-		danger: kv-color('error', 'light')
-	),
-	active: (
-		primary: kv-color('primary', 'dark'),
-		secondary: kv-color('neutral-5'),
-		tertiary: transparent,
-		text: kv-color('neutral-7'),
-		danger: kv-color('error', 'dark')
-	)
-);
-$btn-border-colors: (
-	default: (
-		primary: kv-color('primary'),
-		secondary: kv-color('neutral-6'),
-		tertiary: kv-color('neutral-0'),
-		text: transparent,
-		danger: kv-color('error')
-	),
-	hover: (
-		primary: kv-color('primary', 'dark'),
-		secondary: kv-color('neutral-5'),
-		tertiary: kv-color('neutral-2'),
-		text: kv-color('neutral-7'),
-		danger: kv-color('error', 'dark')
-	),
-	focus: (
-		primary: kv-color('primary'),
-		secondary: kv-color('neutral-0'),
-		tertiary: transparent,
-		text: kv-color('neutral-7'),
-		danger: transparent
-	),
-	disabled: (
-		primary: kv-color('neutral-3'),
-		secondary: kv-color('neutral-3'),
-		tertiary: kv-color('neutral-5'),
-		text: transparent,
-		danger: kv-color('error', 'light')
-	),
-	active: (
-		primary: kv-color('primary', 'dark'),
-		secondary: kv-color('neutral-5'),
-		tertiary: kv-color('neutral-2'),
-		text: kv-color('neutral-7'),
-		danger: kv-color('error', 'dark')
-	)
-);
-$btn-heights: (
-	small: 28px,
-	large: 36px
-);
-
-$btn-paddings-x: (
-	small: $spacing-3x,
-	large: $spacing-4x
-);
-
-@function get-text-color($state, $type) {
-	$values: map.get($btn-text-colors, $state);
-	@if ($values) {
-		@return map.get($values, $type);
-	}
-
-	@return null;
-}
-@function get-background-color($state, $type) {
-	$values: map.get($btn-background-colors, $state);
-	@if ($values) {
-		@return map.get($values, $type);
-	}
-
-	@return null;
-}
-@function get-border-color($state, $type) {
-	$values: map.get($btn-border-colors, $state);
-	@if ($values) {
-		@return map.get($values, $type);
-	}
-
-	@return null;
-}
-@function get-height($size) {
-	@return map.get($btn-heights, $size);
-}
-@function get-horizontal-padding($size) {
-	@return map.get($btn-paddings-x, $size);
-}
-
+/* stylelint-disable csstools/value-no-unknown-custom-properties */
 @mixin button-text-theme($type) {
 	$btn-default-text-color: var(--text-color-default-#{$type});
 	$btn-default-icon-color: var(--icon-color-default-#{$type});
@@ -295,6 +144,7 @@ $btn-paddings-x: (
 		--icon-height: var(--button-icon-size-#{$type}-#{$size});
 	}
 }
+/* stylelint-enable csstools/value-no-unknown-custom-properties */
 
 :host {
 	/**
@@ -422,155 +272,154 @@ $btn-paddings-x: (
 	 */
 
 	//icon colors
-	--icon-color-default-primary: var(--button-primary-icon-color-default, #{get-text-color('default', 'primary')});
-	--icon-color-default-secondary: var(--button-secondary-icon-color-default, #{get-text-color('default', 'secondary')});
-	--icon-color-default-tertiary: var(--button-tertiary-icon-color-default, #{get-text-color('default', 'tertiary')});
-	--icon-color-default-text: var(--button-text-icon-color-default, #{get-text-color('default', 'text')});
-	--icon-color-default-danger: var(--button-danger-icon-color-default, #{get-text-color('default', 'danger')});
+	--icon-color-default-primary: var(--button-primary-icon-color-default);
+	--icon-color-default-secondary: var(--button-secondary-icon-color-default);
+	--icon-color-default-tertiary: var(--button-tertiary-icon-color-default);
+	--icon-color-default-text: var(--button-text-icon-color-default);
+	--icon-color-default-danger: var(--button-danger-icon-color-default);
 
-	--icon-color-hover-primary: var(--button-primary-icon-color-default, #{get-text-color('hover', 'primary')});
-	--icon-color-hover-secondary: var(--button-secondary-icon-color-subtle, #{get-text-color('hover', 'secondary')});
-	--icon-color-hover-tertiary: var(--button-tertiary-icon-color-subtle, #{get-text-color('hover', 'tertiary')});
-	--icon-color-hover-text: var(--button-text-icon-color-default, #{get-text-color('hover', 'text')});
-	--icon-color-hover-danger: var(--button-danger-icon-color-default, #{get-text-color('hover', 'danger')});
+	--icon-color-hover-primary: var(--button-primary-icon-color-default);
+	--icon-color-hover-secondary: var(--button-secondary-icon-color-subtle);
+	--icon-color-hover-tertiary: var(--button-tertiary-icon-color-subtle);
+	--icon-color-hover-text: var(--button-text-icon-color-default);
+	--icon-color-hover-danger: var(--button-danger-icon-color-default);
 
-	--icon-color-focus-primary: var(--button-primary-icon-color-default, #{get-text-color('focus', 'primary')});
-	--icon-color-focus-secondary: var(--button-secondary-icon-color-default, #{get-text-color('focus', 'secondary')});
-	--icon-color-focus-tertiary: var(--button-tertiary-icon-color-default, #{get-text-color('focus', 'tertiary')});
-	--icon-color-focus-text: var(--button-text-icon-color-default, #{get-text-color('focus', 'text')});
-	--icon-color-focus-danger: var(--button-danger-icon-color-default, #{get-text-color('focus', 'danger')});
-	--icon-color-disabled-primary: var(--button-primary-icon-color-disabled, #{get-text-color('disabled', 'primary')});
-	--icon-color-disabled-secondary: var(--button-secondary-icon-color-disabled, #{get-text-color('disabled', 'secondary')});
-	--icon-color-disabled-tertiary: var(--button-tertiary-icon-color-disabled, #{get-text-color('disabled', 'tertiary')});
-	--icon-color-disabled-text: var(--button-text-icon-color-disabled, #{get-text-color('disabled', 'text')});
-	--icon-color-disabled-danger: var(--button-danger-icon-color-disabled, #{get-text-color('disabled', 'danger')});
+	--icon-color-focus-primary: var(--button-primary-icon-color-default);
+	--icon-color-focus-secondary: var(--button-secondary-icon-color-default);
+	--icon-color-focus-tertiary: var(--button-tertiary-icon-color-default);
+	--icon-color-focus-text: var(--button-text-icon-color-default);
+	--icon-color-focus-danger: var(--button-danger-icon-color-default);
+	--icon-color-disabled-primary: var(--button-primary-icon-color-disabled);
+	--icon-color-disabled-secondary: var(--button-secondary-icon-color-disabled);
+	--icon-color-disabled-tertiary: var(--button-tertiary-icon-color-disabled);
+	--icon-color-disabled-text: var(--button-text-icon-color-disabled);
+	--icon-color-disabled-danger: var(--button-danger-icon-color-disabled);
 
-	--icon-color-active-primary: var(--button-primary-icon-color-default, #{get-text-color('active', 'primary')});
-	--icon-color-active-secondary: var(--button-secondary-icon-color-subtle, #{get-text-color('active', 'secondary')});
-	--icon-color-active-tertiary: var(--button-tertiary-icon-color-subtle, #{get-text-color('active', 'tertiary')});
-	--icon-color-active-text: var(--button-text-icon-color-default, #{get-text-color('active', 'text')});
-	--icon-color-active-danger: var(--button-danger-icon-color-default, #{get-text-color('active', 'danger')});
+	--icon-color-active-primary: var(--button-primary-icon-color-default);
+	--icon-color-active-secondary: var(--button-secondary-icon-color-subtle);
+	--icon-color-active-tertiary: var(--button-tertiary-icon-color-subtle);
+	--icon-color-active-text: var(--button-text-icon-color-default);
+	--icon-color-active-danger: var(--button-danger-icon-color-default);
 
 	// text colors
-	--text-color-default-primary: var(--button-primary-label-default, #{get-text-color('default', 'primary')});
-	--text-color-default-secondary: var(--button-secondary-label-default, #{get-text-color('default', 'secondary')});
-	--text-color-default-tertiary: var(--button-tertiary-label-default, #{get-text-color('default', 'tertiary')});
-	--text-color-default-text: var(--button-text-label-default, #{get-text-color('default', 'text')});
-	--text-color-default-danger: var(--button-danger-label-default, #{get-text-color('default', 'danger')});
-	--text-color-hover-primary: var(--button-primary-label-default, #{get-text-color('hover', 'primary')});
-	--text-color-hover-secondary: var(--button-secondary-label-subtle, #{get-text-color('hover', 'secondary')});
-	--text-color-hover-tertiary: var(--button-tertiary-label-subtle, #{get-text-color('hover', 'tertiary')});
-	--text-color-hover-text: var(--button-text-label-default, #{get-text-color('hover', 'text')});
-	--text-color-hover-danger: var(--button-danger-label-default, #{get-text-color('hover', 'danger')});
+	--text-color-default-primary: var(--button-primary-label-default);
+	--text-color-default-secondary: var(--button-secondary-label-default);
+	--text-color-default-tertiary: var(--button-tertiary-label-default);
+	--text-color-default-text: var(--button-text-label-default);
+	--text-color-default-danger: var(--button-danger-label-default);
+	--text-color-hover-primary: var(--button-primary-label-default);
+	--text-color-hover-secondary: var(--button-secondary-label-subtle);
+	--text-color-hover-tertiary: var(--button-tertiary-label-subtle);
+	--text-color-hover-text: var(--button-text-label-default);
+	--text-color-hover-danger: var(--button-danger-label-default);
 
-	--text-color-focus-primary: var(--button-primary-label-default, #{get-text-color('focus', 'primary')});
-	--text-color-focus-secondary: var(--button-secondary-label-default, #{get-text-color('focus', 'secondary')});
-	--text-color-focus-tertiary: var(--button-tertiary-label-default, #{get-text-color('focus', 'tertiary')});
-	--text-color-focus-text: var(--button-text-label-default, #{get-text-color('focus', 'text')});
-	--text-color-focus-danger: var(--button-danger-label-default, #{get-text-color('focus', 'danger')});
-	--text-color-disabled-primary: var(--button-primary-label-disabled, #{get-text-color('disabled', 'primary')});
-	--text-color-disabled-secondary: var(--button-secondary-label-disabled, #{get-text-color('disabled', 'secondary')});
-	--text-color-disabled-tertiary: var(--button-tertiary-label-disabled, #{get-text-color('disabled', 'tertiary')});
-	--text-color-disabled-text: var(--button-text-label-disabled, #{get-text-color('disabled', 'text')});
-	--text-color-disabled-danger: var(--button-danger-label-disabled, #{get-text-color('disabled', 'danger')});
+	--text-color-focus-primary: var(--button-primary-label-default);
+	--text-color-focus-secondary: var(--button-secondary-label-default);
+	--text-color-focus-tertiary: var(--button-tertiary-label-default);
+	--text-color-focus-text: var(--button-text-label-default);
+	--text-color-focus-danger: var(--button-danger-label-default);
+	--text-color-disabled-primary: var(--button-primary-label-disabled);
+	--text-color-disabled-secondary: var(--button-secondary-label-disabled);
+	--text-color-disabled-tertiary: var(--button-tertiary-label-disabled);
+	--text-color-disabled-text: var(--button-text-label-disabled);
+	--text-color-disabled-danger: var(--button-danger-label-disabled);
 
-	--text-color-active-primary: var(--button-primary-label-default, #{get-text-color('active', 'primary')});
-	--text-color-active-secondary: var(--button-secondary-label-subtle, #{get-text-color('active', 'secondary')});
-	--text-color-active-tertiary: var(--button-tertiary-label-subtle, #{get-text-color('active', 'tertiary')});
-	--text-color-active-text: var(--button-text-label-default, #{get-text-color('active', 'text')});
-	--text-color-active-danger: var(--button-danger-label-default, #{get-text-color('active', 'danger')});
+	--text-color-active-primary: var(--button-primary-label-default);
+	--text-color-active-secondary: var(--button-secondary-label-subtle);
+	--text-color-active-tertiary: var(--button-tertiary-label-subtle);
+	--text-color-active-text: var(--button-text-label-default);
+	--text-color-active-danger: var(--button-danger-label-default);
 
 	// background colors
-	--background-color-default-primary: var(--button-primary-background-default, #{get-background-color('default', 'primary')});
-	--background-color-default-secondary: var(--transparent, #{get-background-color('default', 'secondary')});
-	--background-color-default-tertiary: var(--transparent, #{get-background-color('default', 'tertiary')});
-	--background-color-default-text: var(--transparent, #{get-background-color('default', 'text')});
-	--background-color-default-danger: var(--button-danger-background-default, #{get-background-color('default', 'danger')});
+	--background-color-default-primary: var(--button-primary-background-default);
+	--background-color-default-secondary: var(--transparent);
+	--background-color-default-tertiary: var(--transparent);
+	--background-color-default-text: var(--transparent);
+	--background-color-default-danger: var(--button-danger-background-default);
 
-	--background-color-hover-primary: var(--button-primary-background-hover, #{get-background-color('hover', 'primary')});
-	--background-color-hover-secondary: var(--button-secondary-background-hover, #{get-background-color('hover', 'secondary')});
-	--background-color-hover-tertiary: var(--button-tertiary-background-hover, #{get-background-color('hover', 'tertiary')});
-	--background-color-hover-text: var(--transparent, #{get-background-color('hover', 'text')});
-	--background-color-hover-danger: var(--button-danger-background-hover, #{get-background-color('hover', 'danger')});
+	--background-color-hover-primary: var(--button-primary-background-hover);
+	--background-color-hover-secondary: var(--button-secondary-background-hover);
+	--background-color-hover-tertiary: var(--button-tertiary-background-hover);
+	--background-color-hover-text: var(--transparent);
+	--background-color-hover-danger: var(--button-danger-background-hover);
 
-	--background-color-focus-primary: var(--button-primary-background-default, #{get-background-color('focus', 'primary')});
-	--background-color-focus-secondary: var(--transparent, #{get-background-color('focus', 'secondary')});
-	--background-color-focus-tertiary: var(--transparent, #{get-background-color('focus', 'tertiary')});
-	--background-color-focus-text: var(--transparent, #{get-background-color('focus', 'text')});
-	--background-color-focus-danger: var(--button-danger-background-default, #{get-background-color('focus', 'danger')});
-	--background-color-disabled-primary: var(--button-primary-background-disabled, #{get-background-color('disabled', 'primary')});
-	--background-color-disabled-secondary: var(--button-secondary-background-disabled, #{get-background-color('disabled', 'secondary')});
-	--background-color-disabled-tertiary: var(--button-tertiary-background-disabled, #{get-background-color('disabled', 'tertiary')});
-	--background-color-disabled-text: var(--transparent, #{get-background-color('disabled', 'text')});
-	--background-color-disabled-danger: var(--button-danger-background-disabled, #{get-background-color('disabled', 'danger')});
+	--background-color-focus-primary: var(--button-primary-background-default);
+	--background-color-focus-secondary: var(--transparent);
+	--background-color-focus-tertiary: var(--transparent);
+	--background-color-focus-text: var(--transparent);
+	--background-color-focus-danger: var(--button-danger-background-default);
+	--background-color-disabled-primary: var(--button-primary-background-disabled);
+	--background-color-disabled-secondary: var(--button-secondary-background-disabled);
+	--background-color-disabled-tertiary: var(--button-tertiary-background-disabled);
+	--background-color-disabled-text: var(--transparent);
+	--background-color-disabled-danger: var(--button-danger-background-disabled);
 
-	--background-color-active-primary: var(--button-primary-background-pressed, #{get-background-color('active', 'primary')});
-	--background-color-active-secondary: var(--button-secondary-background-pressed, #{get-background-color('active', 'secondary')});
-	--background-color-active-tertiary: var(--button-tertiary-background-pressed, #{get-background-color('active', 'tertiary')});
-	--background-color-active-text: var(--transparent, #{get-background-color('active', 'text')});
-	--background-color-active-danger: var(--button-danger-background-pressed, #{get-background-color('active', 'danger')});
+	--background-color-active-primary: var(--button-primary-background-pressed);
+	--background-color-active-secondary: var(--button-secondary-background-pressed);
+	--background-color-active-tertiary: var(--button-tertiary-background-pressed);
+	--background-color-active-text: var(--transparent);
+	--background-color-active-danger: var(--button-danger-background-pressed);
 
 	// borders colors
-	--border-color-default-primary: var(--button-primary-background-default, #{get-border-color('default', 'primary')});
-	--border-color-default-secondary: var(--button-secondary-border-color-default, #{get-border-color('default', 'secondary')});
-	--border-color-default-tertiary: var(--transparent, #{get-border-color('default', 'tertiary')});
-	--border-color-default-text: var(--transparent, #{get-border-color('default', 'text')});
-	--border-color-default-danger: var(--button-danger-background-default, #{get-border-color('default', 'danger')});
+	--border-color-default-primary: var(--button-primary-background-default);
+	--border-color-default-secondary: var(--button-secondary-border-color-default);
+	--border-color-default-tertiary: var(--transparent);
+	--border-color-default-text: var(--transparent);
+	--border-color-default-danger: var(--button-danger-background-default);
 
-	--border-color-hover-primary: var(--button-primary-background-hover, #{get-border-color('hover', 'primary')});
-	--border-color-hover-secondary: var(--button-secondary-border-color-default, #{get-border-color('hover', 'secondary')});
-	--border-color-hover-tertiary: var(--button-tertiary-background-hover, #{get-border-color('hover', 'tertiary')});
-	--border-color-hover-text: var(--transparent, #{get-border-color('hover', 'text')});
-	--border-color-hover-danger: var(--button-danger-background-hover, #{get-border-color('hover', 'danger')});
+	--border-color-hover-primary: var(--button-primary-background-hover);
+	--border-color-hover-secondary: var(--button-secondary-border-color-default);
+	--border-color-hover-tertiary: var(--button-tertiary-background-hover);
+	--border-color-hover-text: var(--transparent);
+	--border-color-hover-danger: var(--button-danger-background-hover);
 
-	--border-color-focus-primary: var(--button-primary-background-default, #{get-border-color('focus', 'primary')});
-	--border-color-focus-secondary: var(--button-secondary-border-color-default, #{get-border-color('focus', 'secondary')});
-	--border-color-focus-tertiary: var(--transparent, #{get-border-color('focus', 'tertiary')});
-	--border-color-focus-text: var(--transparent, #{get-border-color('focus', 'text')});
-	--border-color-focus-danger: var(--button-danger-background-default, #{get-border-color('focus', 'danger')});
+	--border-color-focus-primary: var(--button-primary-background-default);
+	--border-color-focus-secondary: var(--button-secondary-border-color-default);
+	--border-color-focus-tertiary: var(--transparent);
+	--border-color-focus-text: var(--transparent);
+	--border-color-focus-danger: var(--button-danger-background-default);
 
-	--border-color-disabled-primary: var(--button-primary-background-disabled, #{get-border-color('disabled', 'primary')});
-	--border-color-disabled-secondary: var(--button-secondary-background-disabled, #{get-border-color('disabled', 'secondary')});
-	--border-color-disabled-tertiary: var(--button-tertiary-background-disabled, #{get-border-color('disabled', 'tertiary')});
-	--border-color-disabled-text: var(--transparent, #{get-border-color('disabled', 'text')});
-	--border-color-disabled-danger: var(--button-danger-background-disabled, #{get-border-color('disabled', 'danger')});
+	--border-color-disabled-primary: var(--button-primary-background-disabled);
+	--border-color-disabled-secondary: var(--button-secondary-background-disabled);
+	--border-color-disabled-tertiary: var(--button-tertiary-background-disabled);
+	--border-color-disabled-text: var(--transparent);
+	--border-color-disabled-danger: var(--button-danger-background-disabled);
 
-	--border-color-active-primary: var(--button-primary-background-pressed, #{get-border-color('active', 'primary')});
-	--border-color-active-secondary: var(--button-secondary-border-color-pressed, #{get-border-color('active', 'secondary')});
-	--border-color-active-tertiary: var(--button-tertiary-background-pressed, #{get-border-color('active', 'tertiary')});
-	--border-color-active-text: var(--transparent, #{get-border-color('active', 'text')});
-	--border-color-active-danger: var(--button-danger-background-pressed, #{get-border-color('active', 'danger')});
+	--border-color-active-primary: var(--button-primary-background-pressed);
+	--border-color-active-secondary: var(--button-secondary-border-color-pressed);
+	--border-color-active-tertiary: var(--button-tertiary-background-pressed);
+	--border-color-active-text: var(--transparent);
+	--border-color-active-danger: var(--button-danger-background-pressed);
 
 	// sizing
-	--button-gap-large: var(--button-gap-regular, 8px);
-	--button-gap-small: var(--button-gap-compact, 8px);
-	--button-height-large: var(--button-height-regular, #{get-height('large')});
-	--button-height-small: var(--button-height-compact, #{get-height('small')});
-	--button-padding-x-large: var(--button-padding-x-regular, #{get-horizontal-padding('large')});
-	--button-padding-y-large: var(--button-padding-y-regular, #{get-horizontal-padding('large')});
+	--button-gap-large: var(--button-gap-regular);
+	--button-gap-small: var(--button-gap-compact);
+	--button-height-large: var(--button-height-regular);
+	--button-height-small: var(--button-height-compact);
+	--button-padding-x-large: var(--button-padding-x-regular);
+	--button-padding-y-large: var(--button-padding-y-regular);
 
-	--button-padding-x-small: var(--button-padding-x-compact, #{get-horizontal-padding('small')});
-	--button-padding-y-small: var(--button-padding-y-compact, #{get-horizontal-padding('small')});
+	--button-padding-x-small: var(--button-padding-x-compact);
+	--button-padding-y-small: var(--button-padding-y-compact);
 
-	--button-border-thickness: var(--button-secondary-border-thickness-default, 1px);
-	--button-border-radius-large: var(--button-radius-regular, 4px);
-	--button-border-radius-small: var(--button-radius-compact, 4px);
+	--button-border-thickness: var(--button-secondary-border-thickness-default);
+	--button-border-radius-large: var(--button-radius-regular);
+	--button-border-radius-small: var(--button-radius-compact);
 
-	--button-icon-size-primary-large: var(--button-primary-icon-size-regular, 16px);
-	--button-icon-size-primary-small: var(--button-primary-icon-size-compact, 16px);
+	--button-icon-size-primary-large: var(--button-primary-icon-size-regular);
+	--button-icon-size-primary-small: var(--button-primary-icon-size-compact);
 
-	--button-icon-size-secondary-large: var(--button-secondary-icon-size-regular, 16px);
-	--button-icon-size-secondary-small: var(--button-secondary-icon-size-compact, 16px);
+	--button-icon-size-secondary-large: var(--button-secondary-icon-size-regular);
+	--button-icon-size-secondary-small: var(--button-secondary-icon-size-compact);
 
-	--button-icon-size-tertiary-large: var(--button-tertiary-icon-size-regular, 16px);
-	--button-icon-size-tertiary-small: var(--button-tertiary-icon-size-compact, 16px);
+	--button-icon-size-tertiary-large: var(--button-tertiary-icon-size-regular);
+	--button-icon-size-tertiary-small: var(--button-tertiary-icon-size-compact);
 
-	--button-icon-size-text-large: var(--button-text-icon-size-regular, 16px);
-	--button-icon-size-text-small: var(--button-text-icon-size-compact, 16px);
+	--button-icon-size-text-large: var(--button-text-icon-size-regular);
+	--button-icon-size-text-small: var(--button-text-icon-size-regular);
 
-	--button-icon-size-danger-large: var(--button-danger-icon-size-regular, 16px);
-	--button-icon-size-danger-small: var(--button-danger-icon-size-compact, 16px);
-
+	--button-icon-size-danger-large: var(--button-danger-icon-size-regular);
+	--button-icon-size-danger-small: var(--button-danger-icon-size-compact);
 }
 
 .action-button {

--- a/packages/ui-components/src/components/badge/badge.scss
+++ b/packages/ui-components/src/components/badge/badge.scss
@@ -1,5 +1,6 @@
 @use '../../assets/styles' as *;
 
+/* stylelint-disable csstools/value-no-unknown-custom-properties */
 @mixin badge-type-theme($type) {
 	$badge-text-color: var(--badge-text-color-#{$type});
 	$badge-background-color: var(--badge-background-color-#{$type});
@@ -7,6 +8,7 @@
 	color: $badge-text-color;
 	background-color: $badge-background-color;
 }
+/* stylelint-enable csstools/value-no-unknown-custom-properties */
 
 :host {
 	/**
@@ -29,14 +31,14 @@
 
 	--badge-min-width: unset;
 	--badge-max-width: fit-content;
-	--badge-height: var(--size-md, 20px);
+	--badge-height: var(--size-md);
 	--badge-width: unset;
 	
-	--badge-background-color-primary: var(--background-container-accent-purple-default, #{kv-color('secondary-5')});
-	--badge-text-color-primary: var(--text-container-accent-purple-default, #{kv-color('neutral-2')});
+	--badge-background-color-primary: var(--background-container-accent-purple-default);
+	--badge-text-color-primary: var(--text-container-accent-purple-default);
 	
-	--badge-background-color-secondary: var(--background-interactive-counter-default, #{kv-color('neutral-5')});
-	--badge-text-color-secondary: var(--text-interactive-counter-default, #{kv-color('neutral-2')});
+	--badge-background-color-secondary: var(--background-interactive-counter-default);
+	--badge-text-color-secondary: var(--text-interactive-counter-default);
 	
 }
 
@@ -50,10 +52,10 @@
 	max-width: var(--badge-max-width);
 	height: var(--badge-height);
 	width: var(--badge-width);
-	padding: 0 var(--spacing-xs, $spacing);
+	padding: 0 var(--spacing-xs);
 	line-height: unset;
 
-	border-radius: var(--radius-full, 8px);
+	border-radius: var(--radius-full);
 
 	&--type-primary {
 		@include badge-type-theme(primary);

--- a/packages/ui-components/src/components/copy-to-clipboard/copy-to-clipboard.scss
+++ b/packages/ui-components/src/components/copy-to-clipboard/copy-to-clipboard.scss
@@ -13,14 +13,14 @@
 		@prop --icon-size: The copy icon size
 	**/
 	--container-width: 100%;
-	--container-padding: #{$spacing-2x};
-	--container-hover-background-color: kv-color('neutral-6');
-	--container-gap: #{$spacing-2x};
+	--container-padding: var(--spacing-md);
+	--container-hover-background-color: var(--transparent);
+	--container-gap: var(--spacing-md);
 	--icon-start-opacity: 0;
-	--icon-color-default: #{kv-color('neutral-2')};
-	--icon-color-success: #{kv-color('success')};
-	--icon-background-color-success: #{kv-color('neutral-0')};
-	--icon-size: 16px;
+	--icon-color-default: var(--icon-container-neutral-subtle);
+	--icon-color-success: var(--icon-surface-status-success-default);
+	--icon-background-color-success: var(--background-surface-neutral-inverse);
+	--icon-size: var(--size-md);
 }
 
 .copy-to-clipboard-container {
@@ -28,7 +28,7 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	border-radius: 4px;
+	border-radius: var(--radius-md);
 	gap: var(--container-gap);
 	padding: var(--container-padding);
 	box-sizing: border-box;

--- a/packages/ui-components/src/components/description-list/description-list.helper.ts
+++ b/packages/ui-components/src/components/description-list/description-list.helper.ts
@@ -1,5 +1,5 @@
 import { IDescriptionListItemPopover } from './description-list.types';
 
-export function getTooltipText(popoverInfo: IDescriptionListItemPopover) {
+export function getTooltipText(popoverInfo?: IDescriptionListItemPopover) {
 	return popoverInfo?.text && !popoverInfo.icon ? popoverInfo.text : '';
 }

--- a/packages/ui-components/src/components/description-list/description-list.scss
+++ b/packages/ui-components/src/components/description-list/description-list.scss
@@ -4,7 +4,7 @@ kv-description-list {
 	/**
 		@prop --description-list-gap: The gap between the title and description
 	**/
-	--description-list-row-gap: #{$spacing-3x};
+	--description-list-row-gap: var(--spacing-xl);
 	/**
 		@prop --description-list-row-extremes: The gap for the first and last row
 	**/
@@ -22,7 +22,7 @@ kv-description-list {
 .description-list-container {
 	display: grid;
 	grid-template-columns: max-content 1fr;
-	column-gap: $spacing-7x;
+	column-gap: var(--space-28);
 	word-break: break-all;
 
 	.row {
@@ -44,12 +44,12 @@ kv-description-list {
 
 	.title {
 		@include heading-xs-regular-caps;
-		color: kv-color('neutral-4');
+		color: var(--text-container-neutral-subtle);
 	}
 
 	.description {
 		@include body-m-regular;
-		color: kv-color('neutral-2');
+		color: var(--text-container-neutral-default);
 
 		kv-tooltip::part(content) {
 			display: inline;
@@ -59,7 +59,7 @@ kv-description-list {
 			@include clickable;
 			display: inline-block;
 			vertical-align: text-top;
-			margin-left: $spacing-2x;
+			margin-left: var(--spacing-md);
 		}
 
 		kv-copy-to-clipboard {
@@ -70,5 +70,5 @@ kv-description-list {
 }
 
 .description-list-tooltip-container::part(tooltip-container) {
-	padding: $spacing-2x;
+	padding: var(--spacing-md);
 }

--- a/packages/ui-components/src/components/form-help-text/form-help-text.scss
+++ b/packages/ui-components/src/components/form-help-text/form-help-text.scss
@@ -6,12 +6,12 @@
 	 * @prop --help-text-error-color: Help Text color when state is invalid.
 	 */
 
-	--help-text-default-color: var(--text-surface-neutral-tertiary, #{kv-color('neutral-4')});
-	--help-text-error-color: var(--text-container-status-danger-default, #{kv-color('error', 'light')});
-	--help-text-top-spacing: var(--spacing-xs, #{$spacing});
-	--help-text-bottom-spacing: var(--spacing-none, 0);
-	--help-text-right-spacing: var(--spacing-none, 0);
-	--help-text-left-spacing: var(--spacing-md, #{$spacing-2x});
+	--help-text-default-color: var(--text-surface-neutral-tertiary);
+	--help-text-error-color: var(--text-container-status-danger-default);
+	--help-text-top-spacing: var(--spacing-xs);
+	--help-text-bottom-spacing: var(--spacing-none);
+	--help-text-right-spacing: var(--spacing-none);
+	--help-text-left-spacing: var(--spacing-md);
 
 	display: flex;
 }
@@ -27,20 +27,20 @@
 	.help-text {
 		@include body-s-regular;
 
-		margin-right: var(--spacing-xs, #{$spacing});
+		margin-right: var(--spacing-xs);
 		color: var(--help-text-default-color);
 	}
 
 	span + span::before {
 		content: '•';
-		padding-right: var(--spacing-xs, #{$spacing});
+		padding-right: var(--spacing-xs);
 	}
 
 	kv-icon {
 		--icon-color: var(--help-text-default-color);
 
 		align-items: center;
-		margin-right: var(--spacing-xs, #{$spacing-2x});
+		margin-right: var(--spacing-xs);
 		float: left;
 	}
 

--- a/packages/ui-components/src/components/form-label/form-label.scss
+++ b/packages/ui-components/src/components/form-label/form-label.scss
@@ -4,10 +4,10 @@
 	/**
 	 * @prop --label-color: Label Text color.
 	 */
-	 --label-color: var(--text-surface-neutral-tertiary, #{kv-color('neutral-4')});
-	 --label-required-color: var(--text-surface-danger-default, #{kv-color('error')});
-	 --label-gap: var(--spacing-2xs, #{$spacing});
-	 --label-bottom-spacing: var(--spacing-2xs, #{$spacing});
+	 --label-color: var(--text-surface-neutral-tertiary);
+	 --label-required-color: var(--text-surface-danger-default);
+	 --label-gap: var(--spacing-2xs);
+	 --label-bottom-spacing: var(--spacing-2xs);
 
 	 display: inline-flex;
 	 user-select: none;

--- a/packages/ui-components/src/components/illustration-message/illustration-message.scss
+++ b/packages/ui-components/src/components/illustration-message/illustration-message.scss
@@ -9,8 +9,8 @@
 	 */
 	--image-width: 60px;
 	--image-height: auto;
-	--header-color: var(--text-surface-neutral-secondary, #{kv-color('neutral-2')});
-	--description-color: var(--text-surface-neutral-tertiary, #{kv-color('neutral-4')});
+	--header-color: var(--text-surface-neutral-secondary);
+	--description-color: var(--text-surface-neutral-tertiary);
 }
 
 .illustration-message {
@@ -21,7 +21,7 @@
 }
 
 .image {
-	margin-bottom: var(--spacing-xl, #{$spacing-3x});
+	margin-bottom: var(--spacing-xl);
 	--illustration-width: var(--image-width);
 	--illustration-height: var(--image-height);
 }
@@ -37,5 +37,5 @@
 	text-align: center;
 	@include body-s-regular;
 	white-space: break-spaces;
-	margin-top: var(--spacing-xs, #{$spacing});
+	margin-top: var(--spacing-xs);
 }

--- a/packages/ui-components/src/components/inline-editable-field/inline-editable-field.scss
+++ b/packages/ui-components/src/components/inline-editable-field/inline-editable-field.scss
@@ -1,12 +1,5 @@
 @use '../../assets/styles' as *;
 
-:host {
-	--inline-editable-field-background-color-hover: var(--input-background-default);
-	--inline-editable-field-outline-color-hover: var(--input-border-color-default);
-	--inline-editable-field-outline-color-focus: var(--input-border-color-selected);
-
-}
-
 .inline-editable-field-container {
 	display: inline-flex;
 	align-items: center;
@@ -15,9 +8,15 @@
 	/**
 	* @prop --margin-top-bottom: Margin top and bottom of the editable container.
 	* @prop --margin-left-right: Margin left and right of the editable container.
+	* @prop --inline-editable-field-background-color-hover: Background color of the editable field on hover.
+	* @prop --inline-editable-field-outline-color-hover: Outline color of the editable field on hover.
+	* @prop --inline-editable-field-outline-color-focus: Outline color of the editable field on focus.
 	*/
 	--margin-top-bottom: var(--spacing-xs);
 	--margin-left-right: var(--spacing-md);
+	--inline-editable-field-background-color-hover: var(--input-background-default);
+	--inline-editable-field-outline-color-hover: var(--input-border-color-default);
+	--inline-editable-field-outline-color-focus: var(--input-border-color-selected);
 
 	&__hover .inline-editable-field-slot {
 		border-radius: var(--radius-md);
@@ -67,6 +66,6 @@
 	&__focus {
 		width: 64px;
 		align-self: flex-end;
-		margin-bottom: calc(var(--margin-left-right) * -1);
+		margin-bottom: calc(var(--margin-top-bottom) * -1);
 	}
 }

--- a/packages/ui-components/src/components/inline-editable-field/inline-editable-field.scss
+++ b/packages/ui-components/src/components/inline-editable-field/inline-editable-field.scss
@@ -1,5 +1,12 @@
 @use '../../assets/styles' as *;
 
+:host {
+	--inline-editable-field-background-color-hover: var(--input-background-default);
+	--inline-editable-field-outline-color-hover: var(--input-border-color-default);
+	--inline-editable-field-outline-color-focus: var(--input-border-color-selected);
+
+}
+
 .inline-editable-field-container {
 	display: inline-flex;
 	align-items: center;
@@ -9,12 +16,13 @@
 	* @prop --margin-top-bottom: Margin top and bottom of the editable container.
 	* @prop --margin-left-right: Margin left and right of the editable container.
 	*/
-	--margin-top-bottom: #{$spacing};
-	--margin-left-right: #{$spacing-2x};
+	--margin-top-bottom: var(--spacing-xs);
+	--margin-left-right: var(--spacing-md);
 
 	&__hover .inline-editable-field-slot {
-		border-radius: 4px;
-		background: kv-color('neutral-8');
+		border-radius: var(--radius-md);
+		background: var(--inline-editable-field-background-color-hover);
+		outline-color: var(--inline-editable-field-outline-color-hover);
 	}
 }
 
@@ -29,12 +37,13 @@
 
 		&:hover,
 		&:focus {
-			border-radius: 4px;
-			background: kv-color('neutral-8');
+			border-radius: var(--radius-md);
+			background: var(--inline-editable-field-background-color-hover);
+			outline-color: var(--inline-editable-field-outline-color-hover);
 		}
 
 		&:focus {
-			outline-color: kv-color('neutral-2');
+			outline-color: var(--inline-editable-field-outline-color-focus);
 			text-overflow: unset;
 		}
 	}
@@ -51,9 +60,9 @@
 
 .inline-editable-field-actions {
 	display: inline-flex;
-	gap: $spacing;
+	gap: var(--spacing-xs);
 	flex: 0;
-	margin-left: calc(var(--margin-left-right) + $spacing-2x);
+	margin-left: calc(var(--margin-left-right) + var(--spacing-md));
 
 	&__focus {
 		width: 64px;

--- a/packages/ui-components/src/components/portal/portal.scss
+++ b/packages/ui-components/src/components/portal/portal.scss
@@ -5,7 +5,7 @@
 	 * @prop --portal-arrow-color: arrow color.
 	 */
 
-	--portal-arrow-color: var(--tooltip-background-default, #{kv-color('neutral-6')});
+	--portal-arrow-color: var(--tooltip-background-default);
 }
 
 .portal-container {

--- a/packages/ui-components/src/components/radio-list-item/radio-list-item.scss
+++ b/packages/ui-components/src/components/radio-list-item/radio-list-item.scss
@@ -29,9 +29,11 @@
 	--radio-list-item-border: 1px solid var(--border-persistent-radio-selector-default);
 	--radio-list-item-border-color-hover: var(--border-persistent-radio-selector-hover);
 	--radio-list-item-border-color-checked: var(--border-persistent-radio-selector-seleted);
-	--radio-list-item-border-radius: var(--radius-sm);
-	--radio-list-item-padding: var(--spacing-2xl);
-	--radio-list-item-gap: var(--spacing-md);
+	--radio-list-item-border-radius: var(--radius-md);
+	--radio-list-item-padding-large: var(--spacing-2xl);
+	--radio-list-item-padding-small: var(--spacing-xs) var(--spacing-2xl) var(--spacing-xs) var(--spacing-md);
+	--radio-list-item-gap-large: var(--spacing-md);
+	--radio-list-item-gap-small: var(--spacing-none);
 }
 
 .radio-list-item-container {
@@ -101,7 +103,12 @@
 	.content {
 		display: flex;
 		align-items: center;
-		padding: var(--radio-list-item-padding);
-		gap: var(--radio-list-item-gap);
+		padding: var(--radio-list-item-padding-large);
+		gap: var(--radio-list-item-gap-large);
+
+		&--size-small {
+			gap: var(--radio-list-item-gap-small);
+			padding: var(--radio-list-item-padding-small);
+		}
 	}
 }

--- a/packages/ui-components/src/components/radio-list-item/radio-list-item.scss
+++ b/packages/ui-components/src/components/radio-list-item/radio-list-item.scss
@@ -13,19 +13,25 @@
 	 * @prop --radio-list-item-gap: Gap between radio and info content. Default: 16px (spacing-4x).
 	 * @prop --radio-list-item-label-color: Label text color. Default: neutral-0.
 	 * @prop --radio-list-item-description-color: Description text color. Default: neutral-4.
-	 * @prop --radio-list-item-disabled-opacity: Opacity when disabled. Default: 0.5.
 	 */
 
-	--radio-list-item-background: transparent;
-	--radio-list-item-background-hover: transparent;
-	--radio-list-item-background-checked: transparent;
-	--radio-list-item-border: 1px solid #{kv-color('neutral-7')};
-	--radio-list-item-border-color-hover: #{kv-color('neutral-0')};
-	--radio-list-item-border-color-checked: #{kv-color('neutral-0')};
-	--radio-list-item-border-radius: 2px;
-	--radio-list-item-padding: var(--spacing-2xl, #{$spacing-4x});
-	--radio-list-item-gap: var(--spacing-md, #{$spacing-4x});
-	--radio-list-item-disabled-opacity: 0.5;
+	--radio-list-item-background: var(--background-persistent-radio-selector-default);
+	--radio-list-item-background-hover: var(--background-persistent-radio-selector-hover);
+	--radio-list-item-background-checked: var(--background-persistent-radio-selector-selected);
+	
+	--radio-list-item-label-color: var(--text-interactive-card-default);
+	--radio-list-item-label-color-hover: var(--text-interactive-card-hover);
+	--radio-list-item-label-color-checked: var(--text-interactive-card-selected);
+	--radio-list-item-label-color-disabled: var(--text-interactive-card-disabled);
+	--radio-list-item-description-color: var(--text-container-neutral-default);
+	--radio-list-item-description-color-disabled: var(--text-container-neutral-disabled);
+	
+	--radio-list-item-border: 1px solid var(--border-persistent-radio-selector-default);
+	--radio-list-item-border-color-hover: var(--border-persistent-radio-selector-hover);
+	--radio-list-item-border-color-checked: var(--border-persistent-radio-selector-seleted);
+	--radio-list-item-border-radius: var(--radius-sm);
+	--radio-list-item-padding: var(--spacing-2xl);
+	--radio-list-item-gap: var(--spacing-md);
 }
 
 .radio-list-item-container {
@@ -41,20 +47,53 @@
 
 	@include clickable;
 
-	&--checked,
-	&:focus,
-	&:hover {
-		background: var(--radio-list-item-background-hover);
-		border-color: var(--radio-list-item-border-color-hover);
+	.info {
+		flex: 1;
+		min-width: 0;
+
+		.label {
+			@include heading-m-semibold;
+			color: var(--radio-list-item-label-color);
+		}
+
+		.description {
+			@include body-m-regular;
+			color: var(--radio-list-item-description-color);
+
+			kv-link::part(container) {
+				display: inline;
+			}
+		}
 	}
 
-	&--checked {
+	&:hover:not(.radio-list-item-container--checked):not(.radio-list-item-container--disabled) {
+		background: var(--radio-list-item-background-hover);
+		border-color: var(--radio-list-item-border-color-hover);
+
+		.info .label {
+			color: var(--radio-list-item-label-color-hover);
+		}
+	}
+
+	&--checked:not(.radio-list-item-container--disabled) {
 		background: var(--radio-list-item-background-checked);
 		border-color: var(--radio-list-item-border-color-checked);
+
+		.info .label {
+			color: var(--radio-list-item-label-color-checked);
+		}
 	}
 
 	&--disabled {
-		opacity: var(--radio-list-item-disabled-opacity);
+		.info {
+			.label {
+				color: var(--radio-list-item-label-color-disabled)
+			}
+
+			.description {
+				color: var(--radio-list-item-description-color-disabled);
+			}
+		}
 
 		@include non-clickable;
 	}
@@ -64,24 +103,5 @@
 		align-items: center;
 		padding: var(--radio-list-item-padding);
 		gap: var(--radio-list-item-gap);
-	}
-
-	.info {
-		flex: 1;
-		min-width: 0;
-
-		.label {
-			@include heading-m-semibold;
-			color: kv-color('neutral-0');
-		}
-
-		.description {
-			@include body-m-regular;
-			color: kv-color('neutral-4');
-
-			kv-link::part(container) {
-				display: inline;
-			}
-		}
 	}
 }

--- a/packages/ui-components/src/components/radio-list-item/radio-list-item.tsx
+++ b/packages/ui-components/src/components/radio-list-item/radio-list-item.tsx
@@ -33,6 +33,9 @@ export class KvRadioListItem implements IRadioListItem, IRadioListItemEvents {
 
 	private onOptionClick = (ev: Event) => {
 		ev.stopPropagation();
+		if (this.disabled) {
+			return;
+		}
 		this.optionClick.emit(this.optionId);
 	};
 
@@ -40,21 +43,20 @@ export class KvRadioListItem implements IRadioListItem, IRadioListItemEvents {
 		return (
 			<Host>
 				<div
-					tabIndex={this.disabled ? -1 : 0}
 					class={{
 						'radio-list-item-container': true,
-						'radio-list-item-container--disabled': this.disabled,
-						'radio-list-item-container--checked': this.checked
+						'radio-list-item-container--disabled': !!this.disabled,
+						'radio-list-item-container--checked': !!this.checked
 					}}
 					onClick={this.onOptionClick}
 				>
 					<slot name="header" />
 					<div class="content">
-						<kv-radio size={EComponentSize.Large} checked={this.checked} disabled={this.disabled} onCheckedChange={this.onOptionClick} />
+						<kv-radio size={EComponentSize.Small} checked={this.checked} disabled={this.disabled} onCheckedChange={this.onOptionClick} />
 						<div class="info">
-							<slot name="label">
-								<div class="label">{this.label}</div>
-							</slot>
+							<div class="label">
+								<slot name="label">{this.label}</slot>
+							</div>
 							{this.description && <div class="description">{this.parsedDescription}</div>}
 							<slot name="additional-info"></slot>
 						</div>

--- a/packages/ui-components/src/components/radio-list-item/radio-list-item.tsx
+++ b/packages/ui-components/src/components/radio-list-item/radio-list-item.tsx
@@ -12,9 +12,11 @@ export class KvRadioListItem implements IRadioListItem, IRadioListItemEvents {
 	/** @inheritdoc */
 	@Prop({ reflect: true }) optionId!: string | number;
 	/** @inheritdoc */
-	@Prop({ reflect: true }) label!: string;
+	@Prop({ reflect: true }) label?: string;
 	/** @inheritdoc */
 	@Prop({ reflect: true }) description?: string;
+	/** @inheritdoc */
+	@Prop({ reflect: true }) size: EComponentSize = EComponentSize.Large;
 	/** @inheritdoc */
 	@Prop({ reflect: true }) checked?: boolean = false;
 	/** @inheritdoc */
@@ -51,7 +53,7 @@ export class KvRadioListItem implements IRadioListItem, IRadioListItemEvents {
 					onClick={this.onOptionClick}
 				>
 					<slot name="header" />
-					<div class="content">
+					<div class={{ content: true, [`content--size-${this.size}`]: true }}>
 						<kv-radio size={EComponentSize.Small} checked={this.checked} disabled={this.disabled} onCheckedChange={this.onOptionClick} />
 						<div class="info">
 							<div class="label">

--- a/packages/ui-components/src/components/radio-list-item/radio-list-item.types.ts
+++ b/packages/ui-components/src/components/radio-list-item/radio-list-item.types.ts
@@ -1,12 +1,15 @@
 import { EventEmitter } from '@stencil/core';
+import { EComponentSize } from '../../types';
 
 export interface IRadioListItem {
 	/** (required) The unique id that serves as a key for this item */
 	optionId: string | number;
 	/** (required) The label to display */
-	label: string;
+	label?: string;
 	/** (optional) The description that can contain links in the [text](url) format */
 	description?: string;
+	/** (optional) Button's size */
+	size?: EComponentSize;
 	/** (optional) Defines if this option is checked */
 	checked?: boolean;
 	/** (optional) Defines if this option is disabled */

--- a/packages/ui-components/src/components/radio-list-item/readme.md
+++ b/packages/ui-components/src/components/radio-list-item/readme.md
@@ -53,13 +53,14 @@ export const RadioListItemExample: React.FC = () => (
 
 ## Properties
 
-| Property                | Attribute     | Description                                                                 | Type               | Default     |
-| ----------------------- | ------------- | --------------------------------------------------------------------------- | ------------------ | ----------- |
-| `checked`               | `checked`     | (optional) Defines if this option is checked                                | `boolean`          | `false`     |
-| `description`           | `description` | (optional) The description that can contain links in the [text](url) format | `string`           | `undefined` |
-| `disabled`              | `disabled`    | (optional) Defines if this option is disabled                               | `boolean`          | `false`     |
-| `label` _(required)_    | `label`       | (required) The label to display                                             | `string`           | `undefined` |
-| `optionId` _(required)_ | `option-id`   | (required) The unique id that serves as a key for this item                 | `number \| string` | `undefined` |
+| Property                | Attribute     | Description                                                                 | Type                                           | Default                |
+| ----------------------- | ------------- | --------------------------------------------------------------------------- | ---------------------------------------------- | ---------------------- |
+| `checked`               | `checked`     | (optional) Defines if this option is checked                                | `boolean`                                      | `false`                |
+| `description`           | `description` | (optional) The description that can contain links in the [text](url) format | `string`                                       | `undefined`            |
+| `disabled`              | `disabled`    | (optional) Defines if this option is disabled                               | `boolean`                                      | `false`                |
+| `label`                 | `label`       | (required) The label to display                                             | `string`                                       | `undefined`            |
+| `optionId` _(required)_ | `option-id`   | (required) The unique id that serves as a key for this item                 | `number \| string`                             | `undefined`            |
+| `size`                  | `size`        | (optional) Button's size                                                    | `EComponentSize.Large \| EComponentSize.Small` | `EComponentSize.Large` |
 
 
 ## Events

--- a/packages/ui-components/src/components/radio-list-item/readme.md
+++ b/packages/ui-components/src/components/radio-list-item/readme.md
@@ -81,7 +81,6 @@ export const RadioListItemExample: React.FC = () => (
 | `--radio-list-item-border-color-hover`   | Border color on hover. Default: neutral-0.                           |
 | `--radio-list-item-border-radius`        | Border radius. Default: 2px.                                         |
 | `--radio-list-item-description-color`    | Description text color. Default: neutral-4.                          |
-| `--radio-list-item-disabled-opacity`     | Opacity when disabled. Default: 0.5.                                 |
 | `--radio-list-item-gap`                  | Gap between radio and info content. Default: 16px (spacing-4x).      |
 | `--radio-list-item-label-color`          | Label text color. Default: neutral-0.                                |
 | `--radio-list-item-padding`              | Content padding. Default: 16px (spacing-4x).                         |

--- a/packages/ui-components/src/components/radio-list-item/test/__snapshots__/radio-list-item.spec.tsx.snap
+++ b/packages/ui-components/src/components/radio-list-item/test/__snapshots__/radio-list-item.spec.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Radio List Item (unit tests) when passing required props and \`checked\` true should match the snapshot 1`] = `
-<kv-radio-list-item checked="" label="K3S" option-id="k3s">
+<kv-radio-list-item checked="" label="K3S" option-id="k3s" size="large">
   <template shadowrootmode="open">
     <div class="radio-list-item-container radio-list-item-container--checked">
       <slot name="header"></slot>
-      <div class="content">
+      <div class="content content--size-large">
         <kv-radio checked="" size="small"></kv-radio>
         <div class="info">
           <div class="label">
@@ -22,11 +22,11 @@ exports[`Radio List Item (unit tests) when passing required props and \`checked\
 `;
 
 exports[`Radio List Item (unit tests) when passing required props and \`disabled\` true should match the snapshot 1`] = `
-<kv-radio-list-item disabled="" label="K3S" option-id="k3s">
+<kv-radio-list-item disabled="" label="K3S" option-id="k3s" size="large">
   <template shadowrootmode="open">
     <div class="radio-list-item-container radio-list-item-container--disabled">
       <slot name="header"></slot>
-      <div class="content">
+      <div class="content content--size-large">
         <kv-radio disabled="" size="small"></kv-radio>
         <div class="info">
           <div class="label">
@@ -43,11 +43,11 @@ exports[`Radio List Item (unit tests) when passing required props and \`disabled
 `;
 
 exports[`Radio List Item (unit tests) when passing required props and a description should match the snapshot 1`] = `
-<kv-radio-list-item description="Check the [documentation](https://docs.kelvininc.com/4.10.2/) here." label="K3S" option-id="k3s">
+<kv-radio-list-item description="Check the [documentation](https://docs.kelvininc.com/4.10.2/) here." label="K3S" option-id="k3s" size="large">
   <template shadowrootmode="open">
     <div class="radio-list-item-container">
       <slot name="header"></slot>
-      <div class="content">
+      <div class="content content--size-large">
         <kv-radio size="small"></kv-radio>
         <div class="info">
           <div class="label">
@@ -69,11 +69,11 @@ exports[`Radio List Item (unit tests) when passing required props and a descript
 `;
 
 exports[`Radio List Item (unit tests) when passing required props should match the snapshot 1`] = `
-<kv-radio-list-item label="K3S" option-id="k3s">
+<kv-radio-list-item label="K3S" option-id="k3s" size="large">
   <template shadowrootmode="open">
     <div class="radio-list-item-container">
       <slot name="header"></slot>
-      <div class="content">
+      <div class="content content--size-large">
         <kv-radio size="small"></kv-radio>
         <div class="info">
           <div class="label">

--- a/packages/ui-components/src/components/radio-list-item/test/__snapshots__/radio-list-item.spec.tsx.snap
+++ b/packages/ui-components/src/components/radio-list-item/test/__snapshots__/radio-list-item.spec.tsx.snap
@@ -3,16 +3,16 @@
 exports[`Radio List Item (unit tests) when passing required props and \`checked\` true should match the snapshot 1`] = `
 <kv-radio-list-item checked="" label="K3S" option-id="k3s">
   <template shadowrootmode="open">
-    <div class="radio-list-item-container radio-list-item-container--checked" tabindex="0">
+    <div class="radio-list-item-container radio-list-item-container--checked">
       <slot name="header"></slot>
       <div class="content">
-        <kv-radio checked="" size="large"></kv-radio>
+        <kv-radio checked="" size="small"></kv-radio>
         <div class="info">
-          <slot name="label">
-            <div class="label">
+          <div class="label">
+            <slot name="label">
               K3S
-            </div>
-          </slot>
+            </slot>
+          </div>
           <slot name="additional-info"></slot>
         </div>
       </div>
@@ -24,16 +24,16 @@ exports[`Radio List Item (unit tests) when passing required props and \`checked\
 exports[`Radio List Item (unit tests) when passing required props and \`disabled\` true should match the snapshot 1`] = `
 <kv-radio-list-item disabled="" label="K3S" option-id="k3s">
   <template shadowrootmode="open">
-    <div class="radio-list-item-container radio-list-item-container--disabled" tabindex="-1">
+    <div class="radio-list-item-container radio-list-item-container--disabled">
       <slot name="header"></slot>
       <div class="content">
-        <kv-radio disabled="" size="large"></kv-radio>
+        <kv-radio disabled="" size="small"></kv-radio>
         <div class="info">
-          <slot name="label">
-            <div class="label">
+          <div class="label">
+            <slot name="label">
               K3S
-            </div>
-          </slot>
+            </slot>
+          </div>
           <slot name="additional-info"></slot>
         </div>
       </div>
@@ -45,16 +45,16 @@ exports[`Radio List Item (unit tests) when passing required props and \`disabled
 exports[`Radio List Item (unit tests) when passing required props and a description should match the snapshot 1`] = `
 <kv-radio-list-item description="Check the [documentation](https://docs.kelvininc.com/4.10.2/) here." label="K3S" option-id="k3s">
   <template shadowrootmode="open">
-    <div class="radio-list-item-container" tabindex="0">
+    <div class="radio-list-item-container">
       <slot name="header"></slot>
       <div class="content">
-        <kv-radio size="large"></kv-radio>
+        <kv-radio size="small"></kv-radio>
         <div class="info">
-          <slot name="label">
-            <div class="label">
+          <div class="label">
+            <slot name="label">
               K3S
-            </div>
-          </slot>
+            </slot>
+          </div>
           <div class="description">
             Check the
             <kv-link href="https://docs.kelvininc.com/4.10.2/" label="documentation" target="_blank"></kv-link>
@@ -71,16 +71,16 @@ exports[`Radio List Item (unit tests) when passing required props and a descript
 exports[`Radio List Item (unit tests) when passing required props should match the snapshot 1`] = `
 <kv-radio-list-item label="K3S" option-id="k3s">
   <template shadowrootmode="open">
-    <div class="radio-list-item-container" tabindex="0">
+    <div class="radio-list-item-container">
       <slot name="header"></slot>
       <div class="content">
-        <kv-radio size="large"></kv-radio>
+        <kv-radio size="small"></kv-radio>
         <div class="info">
-          <slot name="label">
-            <div class="label">
+          <div class="label">
+            <slot name="label">
               K3S
-            </div>
-          </slot>
+            </slot>
+          </div>
           <slot name="additional-info"></slot>
         </div>
       </div>

--- a/packages/ui-components/src/components/radio-list/radio-list.scss
+++ b/packages/ui-components/src/components/radio-list/radio-list.scss
@@ -3,5 +3,5 @@
 .radio-list-items {
 	display: flex;
 	flex-direction: column;
-	gap: $spacing-2x;
+	gap: var(--spacing-md);
 }

--- a/packages/ui-components/src/components/radio/radio.scss
+++ b/packages/ui-components/src/components/radio/radio.scss
@@ -14,16 +14,16 @@
 	 * @prop --radio-background-disabled-color: Radio circle background color when state is disabled.
 	 */
 
-	--input-height-large: var(--input-height-regular, 36px);
-	--input-height-small: var(--input-height-compact, 28px);
+	--input-height-large: var(--input-height-regular);
+	--input-height-small: var(--input-height-compact);
 	--input-gap-large: var(--spacing-none);
 	--input-gap-small: var(--spacing-xs);
 	--input-label-color: var(--text-surface-neutral-secondary);
 
-	--radio-input-large: var(--size-xl, 14px);
-	--radio-input-small: var(--size-default, 14px);
-	--radio-input-default-color: var(--icon-persistent-indicator-on, #{kv-color('neutral-0')});
-	--radio-input-disabled-color: var(--icon-surface-neutral-disabled, #{kv-color('neutral-0')});
+	--radio-input-large: var(--size-xl);
+	--radio-input-small: var(--size-default);
+	--radio-input-default-color: var(--icon-persistent-indicator-on);
+	--radio-input-disabled-color: var(--icon-surface-neutral-disabled);
 	--radio-background-default-color: var(--transparent);
 	--radio-background-hover-color: var(--overlay-interactive-opacity-10);
 	--radio-background-pressed-color: var(--overlay-interactive-opacity-16);

--- a/packages/ui-components/src/components/relative-time-picker/relative-time-picker.scss
+++ b/packages/ui-components/src/components/relative-time-picker/relative-time-picker.scss
@@ -12,20 +12,24 @@
 	display: flex;
 	flex-direction: column;
 	width: 328px;
+	/* stylelint-disable-next-line csstools/value-no-unknown-custom-properties -- vars defined by parent component */
 	max-height: var(--max-height);
 	background-color: var(--background-color);
 
 	.relative-time-selector {
 		@include kelvin-scrollbar;
 
+		/* stylelint-disable-next-line csstools/value-no-unknown-custom-properties -- vars defined by parent component */
 		padding: var(--padding-size) 0;
 		display: flex;
 		flex-direction: column;
+		/* stylelint-disable-next-line csstools/value-no-unknown-custom-properties -- vars defined by parent component */
 		gap: var(--group-gap);
 		overflow: auto;
 		min-height: var(--min-height);
 
 		kv-time-picker-select-option {
+			/* stylelint-disable-next-line csstools/value-no-unknown-custom-properties -- vars defined by parent component */
 			--time-picker-select-option-height: var(--option-height);
 		}
 

--- a/packages/ui-components/src/components/select-create-option/select-create-option.scss
+++ b/packages/ui-components/src/components/select-create-option/select-create-option.scss
@@ -3,7 +3,7 @@
 .select-create-option {
 	display: flex;
 	align-items: flex-start;
-	gap: var(--spacing-xl, #{$spacing-3x});
+	gap: var(--spacing-xl);
 }
 
 .form {
@@ -14,5 +14,5 @@
 .actions {
 	display: flex;
 	align-items: center;
-	gap: var(--spacing-xs, #{$spacing});
+	gap: var(--spacing-xs);
 }

--- a/packages/ui-components/src/components/select-multi-options/select-multi-options.scss
+++ b/packages/ui-components/src/components/select-multi-options/select-multi-options.scss
@@ -28,14 +28,14 @@ kv-select {
 .selected-items-label {
 	@include ellipsis;
 	@include body-s-regular;
-	color: var(--text-container-neutral-subtle, #{kv-color('neutral-4')});
+	color: var(--text-container-neutral-subtle);
 	text-wrap: nowrap;
 }
 
 .counter {
 	display: flex;
 	align-items: center;
-	color: var(--text-container-neutral-subtle, #{kv-color('neutral-4')});
+	color: var(--text-container-neutral-subtle);
 	@include body-xs-regular;
 }
 
@@ -43,22 +43,22 @@ kv-select {
 	position: absolute;
 	top: 0;
 	left: 0;
-	border-radius: var(--slider-radius-default, #{$spacing});
-	border: var(--slider-border-thickness-default, 1px) solid var(--slider-border-color-default, #{kv-color('neutral-6')});
+	border-radius: var(--slider-radius-default);
+	border: var(--slider-border-thickness-default) solid var(--slider-border-color-default);
 	width: calc(100% - 2px);
 	height: calc(100% - 2px);
-	background: var(--overlay-surface-opacity-80, #{kv-color('neutral-7', 'base', 0.8)});
+	background: var(--overlay-surface-opacity-80);
 	z-index: 1;
 
 	&.has-shortcuts .create-new-option-form {
 		bottom: 36px;
-		border-bottom: var(--slider-border-thickness-default, 1px) solid var(--slider-border-color-default, #{kv-color('neutral-6')});
+		border-bottom: var(--slider-border-thickness-default) solid var(--slider-border-color-default);
 	}
 }
 
 .form-container {
-	background: var(--slider-background-default, #{kv-color('neutral-7')});
-	padding: var(--spacing-xl, #{$spacing-3x}) var(--spacing-2xl, #{$spacing-4x});
+	background: var(--slider-background-default);
+	padding: var(--spacing-xl) var(--spacing-2xl);
 }
 
 .create-new-option-form {
@@ -66,12 +66,12 @@ kv-select {
 	position: absolute;
 	bottom: 0;
 	left: 0;
-	border-top: var(--slider-border-thickness-default, 1px) solid var(--slider-border-color-default, #{kv-color('neutral-6')});
+	border-top: var(--slider-border-thickness-default) solid var(--slider-border-color-default);
 }
 
 .create-new-option-button {
-	border-top: var(--slider-border-thickness-default, 1px) solid var(--slider-border-color-default, #{kv-color('neutral-6')});
-	padding: var(--spacing-xl, #{$spacing-3x}) 0;
+	border-top: var(--slider-border-thickness-default) solid var(--slider-border-color-default);
+	padding: var(--spacing-xl) 0;
 }
 
 .no-results-found,
@@ -81,7 +81,7 @@ kv-select {
 
 	.illustration-message {
 		max-width: 292px;
-		padding: var(--spacing-5xl, #{$spacing-8x}) var(--spacing-xl, #{$spacing-3x});
+		padding: var(--spacing-5xl) var(--spacing-xl);
 		align-self: center;
 	}
 }

--- a/packages/ui-components/src/components/select-option/select-option.scss
+++ b/packages/ui-components/src/components/select-option/select-option.scss
@@ -25,38 +25,38 @@
 	--select-option-height: 32px;
 	--select-option-transition-duration: 100ms;
 
-	--select-option-background-color: var(--transparent, #{kv-color('neutral-7')});
-	--select-option-background-color-selected: var(--background-interactive-slider-list-selected, #{kv-color('neutral-6')});
-	--select-option-background-color-highlighted: var(--background-interactive-slider-list-hover, #{kv-color('neutral-6')});
-	--select-option-background-color-hover: var(--background-interactive-slider-list-hover, #{kv-color('neutral-6')});
-	--select-option-background-color-disabled: var(--transparent, #{kv-color('neutral-7')});
+	--select-option-background-color: var(--transparent);
+	--select-option-background-color-selected: var(--background-interactive-slider-list-selected);
+	--select-option-background-color-highlighted: var(--background-interactive-slider-list-hover);
+	--select-option-background-color-hover: var(--background-interactive-slider-list-hover);
+	--select-option-background-color-disabled: var(--transparent);
 
-	--select-option-label-color: var(--text-interactive-slider-list-default, #{kv-color('neutral-4')});
-	--select-option-label-color-selected: var(--text-interactive-slider-list-selected, #{kv-color('neutral-1')});
-	--select-option-label-color-highlighted: var(--text-interactive-slider-list-hover, #{kv-color('neutral-2')});
-	--select-option-label-color-hover: var(--text-interactive-slider-list-hover, #{kv-color('neutral-2')});
-	--select-option-label-color-disabled: var(--text-interactive-slider-list-disabled, #{kv-color('neutral-6')});
+	--select-option-label-color: var(--text-interactive-slider-list-default);
+	--select-option-label-color-selected: var(--text-interactive-slider-list-selected);
+	--select-option-label-color-highlighted: var(--text-interactive-slider-list-hover);
+	--select-option-label-color-hover: var(--text-interactive-slider-list-hover);
+	--select-option-label-color-disabled: var(--text-interactive-slider-list-disabled);
 
-	--select-option-description-color: var(--text-on-color-neutral-tertiary, #{kv-color('neutral-4')});
-	--select-option-description-color-selected: var(--text-on-color-neutral-tertiary, #{kv-color('neutral-4')});
-	--select-option-description-color-highlighted: var(--text-on-color-neutral-tertiary, #{kv-color('neutral-4')});
-	--select-option-description-color-hover: var(--text-on-color-neutral-tertiary, #{kv-color('neutral-4')});
-	--select-option-description-color-disabled: var(--text-on-color-neutral-disabled, #{kv-color('neutral-6')});
+	--select-option-description-color: var(--text-on-color-neutral-tertiary);
+	--select-option-description-color-selected: var(--text-on-color-neutral-tertiary);
+	--select-option-description-color-highlighted: var(--text-on-color-neutral-tertiary);
+	--select-option-description-color-hover: var(--text-on-color-neutral-tertiary);
+	--select-option-description-color-disabled: var(--text-on-color-neutral-disabled);
 
-	--select-option-icon-color: var(--icon-interactive-slider-list-default, #{kv-color('neutral-0')});
-	--select-option-icon-color-selected: var(--icon-interactive-slider-list-selected, #{kv-color('neutral-0')});
-	--select-option-icon-color-highlighted: var(--icon-interactive-slider-list-hover, #{kv-color('neutral-0')});
-	--select-option-icon-color-hover: var(--icon-interactive-slider-list-hover, #{kv-color('neutral-0')});
-	--select-option-icon-color-disabled: var(--icon-interactive-slider-list-disabled, #{kv-color('neutral-6')});
+	--select-option-icon-color: var(--icon-interactive-slider-list-default);
+	--select-option-icon-color-selected: var(--icon-interactive-slider-list-selected);
+	--select-option-icon-color-highlighted: var(--icon-interactive-slider-list-hover);
+	--select-option-icon-color-hover: var(--icon-interactive-slider-list-hover);
+	--select-option-icon-color-disabled: var(--icon-interactive-slider-list-disabled);
 
-	--select-option-right-icon-color: var(--icon-interactive-slider-list-default, #{kv-color('neutral-4')});
-	--select-option-right-icon-color-selected: var(--icon-interactive-slider-list-selected, #{kv-color('neutral-4')});
-	--select-option-right-icon-color-highlighted: var(--icon-interactive-slider-list-hover, #{kv-color('neutral-4')});
-	--select-option-right-icon-color-hover: var(--icon-interactive-slider-list-hover, #{kv-color('neutral-4')});
-	--select-option-right-icon-color-disabled: var(--icon-interactive-slider-list-disabled, #{kv-color('neutral-6')});
+	--select-option-right-icon-color: var(--icon-interactive-slider-list-default);
+	--select-option-right-icon-color-selected: var(--icon-interactive-slider-list-selected);
+	--select-option-right-icon-color-highlighted: var(--icon-interactive-slider-list-hover);
+	--select-option-right-icon-color-hover: var(--icon-interactive-slider-list-hover);
+	--select-option-right-icon-color-disabled: var(--icon-interactive-slider-list-disabled);
 
-	--select-option-icon-size: var(--size-default, 16px);
-	--select-option-right-icon-size: var(--size-default, 16px);
+	--select-option-icon-size: var(--size-default);
+	--select-option-right-icon-size: var(--size-default);
 }
 
 .select-option {
@@ -68,15 +68,16 @@
 	cursor: pointer;
 	background-color: var(--select-option-background-color);
 	transition: background-color var(--select-option-transition-duration) linear;
-	padding-right: var(--spacing-2xl, #{$spacing-4x});
-	padding-left: calc(var(--level-padding-offset) + var(--spacing-2xl, #{$spacing-4x}));
+	padding-right: var(--spacing-2xl);
+	/* stylelint-disable-next-line csstools/value-no-unknown-custom-properties -- vars defined by parent component */
+	padding-left: calc(var(--level-padding-offset) + var(--spacing-2xl));
 
 	.text-container {
 		flex: 1;
 		min-width: 0;
 		display: flex;
 		align-items: center;
-		gap: var(--spacing-md, #{$spacing-2x});
+		gap: var(--spacing-md);
 	}
 
 	.left-content {
@@ -84,17 +85,17 @@
 		min-width: 0;
 		display: flex;
 		align-items: center;
-		gap: var(--spacing-xs, #{$spacing});
+		gap: var(--spacing-xs);
 	}
 
 	.right-content {
 		display: flex;
 		align-items: center;
-		gap: var(--spacing-md, #{$spacing-2x});
+		gap: var(--spacing-md);
 	}
 
 	.icon-container {
-		margin-right: var(--spacing-md, #{$spacing-2x});
+		margin-right: var(--spacing-md);
 
 		kv-icon {
 			--icon-width: var(--select-option-icon-size);
@@ -122,7 +123,7 @@
 	.group {
 		display: flex;
 		flex-direction: row;
-		gap: var(--spacing-xs, #{$spacing});
+		gap: var(--spacing-xs);
 		align-items: center;
 	}
 
@@ -217,13 +218,13 @@
 	&--heading {
 		.item-label {
 			@include body-m-regular;
-			color: var(--text-on-color-neutral-tertiary, #{kv-color('neutral-2')});
+			color: var(--text-on-color-neutral-tertiary);
 		}
 
 		.text-container .left-content::after {
-			@include kelvin-horizontal-divider(var(--border-on-color-neutral-default, #{kv-color('neutral-6')}));
+			@include kelvin-horizontal-divider(var(--border-on-color-neutral-default));
 
-			margin-left: var(--spacing-md, #{$spacing-2x});
+			margin-left: var(--spacing-md);
 		}
 	}
 

--- a/packages/ui-components/src/components/select-shortcuts-label/select-shortcuts-label.scss
+++ b/packages/ui-components/src/components/select-shortcuts-label/select-shortcuts-label.scss
@@ -1,50 +1,50 @@
 @use '../../assets/styles' as *;
 
 .shortcuts {
-	background: var(--background-container-neutral-default, #{kv-color('neutral-6')});
+	background: var(--background-container-neutral-default);
 	display: flex;
 	justify-content: space-between;
-	padding: var(--spacing-sm, #{$spacing-2x}) var(--spacing-2xl, #{$spacing-4x});
+	padding: var(--spacing-sm) var(--spacing-2xl);
 	user-select: none;
 }
 
 .left-items {
 	display: flex;
-	gap: var(--spacing-5xl, #{$spacing-5x});
+	gap: var(--spacing-5xl);
 }
 
 .group {
 	display: flex;
 	align-items: center;
-	gap: var(--spacing-md, #{$spacing-2x});
+	gap: var(--spacing-md);
 }
 
 .icons {
 	display: flex;
 	align-items: center;
-	gap: var(--spacing-xs, #{$spacing});
+	gap: var(--spacing-xs);
 }
 
 .label {
-	color: var(--text-on-color-neutral-tertiary, #{kv-color('neutral-4')});
+	color: var(--text-on-color-neutral-tertiary);
 	@include body-xs-regular;
 }
 
 .icon {
-	border-radius: var(--radius-sm, 4px);
-	background: var(--background-container-neutral-subtlest, #{kv-color('neutral-5')});
-	color: var(--text-container-neutral-default, #{kv-color('neutral-2')});
+	border-radius: var(--radius-sm);
+	background: var(--background-container-neutral-subtlest);
+	color: var(--text-container-neutral-default);
 	@include body-xs-regular;
 	text-align: center;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	height: var(--size-lg, 20px);
-	width: var(--size-lg, 20px);
+	height: var(--size-lg);
+	width: var(--size-lg);
 
 	kv-icon {
-		--icon-width: var(--size-default, 16px);
-		--icon-height: var(--size-default, 16px);
-		--icon-color: var(--icon-container-neutral-subtle, #{kv-color('neutral-2')});
+		--icon-width: var(--size-default);
+		--icon-height: var(--size-default);
+		--icon-color: var(--icon-container-neutral-subtle);
 	}
 }

--- a/packages/ui-components/src/components/select/select.scss
+++ b/packages/ui-components/src/components/select/select.scss
@@ -13,10 +13,10 @@
 	--select-min-height: auto;
 	--select-max-width: auto;
 	--select-min-width: max-content;
-	--select-background-color: var(--slider-background-default, #{kv-color('neutral-7')});
-	--select-border: var(--slider-border-thickness-default, 1px) solid var(--slider-border-color-default, #{kv-color('neutral-6')});
-	--select-inner-border: 1px solid var(--border-on-color-neutral-default, #{kv-color('neutral-6')});
-	--select-border-radius: var(--slider-radius-default, #{$spacing});
+	--select-background-color: var(--slider-background-default);
+	--select-border: var(--slider-border-thickness-default) solid var(--slider-border-color-default);
+	--select-inner-border: 1px solid var(--border-on-color-neutral-default);
+	--select-border-radius: var(--slider-radius-default);
 }
 
 .select-container {
@@ -46,8 +46,8 @@
 .select-header-container {
 	display: flex;
 	flex-direction: column;
-	gap: var(--spacing-md, #{$spacing-3x});
-	padding: 0 var(--spacing-xl, #{$spacing-4x}) var(--spacing-md, #{$spacing-3x});
+	gap: var(--spacing-md);
+	padding: 0 var(--spacing-xl) var(--spacing-md);
 	border-bottom: var(--select-inner-border);
 }
 
@@ -55,15 +55,15 @@
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	gap: var(--spacing-xl, #{$spacing-3x});
+	gap: var(--spacing-xl);
 
 	.footer-actions {
 		@include body-s-regular;
 		display: flex;
 		flex-direction: row;
 		align-items: center;
-		gap: var(--spacing-xs, #{$spacing-2x});
-		color: var(--text-container-neutral-subtle, #{kv-color('neutral-4')});
+		gap: var(--spacing-xs);
+		color: var(--text-container-neutral-subtle);
 	}
 
 	.divider {
@@ -71,7 +71,7 @@
 		height: 100%;
 
 		&::after {
-			@include kelvin-vertical-divider(var(--text-on-color-neutral-muted, #{kv-color('neutral-6')}));
+			@include kelvin-vertical-divider(var(--text-on-color-neutral-muted));
 		}
 	}
 }

--- a/packages/ui-components/src/components/single-select-dropdown/single-select-dropdown.scss
+++ b/packages/ui-components/src/components/single-select-dropdown/single-select-dropdown.scss
@@ -16,6 +16,6 @@
 .counter {
 	display: flex;
 	align-items: center;
-	color: var(--text-container-neutral-subtle, #{kv-color('neutral-4')});
+	color: var(--text-container-neutral-subtle);
 	@include body-xs-regular;
 }

--- a/packages/ui-components/src/components/switch-button/switch-button.scss
+++ b/packages/ui-components/src/components/switch-button/switch-button.scss
@@ -1,5 +1,6 @@
 @use '../../assets/styles' as *;
 
+/* stylelint-disable csstools/value-no-unknown-custom-properties */
 @mixin button-theme($size) {
 	height: var(--switch-height-#{$size});
 	width: var(--switch-width-#{$size});
@@ -19,6 +20,7 @@
 		transform: translateX(calc(var(--switch-width-#{$size}) - var(--switch-icon-size-#{$size})));
 	}
 }
+/* stylelint-enable csstools/value-no-unknown-custom-properties */
 
 :host {
 	/**
@@ -29,31 +31,31 @@
 	 * @prop --switch-disabled-icon-color: Icon square container background color when's disabled.
 	 */
 
-	--off-background-color: var(--switch-background-off, #{kv-color('neutral-5')});
-	--on-background-color: var(--switch-background-on, #{kv-color('primary')});
-	--disabled-background-color: var(--switch-background-disabled, #{kv-color('neutral-5')});
-	--switch-icon-color: var(--switch-icon-color-default, #{kv-color('primary', 'contrast')});
-	--switch-disabled-icon-color: var(--switch-icon-color-disabled, #{kv-color('neutral-6')});
+	--off-background-color: var(--switch-background-off);
+	--on-background-color: var(--switch-background-on);
+	--disabled-background-color: var(--switch-background-disabled);
+	--switch-icon-color: var(--switch-icon-color-default);
+	--switch-disabled-icon-color: var(--switch-icon-color-disabled);
 
 	// sizing - maps component size names (large/small) to token names (regular/compact)
-	--switch-height-large: var(--switch-height-regular, 20px);
-	--switch-height-small: var(--switch-height-compact, 16px);
-	--switch-width-large: var(--switch-width-regular, 40px);
-	--switch-width-small: var(--switch-width-compact, 32px);
-	--switch-icon-size-large: var(--switch-icon-size-regular, 16px);
-	--switch-icon-size-small: var(--switch-icon-size-compact, 11px);
-	--switch-padding-large: var(--spacing-2xs, 2px);
+	--switch-height-large: var(--switch-height-regular);
+	--switch-height-small: var(--switch-height-compact);
+	--switch-width-large: var(--switch-width-regular);
+	--switch-width-small: var(--switch-width-compact);
+	--switch-icon-size-large: var(--switch-icon-size-regular);
+	--switch-icon-size-small: var(--switch-icon-size-compact);
+	--switch-padding-large: var(--spacing-2xs);
 	--switch-padding-small: 2.5px;
 
 	display: flex;
 	align-items: center;
-	gap: var(--spacing-md, $spacing-2x);
+	gap: var(--spacing-md);
 }
 
 .switch-button {
 	display: flex;
 	box-sizing: border-box;
-	border-radius: var(--switch-radius-default, 4px);
+	border-radius: var(--switch-radius-default);
 	background-color: var(--off-background-color);
 	transition: background-color 0.3s ease-out;
 	

--- a/packages/ui-components/src/components/tag-status/tag-status.scss
+++ b/packages/ui-components/src/components/tag-status/tag-status.scss
@@ -17,19 +17,19 @@
 	 * @prop --tag-status-gap: Tag status gap between label and icon in pixels.
 	 */
 
-	--tag-status-label-color: var(--text-surface-neutral-secondary ,#{kv-color('neutral-2')});
-	--tag-status-icon-size: var(--size-md, 16px);
-	--tag-status-icon-success-color: var(--icon-surface-status-success-default, #{kv-color('success', 'dark')});
-	--tag-status-icon-success-background-color: var(--background-surface-inverse, #{kv-color('neutral-0')});
-	--tag-status-icon-error-color: var(--icon-surface-status-danger-default, #{kv-color('error', 'dark')});
-	--tag-status-icon-error-background-color: var(--background-surface-inverse, #{kv-color('neutral-0')});
-	--tag-status-icon-unknown-color: var(--icon-surface-status-inactive-default, #{kv-color('neutral-4')});
+	--tag-status-label-color: var(--text-surface-neutral-secondary );
+	--tag-status-icon-size: var(--size-md);
+	--tag-status-icon-success-color: var(--icon-surface-status-success-default);
+	--tag-status-icon-success-background-color: var(--background-surface-neutral-inverse);
+	--tag-status-icon-error-color: var(--icon-surface-status-danger-default);
+	--tag-status-icon-error-background-color: var(--background-surface-neutral-inverse);
+	--tag-status-icon-unknown-color: var(--icon-surface-status-inactive-default);
 	--tag-status-icon-unknown-background-color: transparent;
-	--tag-status-icon-warning-color: var(--icon-surface-status-warning-default, #{kv-color('warning', 'dark')});
+	--tag-status-icon-warning-color: var(--icon-surface-status-warning-default);
 	--tag-status-icon-warning-background-color: transparent;
-	--tag-status-icon-info-color: var(--icon-surface-status-info-default, #{kv-color('info', 'dark')});
-	--tag-status-icon-info-background-color: var(--background-surface-inverse, #{kv-color('neutral-0')});
-	--tag-status-gap: var(--spacing-md, #{$spacing-2x});
+	--tag-status-icon-info-color: var(--icon-surface-status-info-default);
+	--tag-status-icon-info-background-color: var(--background-surface-neutral-inverse);
+	--tag-status-gap: var(--spacing-md);
 }
 
 .tag-status {

--- a/packages/ui-components/src/components/tag/readme.md
+++ b/packages/ui-components/src/components/tag/readme.md
@@ -40,6 +40,7 @@ export const TagExample: React.FC = () => (
 | `--tag-background-color`       | Tag background color.              |
 | `--tag-badge-background-color` | Tag badge background color.        |
 | `--tag-badge-color`            | Tag badge text color.              |
+| `--tag-border-color`           | Tag border color.                  |
 | `--tag-content-gap`            | Gap between icon, label and badge. |
 | `--tag-content-padding-x`      | Horizontal padding inside the tag. |
 | `--tag-content-padding-y`      | Vertical padding inside the tag.   |

--- a/packages/ui-components/src/components/tag/tag.scss
+++ b/packages/ui-components/src/components/tag/tag.scss
@@ -3,6 +3,7 @@
 :host {
 	/**
 	 * @prop --tag-background-color: Tag background color.
+	 * @prop --tag-border-color: Tag border color.
 	 * @prop --tag-label-color: Tag label text color.
 	 * @prop --tag-badge-color: Tag badge text color.
 	 * @prop --tag-badge-background-color: Tag badge background color.
@@ -12,9 +13,9 @@
 	 * @prop --tag-content-padding-y: Vertical padding inside the tag.
 	 */
 
-	--tag-content-gap: var(--spacing-xs, #{$spacing});
-	--tag-content-padding-x: var(--spacing-md, #{$spacing});
-	--tag-content-padding-y: var(--spacing-none, 2px);
+	--tag-content-gap: var(--spacing-xs);
+	--tag-content-padding-x: var(--spacing-md);
+	--tag-content-padding-y: var(--spacing-none);
 }
 
 .tag-container {
@@ -23,19 +24,23 @@
 	align-items: center;
 	gap: var(--tag-content-gap);
 	width: fit-content;
-	height: var(--size-xl, 24px);
+	max-width: stretch;
+	height: var(--size-xl);
+	box-sizing: border-box;
 	border-radius: var(--radius-md);
 	padding: var(--tag-content-padding-y) var(--tag-content-padding-x);
 	background-color: var(--tag-background-color, var(--_tag-bg));
+	border: 1px solid var(--tag-border-color, var(--_tag-border-color));
 
 	kv-icon {
 		--icon-color: var(--tag-icon-color, var(--_tag-icon));
-		--icon-width: var(--size-md, 12px);
-		--icon-height: var(--size-md, 12px);
+		--icon-width: var(--size-md);
+		--icon-height: var(--size-md);
 	}
 
 	.tag-label {
 		@include label-m-regular;
+		@include ellipsis;
 
 		color: var(--tag-label-color, var(--_tag-label));
 	}
@@ -48,6 +53,7 @@
 	// Color variants
 	&--color-neutral {
 		--_tag-bg: var(--background-container-neutral-default);
+		--_tag-border-color: var(--border-container-tag-neutral-subtle);
 		--_tag-label: var(--text-container-neutral-subtle);
 		--_tag-badge: var(--text-container-neutral-subtle);
 		--_tag-badge-bg: var(--background-container-neutral-subtle);
@@ -56,6 +62,7 @@
 
 	&--color-brand {
 		--_tag-bg: var(--background-container-brand-default);
+		--_tag-border-color: var(--border-container-tag-brand-subtle);
 		--_tag-label: var(--text-container-brand-default);
 		--_tag-badge: var(--text-container-brand-default);
 		--_tag-badge-bg: var(--background-container-brand-subtle);
@@ -64,6 +71,7 @@
 
 	&--color-purple {
 		--_tag-bg: var(--background-container-accent-purple-default);
+		--_tag-border-color: var(--border-container-accent-purple-subtle);
 		--_tag-label: var(--text-container-accent-purple-default);
 		--_tag-badge: var(--text-container-accent-purple-default);
 		--_tag-badge-bg: var(--background-container-accent-purple-subtle);
@@ -72,6 +80,7 @@
 
 	&--color-green {
 		--_tag-bg: var(--background-container-status-success-default);
+		--_tag-border-color: var(--border-container-status-success-subtle);
 		--_tag-label: var(--text-container-status-success-default);
 		--_tag-badge: var(--text-container-status-success-default);
 		--_tag-badge-bg: var(--background-container-status-success-subtle);
@@ -80,6 +89,7 @@
 
 	&--color-yellow {
 		--_tag-bg: var(--background-container-status-warning-default);
+		--_tag-border-color: var(--border-container-status-warning-subtle);
 		--_tag-label: var(--text-container-status-warning-default);
 		--_tag-badge: var(--text-container-status-warning-default);
 		--_tag-badge-bg: var(--background-container-status-warning-subtle);
@@ -88,6 +98,7 @@
 
 	&--color-red {
 		--_tag-bg: var(--background-container-status-danger-default);
+		--_tag-border-color: var(--border-container-status-danger-subtle);
 		--_tag-label: var(--text-container-status-danger-default);
 		--_tag-badge: var(--text-container-status-danger-default);
 		--_tag-badge-bg: var(--background-container-status-danger-subtle);
@@ -96,6 +107,7 @@
 
 	&--color-blue {
 		--_tag-bg: var(--background-container-status-info-default);
+		--_tag-border-color: var(--border-container-status-info-subtle);
 		--_tag-label: var(--text-container-status-info-default);
 		--_tag-badge: var(--text-container-status-info-default);
 		--_tag-badge-bg: var(--background-container-status-info-subtle);

--- a/packages/ui-components/src/components/text-area/text-area.scss
+++ b/packages/ui-components/src/components/text-area/text-area.scss
@@ -5,7 +5,7 @@
 	* @prop --height-default: The height of the text area when is not focused.
 	* @prop --height-active: The height of the text are when is focused.
 	*/
-	--height-default: var(--text-area-height-default, 36px);
+	--height-default: var(--text-area-height-default);
 	--height-active: 100px;
 }
 

--- a/packages/ui-components/src/components/text-field/text-field.scss
+++ b/packages/ui-components/src/components/text-field/text-field.scss
@@ -40,56 +40,56 @@
 	--input-width: auto;
 	--input-min-width: 140px;
 	--input-max-width: 100%;
-	--input-height-large: var(--input-height-regular, 36px);
-	--input-height-small: var(--input-height-compact, 28px);
+	--input-height-large: var(--input-height-regular);
+	--input-height-small: var(--input-height-compact);
 	--input-gap-x: var(--input-gap-vertical-default);
-	--input-prefix-spacing-x: var(--input-gap-vertical-small, 2px);
-	--input-gap-y: var(--input-gap-horizontal-horizontal, #{$spacing});
+	--input-prefix-spacing-x: var(--input-gap-vertical-small);
+	--input-gap-y: var(--input-gap-horizontal-horizontal);
 	--input-padding-x-large: var(--input-padding-x-regular);
 	--input-padding-x-small: var(--input-padding-x-compact);
-	--input-radius-large: var(--input-radius-regular, 4px);
-	--input-radius-small: var(--input-radius-compact, 4px);
-	--input-border-thickness: var(--input-border-thickness-default, 1px);
-	--icon-size-large: var(--input-icon-size-regular, 24px);
-	--icon-size-small: var(--input-icon-size-regular, 16px);
-	--action-icon-size: var(--size-lg, 16px);
+	--input-radius-large: var(--input-radius-regular);
+	--input-radius-small: var(--input-radius-compact);
+	--input-border-thickness: var(--input-border-thickness-default);
+	--icon-size-large: var(--input-icon-size-regular);
+	--icon-size-small: var(--input-icon-size-regular);
+	--action-icon-size: var(--size-lg);
 
 	//Colors
 	////Default
-	--text-color-input-default: var(--input-text-text-input-default, #{kv-color('neutral-4')});
-	--text-color-help-text-default: var(--input-text-helper-text-default, #{kv-color('neutral-4')});
-	--border-color-default: var(--input-border-color-default, #{kv-color('neutral-6')});
-	--background-color-default: var(--input-background-default, #{kv-color('neutral-6')});
-	--text-color-icon-default: var(--input-icon-color-default, #{kv-color('neutral-4')});
-	--text-color-action-icon-default: var(--input-icon-color-default, #{kv-color('neutral-4')});
+	--text-color-input-default: var(--input-text-text-input-default);
+	--text-color-help-text-default: var(--input-text-helper-text-default);
+	--border-color-default: var(--input-border-color-default);
+	--background-color-default: var(--input-background-default);
+	--text-color-icon-default: var(--input-icon-color-default);
+	--text-color-action-icon-default: var(--input-icon-color-default);
 
 	/// Selected
-	--text-color-input-focused: var(--input-text-text-input-selected, #{kv-color('neutral-2')});
-	--border-color-focused: var(--input-border-color-selected, #{kv-color('neutral-0')});
-	--text-color-icon-focused: var(--icon-interactive-input-selected, #{kv-color('neutral-2')});
-	--text-color-action-icon-focused: var(--icon-interactive-input-selected, #{kv-color('neutral-2')});
+	--text-color-input-focused: var(--input-text-text-input-selected);
+	--border-color-focused: var(--input-border-color-selected);
+	--text-color-icon-focused: var(--icon-interactive-input-selected);
+	--text-color-action-icon-focused: var(--icon-interactive-input-selected);
 
 	/// Filled
-	--text-color-input-filled: var(--input-text-text-input-filled, #{kv-color('neutral-2')});
-	--text-color-icon-filled: var(--icon-interactive-input-filled, #{kv-color('neutral-2')});
-	--text-color-action-icon-filled: var(--icon-interactive-input-filled, #{kv-color('neutral-2')});
-	--border-color-filled: var(--input-border-color-filled, #{kv-color('neutral-6')});
+	--text-color-input-filled: var(--input-text-text-input-filled);
+	--text-color-icon-filled: var(--icon-interactive-input-filled);
+	--text-color-action-icon-filled: var(--icon-interactive-input-filled);
+	--border-color-filled: var(--input-border-color-filled);
 
 	/// Disabled
-	--text-color-input-disabled: var(--input-text-text-input-disabled, #{kv-color('neutral-5')});
-	--text-color-placeholder-disabled: var(--input-text-text-input-disabled, #{kv-color('neutral-5')});
-	--border-color-disabled: var(--input-border-color-disabled, #{kv-color('neutral-7')});
-	--background-color-disabled: var(--input-background-disabled, #{kv-color('neutral-7')});
-	--text-color-icon-disabled: var(--icon-interactive-input-disabled, #{kv-color('neutral-5')});
-	--text-color-action-icon-disabled: var(--icon-interactive-input-disabled, #{kv-color('neutral-5')});
+	--text-color-input-disabled: var(--input-text-text-input-disabled);
+	--text-color-placeholder-disabled: var(--input-text-text-input-disabled);
+	--border-color-disabled: var(--input-border-color-disabled);
+	--background-color-disabled: var(--input-background-disabled);
+	--text-color-icon-disabled: var(--icon-interactive-input-disabled);
+	--text-color-action-icon-disabled: var(--icon-interactive-input-disabled);
 
 	/// Error
-	--text-color-help-text-error: var(--input-text-helper-text-error, #{kv-color('error', 'light')});
-	--border-color-error: var(--input-border-color-error, #{kv-color('error')});
+	--text-color-help-text-error: var(--input-text-helper-text-error);
+	--border-color-error: var(--input-border-color-error);
 }
 
 kv-form-label {
-	--label-color: var(--input-text-label-default, #{kv-color('neutral-4')});
+	--label-color: var(--input-text-label-default);
 	--label-gap: var(--input-gap-vertical-small);
 	--label-required-color: var(--input-text-required-default);
 	--label-bottom-spacing: var(--spacing-none);
@@ -212,7 +212,7 @@ input {
 		height: 100%;
 		display: flex;
 		align-items: center;
-		gap: var(--spacing-xs, #{$spacing});
+		gap: var(--spacing-xs);
 
 		color: var(--text-color-input-default);
 

--- a/packages/ui-components/src/components/toaster/toaster.scss
+++ b/packages/ui-components/src/components/toaster/toaster.scss
@@ -14,10 +14,10 @@
 	--toaster-large-height: 76px;
 	--toaster-small-height: 56px;
 	--toaster-width: 360px;
-	--toaster-top-space: var(--spacing-2xl, #{$spacing-4x});
-	--background-color-default: var(--toast-background-default, #{kv-color('neutral-6')});
-	--toaster-icon-width: var(--toast-icon-size-large, 24px);
-	--toaster-icon-height: var(--toast-icon-size-large, 24px);
+	--toaster-top-space: var(--spacing-2xl);
+	--background-color-default: var(--toast-background-default);
+	--toaster-icon-width: var(--toast-icon-size-large);
+	--toaster-icon-height: var(--toast-icon-size-large);
 }
 
 .toaster-container {
@@ -33,8 +33,8 @@
 	justify-content: space-between;
 	gap: var(--toast-gap-vertical);
 	z-index: 1000;
-	padding: var(--toast-padding-y-default, #{$spacing-4x}) var(--toast-padding-x-default, #{$spacing-4x});
-	border-left: solid var(--toast-border-thickness-default, 2px) var(--background-color-default);
+	padding: var(--toast-padding-y-default) var(--toast-padding-x-default);
+	border-left: solid var(--toast-border-thickness-default) var(--background-color-default);
 	background-color: var(--background-color-default);
 	box-sizing: border-box;
 	overflow: hidden;
@@ -45,37 +45,37 @@
 	}
 
 	&.toaster-type--info {
-		border-color: var(--toast-border-color-info, #{kv-color('info')});
+		border-color: var(--toast-border-color-info);
 
 		.toaster-icon kv-icon {
-			--icon-color: var(--toast-icon-color-info, #{kv-color('info')});
-			--icon-background-color: var(--icon-container-neutral-inverse, #{kv-color('neutral-0')});
+			--icon-color: var(--toast-icon-color-info);
+			--icon-background-color: var(--icon-container-neutral-inverse);
 		}
 	}
 
 	&.toaster-type--warning {
-		border-color: var(--toast-border-color-warning, #{kv-color('warning')});
+		border-color: var(--toast-border-color-warning);
 
 		.toaster-icon kv-icon {
-			--icon-color: var(--toast-icon-color-warning, #{kv-color('warning')});
+			--icon-color: var(--toast-icon-color-warning);
 		}
 	}
 
 	&.toaster-type--error {
-		border-color: var(--toast-border-color-error, #{kv-color('error')});
+		border-color: var(--toast-border-color-error);
 
 		.toaster-icon kv-icon {
-			--icon-color: var(--toast-icon-color-error, #{kv-color('error')});
-			--icon-background-color: var(--icon-container-neutral-inverse, #{kv-color('neutral-0')});
+			--icon-color: var(--toast-icon-color-error);
+			--icon-background-color: var(--icon-container-neutral-inverse);
 		}
 	}
 
 	&.toaster-type--success {
-		border-color: var(--toast-border-color-success, #{kv-color('success')});
+		border-color: var(--toast-border-color-success);
 
 		.toaster-icon kv-icon {
-			--icon-color: var(--toast-icon-color-success, #{kv-color('success')});
-			--icon-background-color: var(--icon-container-neutral-inverse, #{kv-color('neutral-0')});
+			--icon-color: var(--toast-icon-color-success);
+			--icon-background-color: var(--icon-container-neutral-inverse);
 		}
 	}
 
@@ -116,12 +116,12 @@
 
 		.main-message {
 			@include body-m-semibold;
-			color: var(--toast-main-message-default, #{kv-color('neutral-2')});
+			color: var(--toast-main-message-default);
 		}
 
 		.secondary-message {
 			@include body-m-regular;
-			color: var(--toast-secondary-message-default, #{kv-color('neutral-4')});
+			color: var(--toast-secondary-message-default);
 		}
 	}
 }

--- a/packages/ui-components/src/components/toggle-button/toggle-button.scss
+++ b/packages/ui-components/src/components/toggle-button/toggle-button.scss
@@ -35,45 +35,45 @@
 	 * @prop --border-radius-bottom-right: toggle button component's bottom-right border radius.
 	 */
 
-	--button-height-large: var(--toggle-height-regular, 36px);
-	--button-height-small: var(--toggle-height-compact, 28px);
-	--button-width: fit-content;
+	--button-height-large: var(--toggle-height-regular);
+	--button-height-small: var(--toggle-height-compact);
+	--button-width: 100%;
 
-	--button-padding-large: #{var(--spacing-none, #{$spacing-2x}) var(--toggle-padding-x-default, #{$spacing-4x})};
-	--button-padding-small: #{var(--spacing-none, #{$spacing}) var(--toggle-padding-x-default, #{$spacing-3x})};
+	--button-padding-large: #{var(--spacing-none) var(--toggle-padding-x-default)};
+	--button-padding-small: #{var(--spacing-none) var(--toggle-padding-x-default)};
 	
-	--button-icon-height-large: var(--toggle-icon-size-default, 24px);
-	--button-icon-height-small: var(--toggle-icon-size-default, 16px);
-	--button-icon-width-large: var(--toggle-icon-size-default, 24px);
-	--button-icon-width-small: var(--toggle-icon-size-default, 16px);
+	--button-icon-height-large: var(--toggle-icon-size-default);
+	--button-icon-height-small: var(--toggle-icon-size-default);
+	--button-icon-width-large: var(--toggle-icon-size-default);
+	--button-icon-width-small: var(--toggle-icon-size-default);
 
-	--text-color-default: var(--toggle-text-off, #{kv-color('neutral-2')});
-	--text-color-active: var(--toggle-text-on, #{kv-color('neutral-0')});
-	--text-color-disabled: var(--toggle-text-disabled, #{kv-color('neutral-5')});
-	--text-color-disabled-active: var(--toggle-text-disabled, #{kv-color('neutral-5')});
+	--text-color-default: var(--toggle-text-off);
+	--text-color-active: var(--toggle-text-on);
+	--text-color-disabled: var(--toggle-text-disabled);
+	--text-color-disabled-active: var(--toggle-text-disabled);
 
-	--icon-color-default: var(--toggle-icon-color-off, #{kv-color('neutral-2')});
-	--icon-color-active: var(--toggle-icon-color-on, #{kv-color('neutral-0')});
-	--icon-color-disabled: var(--toggle-icon-color-disabled, #{kv-color('neutral-5')});
-	--icon-color-disabled-active: var(--toggle-icon-color-disabled, #{kv-color('neutral-5')});
+	--icon-color-default: var(--toggle-icon-color-off);
+	--icon-color-active: var(--toggle-icon-color-on);
+	--icon-color-disabled: var(--toggle-icon-color-disabled);
+	--icon-color-disabled-active: var(--toggle-icon-color-disabled);
 
-	--background-color-default: var(--transparent, #{kv-color('neutral-6')});
-	--background-color-active: var(--toggle-background-on, #{kv-color('neutral-6')});
-	--background-color-disabled: var(--transparent, #{kv-color('neutral-7')});
-	--background-color-disabled-active: var(--toggle-background-disabled, #{kv-color('neutral-7')});
+	--background-color-default: var(--transparent);
+	--background-color-active: var(--toggle-background-on);
+	--background-color-disabled: var(--transparent);
+	--background-color-disabled-active: var(--toggle-background-disabled);
 
-	--border-size: var(--toggle-border-thickness-default, 1px);
-	--border-left-size: var(--toggle-border-thickness-default, 1px);
-	--border-right-size: var(--toggle-border-thickness-default, 1px);
-	--border-color-default: var(--toggle-border-color-off, #{kv-color('neutral-6')});
-	--border-color-active: var(--toggle-border-color-on, #{kv-color('neutral-0')});
-	--border-color-disabled: var(--toggle-border-color-disabled, #{kv-color('neutral-6')});
-	--border-color-disabled-active: var(--toggle-border-color-disabled, #{kv-color('neutral-6')});
+	--border-size: var(--toggle-border-thickness-default);
+	--border-left-size: var(--toggle-border-thickness-default);
+	--border-right-size: var(--toggle-border-thickness-default);
+	--border-color-default: var(--toggle-border-color-off);
+	--border-color-active: var(--toggle-border-color-on);
+	--border-color-disabled: var(--toggle-border-color-disabled);
+	--border-color-disabled-active: var(--toggle-border-color-disabled);
 
-	--border-radius-top-left: var(--toggle-radius-default, 2px);
-	--border-radius-bottom-left: var(--toggle-radius-default, 2px);
-	--border-radius-top-right: var(--toggle-radius-default, 2px);
-	--border-radius-bottom-right: var(--toggle-radius-default, 2px);
+	--border-radius-top-left: var(--toggle-radius-default);
+	--border-radius-bottom-left: var(--toggle-radius-default);
+	--border-radius-top-right: var(--toggle-radius-default);
+	--border-radius-bottom-right: var(--toggle-radius-default);
 }
 
 kv-tooltip::part(content) {
@@ -83,7 +83,7 @@ kv-tooltip::part(content) {
 .toggle-button {
 	display: inline-flex;
 	align-items: center;
-	gap: var(--spacing-md, #{$spacing-2x});
+	gap: var(--spacing-md);
 	border-top-left-radius: var(--border-radius-top-left);
 	border-bottom-left-radius: var(--border-radius-bottom-left);
 	border-top-right-radius: var(--border-radius-top-right);
@@ -159,5 +159,10 @@ kv-tooltip::part(content) {
 			--icon-width: var(--button-icon-width-large);
 			--icon-height: var(--button-icon-height-large);
 		}
+	}
+
+	&--with-radio {
+		gap: var(--spacing-none);
+		padding-left: var(--spacing-md);
 	}
 }

--- a/packages/ui-components/src/components/toggle-button/toggle-button.tsx
+++ b/packages/ui-components/src/components/toggle-button/toggle-button.tsx
@@ -68,19 +68,20 @@ export class KvToggleButton implements IToggleButton, IToggleButtonEvents {
 					<div
 						class={{
 							'toggle-button': true,
-							'toggle-button--checked': this.checked,
-							'toggle-button--disabled': this.disabled,
+							'toggle-button--checked': !!this.checked,
+							'toggle-button--disabled': !!this.disabled,
 							'toggle-button--only-icon': hasIcon && !hasLabel,
+							'toggle-button--with-radio': !!this.withRadio,
 							[`toggle-button--size-${this.size}`]: true
 						}}
 						part="toggle-button"
 						onClick={this.onClick}
 						{...this.customAttributes}
 					>
-						{this.withRadio && <kv-radio size={this.size} checked={this.checked} disabled={this.disabled} />}
+						{this.withRadio && <kv-radio size={EComponentSize.Small} checked={this.checked} disabled={this.disabled} />}
 						{hasIcon && (
 							<div class="toggle-button-icon" part="toggle-icon">
-								<kv-icon name={this.icon} />
+								<kv-icon name={this.icon!} />
 							</div>
 						)}
 						{hasLabel && (

--- a/packages/ui-components/src/components/toggle-switch/toggle-switch.scss
+++ b/packages/ui-components/src/components/toggle-switch/toggle-switch.scss
@@ -4,13 +4,13 @@
 	display: flex;
 
 	> :last-child {
-		--border-radius-top-right: var(--toggle-radius-default, 4px);
-		--border-radius-bottom-right: var(--toggle-radius-default, 4px);
+		--border-radius-top-right: var(--toggle-radius-default);
+		--border-radius-bottom-right: var(--toggle-radius-default);
 	}
 
 	> :first-child {
-		--border-radius-top-left: var(--toggle-radius-default, 4px);
-		--border-radius-bottom-left: var(--toggle-radius-default, 4px);
+		--border-radius-top-left: var(--toggle-radius-default);
+		--border-radius-bottom-left: var(--toggle-radius-default);
 	}
 
 	kv-toggle-button {

--- a/packages/ui-components/src/components/toggle-tip/toggle-tip.scss
+++ b/packages/ui-components/src/components/toggle-tip/toggle-tip.scss
@@ -6,5 +6,5 @@
 }
 
 .toggle-tip-container::part(tooltip-container) {
-	padding: var(--spacing-xl, #{$spacing-3x});
+	padding: var(--spacing-xl);
 }

--- a/packages/ui-components/src/components/tooltip-text/tooltip-text.scss
+++ b/packages/ui-components/src/components/tooltip-text/tooltip-text.scss
@@ -10,7 +10,7 @@
 	--container-width: fit-content;
 	--container-max-width: 280px;
 
-	--container-background-color: var(--tooltip-background-default, #{kv-color('neutral-6')});
+	--container-background-color: var(--tooltip-background-default);
 }
 
 .tooltip-container {
@@ -21,12 +21,12 @@
 	word-wrap: break-word;
 	background-color: var(--container-background-color);
 	user-select: none;
-	border-radius: var(--tooltip-radius-default, 2px);
-	padding: var(--tooltip-padding-y-default, #{$spacing}) var(--tooltip-padding-x-default, #{$spacing-2x});
+	border-radius: var(--tooltip-radius-default);
+	padding: var(--tooltip-padding-y-default) var(--tooltip-padding-x-default);
 	white-space: var(--container-white-space);
 
 	.tooltip-text {
 		@include body-m-semibold();
-		color: var(--tooltip-text-default, #{kv-color('neutral-2')});
+		color: var(--tooltip-text-default);
 	}
 }

--- a/packages/ui-components/src/illustrations/illustrations.scss
+++ b/packages/ui-components/src/illustrations/illustrations.scss
@@ -9,8 +9,10 @@
 	--illustration-color-dark-35: var(--kv-illustrations-color-dark-35, #{color.mix(#000, $primary-color, 36%)});
 	--illustration-success-color: var(--kv-illustrations-success-color, #{$success-color});
 
+	/* stylelint-disable csstools/value-no-unknown-custom-properties -- vars defined by parent component */
 	width: var(--illustration-width);
 	height: var(--illustration-height);
+	/* stylelint-enable csstools/value-no-unknown-custom-properties -- vars defined by parent component */
 	display: flex;
 	
 	&-full-size {

--- a/packages/ui-components/src/utils/string.helper.ts
+++ b/packages/ui-components/src/utils/string.helper.ts
@@ -1,10 +1,10 @@
 import { isEmpty } from 'lodash-es';
 
-export const isValidLabel = (label: string) => {
+export const isValidLabel = (label?: string) => {
 	return !isEmpty(label?.trim());
 };
 
-export const getUTF8StringLength = (label: string) => {
+export const getUTF8StringLength = (label?: string) => {
 	return label ? [...label].length : 0;
 };
 

--- a/packages/ui-components/tokens/components/component_semantics.json
+++ b/packages/ui-components/tokens/components/component_semantics.json
@@ -1515,7 +1515,7 @@
       },
       "secondary": {
         "default": {
-          "value": "{background.container.neutral.subtlest}",
+          "value": "{background.container.alert-secondary.default}",
           "type": "color",
           "prefix": "component_semantics"
         }

--- a/packages/ui-components/tokens/semantic/dark.json
+++ b/packages/ui-components/tokens/semantic/dark.json
@@ -25,7 +25,7 @@
       },
       "sidebar": {
         "default": {
-          "value": "{color.gray.800}",
+          "value": "{color.gray.900}",
           "type": "color",
           "prefix": "color"
         },
@@ -295,6 +295,13 @@
           "type": "color",
           "prefix": "color"
         }
+      },
+      "alert-secondary": {
+        "default": {
+          "value": "{color.gray.700}",
+          "type": "color",
+          "prefix": "color"
+        }
       }
     },
     "interactive": {
@@ -557,7 +564,51 @@
           "prefix": "color"
         },
         "default": {
+          "value": "{color.gray.800}",
+          "type": "color",
+          "prefix": "color"
+        }
+      },
+      "card-application": {
+        "default": {
+          "value": "{color.gray.900}",
+          "type": "color",
+          "prefix": "color"
+        },
+        "hover": {
+          "value": "{color.gray.800}",
+          "type": "color",
+          "prefix": "color"
+        }
+      },
+      "column-bar": {
+        "active": {
           "value": "{color.gray.700}",
+          "type": "color",
+          "prefix": "color"
+        },
+        "hidden": {
+          "value": "{color.gray.900}",
+          "type": "color",
+          "prefix": "color"
+        },
+        "hover": {
+          "value": "{color.gray.600}",
+          "type": "color",
+          "prefix": "color"
+        },
+        "drag": {
+          "value": "{color.gray.500}",
+          "type": "color",
+          "prefix": "color"
+        },
+        "locked": {
+          "value": "{color.gray.800}",
+          "type": "color",
+          "prefix": "color"
+        },
+        "empty": {
+          "value": "{color.gray.800}",
           "type": "color",
           "prefix": "color"
         }
@@ -1314,11 +1365,21 @@
             "value": "{color.green.500}",
             "type": "color",
             "prefix": "color"
+          },
+          "subtle": {
+            "value": "#07d57100",
+            "type": "color",
+            "prefix": "color"
           }
         },
         "warning": {
           "default": {
             "value": "{color.yellow.500}",
+            "type": "color",
+            "prefix": "color"
+          },
+          "subtle": {
+            "value": "#ffe4a800",
             "type": "color",
             "prefix": "color"
           }
@@ -1328,11 +1389,21 @@
             "value": "{color.red.500}",
             "type": "color",
             "prefix": "color"
+          },
+          "subtle": {
+            "value": "#ffb8ad00",
+            "type": "color",
+            "prefix": "color"
           }
         },
         "info": {
           "default": {
             "value": "{color.blue.500}",
+            "type": "color",
+            "prefix": "color"
+          },
+          "subtle": {
+            "value": "#b8d0f900",
             "type": "color",
             "prefix": "color"
           }
@@ -1406,6 +1477,11 @@
             "value": "{color.purple.500}",
             "type": "color",
             "prefix": "color"
+          },
+          "subtle": {
+            "value": "#c6b2ff00",
+            "type": "color",
+            "prefix": "color"
           }
         }
       },
@@ -1451,6 +1527,41 @@
       "graphic-recommendation": {
         "default": {
           "value": "#40404000",
+          "type": "color",
+          "prefix": "color"
+        }
+      },
+      "radio-selected": {
+        "hover": {
+          "value": "{color.gray.50}",
+          "type": "color",
+          "prefix": "color"
+        },
+        "selected": {
+          "value": "{color.gray.50}",
+          "type": "color",
+          "prefix": "color"
+        }
+      },
+      "tag": {
+        "neutral": {
+          "subtle": {
+            "value": "#bfbfbf00",
+            "type": "color",
+            "prefix": "color"
+          }
+        },
+        "brand": {
+          "subtle": {
+            "value": "#b2d4ff00",
+            "type": "color",
+            "prefix": "color"
+          }
+        }
+      },
+      "column-bar": {
+        "default": {
+          "value": "#1a1a1a00",
           "type": "color",
           "prefix": "color"
         }

--- a/packages/ui-components/tokens/semantic/light.json
+++ b/packages/ui-components/tokens/semantic/light.json
@@ -295,6 +295,13 @@
           "type": "color",
           "prefix": "color"
         }
+      },
+      "alert-secondary": {
+        "default": {
+          "value": "{color.gray.200}",
+          "type": "color",
+          "prefix": "color"
+        }
       }
     },
     "interactive": {
@@ -557,6 +564,50 @@
           "prefix": "color"
         },
         "default": {
+          "value": "{color.gray.50}",
+          "type": "color",
+          "prefix": "color"
+        }
+      },
+      "card-application": {
+        "default": {
+          "value": "{color.gray.50}",
+          "type": "color",
+          "prefix": "color"
+        },
+        "hover": {
+          "value": "{color.gray.200}",
+          "type": "color",
+          "prefix": "color"
+        }
+      },
+      "column-bar": {
+        "active": {
+          "value": "{color.gray.50}",
+          "type": "color",
+          "prefix": "color"
+        },
+        "hidden": {
+          "value": "{color.gray.200}",
+          "type": "color",
+          "prefix": "color"
+        },
+        "hover": {
+          "value": "{color.gray.50}",
+          "type": "color",
+          "prefix": "color"
+        },
+        "drag": {
+          "value": "{color.brand.100}",
+          "type": "color",
+          "prefix": "color"
+        },
+        "locked": {
+          "value": "{color.gray.200}",
+          "type": "color",
+          "prefix": "color"
+        },
+        "empty": {
           "value": "{color.gray.200}",
           "type": "color",
           "prefix": "color"
@@ -1314,11 +1365,21 @@
             "value": "{color.green.500}",
             "type": "color",
             "prefix": "color"
+          },
+          "subtle": {
+            "value": "{color.green.400}",
+            "type": "color",
+            "prefix": "color"
           }
         },
         "warning": {
           "default": {
             "value": "{color.yellow.500}",
+            "type": "color",
+            "prefix": "color"
+          },
+          "subtle": {
+            "value": "{color.yellow.200}",
             "type": "color",
             "prefix": "color"
           }
@@ -1328,11 +1389,21 @@
             "value": "{color.red.500}",
             "type": "color",
             "prefix": "color"
+          },
+          "subtle": {
+            "value": "{color.red.200}",
+            "type": "color",
+            "prefix": "color"
           }
         },
         "info": {
           "default": {
             "value": "{color.blue.500}",
+            "type": "color",
+            "prefix": "color"
+          },
+          "subtle": {
+            "value": "{color.blue.200}",
             "type": "color",
             "prefix": "color"
           }
@@ -1406,6 +1477,11 @@
             "value": "{color.purple.500}",
             "type": "color",
             "prefix": "color"
+          },
+          "subtle": {
+            "value": "{color.purple.200}",
+            "type": "color",
+            "prefix": "color"
           }
         }
       },
@@ -1449,6 +1525,41 @@
         }
       },
       "graphic-recommendation": {
+        "default": {
+          "value": "{color.gray.300}",
+          "type": "color",
+          "prefix": "color"
+        }
+      },
+      "radio-selected": {
+        "hover": {
+          "value": "{color.gray.950}",
+          "type": "color",
+          "prefix": "color"
+        },
+        "selected": {
+          "value": "{color.gray.950}",
+          "type": "color",
+          "prefix": "color"
+        }
+      },
+      "tag": {
+        "neutral": {
+          "subtle": {
+            "value": "{color.gray.400}",
+            "type": "color",
+            "prefix": "color"
+          }
+        },
+        "brand": {
+          "subtle": {
+            "value": "{color.brand.200}",
+            "type": "color",
+            "prefix": "color"
+          }
+        }
+      },
+      "column-bar": {
         "default": {
           "value": "{color.gray.300}",
           "type": "color",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,18 @@ importers:
       sass:
         specifier: ^1.79.4
         version: 1.79.4
+      stylelint:
+        specifier: ^15.0.0
+        version: 15.11.0(typescript@5.6.2)
+      stylelint-config-prettier-scss:
+        specifier: ^1.0.0
+        version: 1.0.0(stylelint@15.11.0)
+      stylelint-config-standard-scss:
+        specifier: ^11.1.0
+        version: 11.1.0(postcss@8.4.47)(stylelint@15.11.0)
+      stylelint-value-no-unknown-custom-properties:
+        specifier: 5.0.0
+        version: 5.0.0(stylelint@15.11.0)
       tslib:
         specifier: ^2.7.0
         version: 2.7.0
@@ -379,6 +391,9 @@ importers:
       stylelint-config-sass-guidelines:
         specifier: ^10.0.0
         version: 10.0.0(postcss@8.5.6)(stylelint@15.11.0)
+      stylelint-value-no-unknown-custom-properties:
+        specifier: ^5.0.0
+        version: 5.0.0(stylelint@15.11.0)
       svg-parser:
         specifier: ^2.0.4
         version: 2.0.4
@@ -6310,7 +6325,7 @@ packages:
         optional: true
     dependencies:
       import-fresh: 3.3.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
       typescript: 5.6.2
@@ -11845,11 +11860,20 @@ packages:
     resolution: {integrity: sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==}
     dev: true
 
-  /postcss-safe-parser@6.0.0(postcss@8.4.47):
+  /postcss-safe-parser@6.0.0(postcss@8.5.6):
     resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.3.3
+    dependencies:
+      postcss: 8.5.6
+    dev: true
+
+  /postcss-scss@4.0.9(postcss@8.4.47):
+    resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.4.29
     dependencies:
       postcss: 8.4.47
     dev: true
@@ -13578,6 +13602,41 @@ packages:
       postcss-selector-parser: 6.1.2
     dev: true
 
+  /stylelint-config-prettier-scss@1.0.0(stylelint@15.11.0):
+    resolution: {integrity: sha512-Gr2qLiyvJGKeDk0E/+awNTrZB/UtNVPLqCDOr07na/sLekZwm26Br6yYIeBYz3ulsEcQgs5j+2IIMXCC+wsaQA==}
+    engines: {node: 14.* || 16.* || >= 18}
+    hasBin: true
+    peerDependencies:
+      stylelint: '>=15.0.0'
+    dependencies:
+      stylelint: 15.11.0(typescript@5.6.2)
+    dev: true
+
+  /stylelint-config-recommended-scss@13.1.0(postcss@8.4.47)(stylelint@15.11.0):
+    resolution: {integrity: sha512-8L5nDfd+YH6AOoBGKmhH8pLWF1dpfY816JtGMePcBqqSsLU+Ysawx44fQSlMOJ2xTfI9yTGpup5JU77c17w1Ww==}
+    peerDependencies:
+      postcss: ^8.3.3
+      stylelint: ^15.10.0
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+    dependencies:
+      postcss: 8.4.47
+      postcss-scss: 4.0.9(postcss@8.4.47)
+      stylelint: 15.11.0(typescript@5.6.2)
+      stylelint-config-recommended: 13.0.0(stylelint@15.11.0)
+      stylelint-scss: 5.3.2(stylelint@15.11.0)
+    dev: true
+
+  /stylelint-config-recommended@13.0.0(stylelint@15.11.0):
+    resolution: {integrity: sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      stylelint: ^15.10.0
+    dependencies:
+      stylelint: 15.11.0(typescript@5.6.2)
+    dev: true
+
   /stylelint-config-sass-guidelines@10.0.0(postcss@8.5.6)(stylelint@15.11.0):
     resolution: {integrity: sha512-+Rr2Dd4b72CWA4qoj1Kk+y449nP/WJsrD0nzQAWkmPPIuyVcy2GMIcfNr0Z8JJOLjRvtlkKxa49FCNXMePBikQ==}
     engines: {node: ^14.13.1 || >=16.13.0 || >=18.0.0}
@@ -13591,6 +13650,31 @@ packages:
       stylelint-scss: 4.7.0(stylelint@15.11.0)
     dev: true
 
+  /stylelint-config-standard-scss@11.1.0(postcss@8.4.47)(stylelint@15.11.0):
+    resolution: {integrity: sha512-5gnBgeNTgRVdchMwiFQPuBOtj9QefYtfXiddrOMJA2pI22zxt6ddI2s+e5Oh7/6QYl7QLJujGnaUR5YyGq72ow==}
+    peerDependencies:
+      postcss: ^8.3.3
+      stylelint: ^15.10.0
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+    dependencies:
+      postcss: 8.4.47
+      stylelint: 15.11.0(typescript@5.6.2)
+      stylelint-config-recommended-scss: 13.1.0(postcss@8.4.47)(stylelint@15.11.0)
+      stylelint-config-standard: 34.0.0(stylelint@15.11.0)
+    dev: true
+
+  /stylelint-config-standard@34.0.0(stylelint@15.11.0):
+    resolution: {integrity: sha512-u0VSZnVyW9VSryBG2LSO+OQTjN7zF9XJaAJRX/4EwkmU0R2jYwmBSN10acqZisDitS0CLiEiGjX7+Hrq8TAhfQ==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      stylelint: ^15.10.0
+    dependencies:
+      stylelint: 15.11.0(typescript@5.6.2)
+      stylelint-config-recommended: 13.0.0(stylelint@15.11.0)
+    dev: true
+
   /stylelint-scss@4.7.0(stylelint@15.11.0):
     resolution: {integrity: sha512-TSUgIeS0H3jqDZnby1UO1Qv3poi1N8wUYIJY6D1tuUq2MN3lwp/rITVo0wD+1SWTmRm0tNmGO0b7nKInnqF6Hg==}
     peerDependencies:
@@ -13600,6 +13684,30 @@ packages:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
+      stylelint: 15.11.0(typescript@5.6.2)
+    dev: true
+
+  /stylelint-scss@5.3.2(stylelint@15.11.0):
+    resolution: {integrity: sha512-4LzLaayFhFyneJwLo0IUa8knuIvj+zF0vBFueQs4e3tEaAMIQX8q5th8ziKkgOavr6y/y9yoBe+RXN/edwLzsQ==}
+    peerDependencies:
+      stylelint: ^14.5.1 || ^15.0.0
+    dependencies:
+      known-css-properties: 0.29.0
+      postcss-media-query-parser: 0.2.3
+      postcss-resolve-nested-selector: 0.1.6
+      postcss-selector-parser: 6.1.2
+      postcss-value-parser: 4.2.0
+      stylelint: 15.11.0(typescript@5.6.2)
+    dev: true
+
+  /stylelint-value-no-unknown-custom-properties@5.0.0(stylelint@15.11.0):
+    resolution: {integrity: sha512-nz6Dok3IdcXDjJXevLwkdc9bgXkv/jJ9FmBWrPWVVHX+iF402zywsNQymTg8VH45Hpf/Sg/BD6Kbm+qOBlmhag==}
+    engines: {node: ^16 || ^18 || ^20}
+    peerDependencies:
+      stylelint: 10 - 15
+    dependencies:
+      postcss-value-parser: 4.2.0
+      resolve: 1.22.8
       stylelint: 15.11.0(typescript@5.6.2)
     dev: true
 
@@ -13617,7 +13725,7 @@ packages:
       cosmiconfig: 8.3.6(typescript@5.6.2)
       css-functions-list: 3.2.2
       css-tree: 2.3.1
-      debug: 4.3.7
+      debug: 4.4.3
       fast-glob: 3.3.2
       fastest-levenshtein: 1.0.16
       file-entry-cache: 7.0.2
@@ -13634,10 +13742,10 @@ packages:
       meow: 10.1.5
       micromatch: 4.0.8
       normalize-path: 3.0.0
-      picocolors: 1.1.0
-      postcss: 8.4.47
+      picocolors: 1.1.1
+      postcss: 8.5.6
       postcss-resolve-nested-selector: 0.1.6
-      postcss-safe-parser: 6.0.0(postcss@8.4.47)
+      postcss-safe-parser: 6.0.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0


### PR DESCRIPTION
Remove legacy kv-color() fallbacks from CSS var() declarations across action-button, action-button-icon, action-button-split, badge, form-help-text, form-label, select, radio, tag, tag-status, text-field, text-area, toaster, toggle-button, toggle-switch, toggle-tip, tooltip-text, illustration-message, portal, and SchemaForm components.

Remove deprecated SASS color/size maps and helper functions from action-button in favor of design token variables.

Add stylelint-value-no-unknown-custom-properties plugin to both ui-components and react-ui-components packages to enforce valid custom property usage.

Add new design tokens: alert-secondary-default background, card-application interactive states, and radio-selected border tokens. Update dark theme sidebar background from gray-800 to gray-900.

BREAKING CHANGE: Components no longer provide legacy kv-color() fallback values — consumers must ensure design token CSS custom properties are loaded.