### PR TITLE
feat: add `showShortcuts` prop to select-multi-options

### DIFF
--- a/packages/ui-components/src/components/multi-select-dropdown/multi-select-dropdown.tsx
+++ b/packages/ui-components/src/components/multi-select-dropdown/multi-select-dropdown.tsx
@@ -84,6 +84,8 @@ export class KvMultiSelectDropdown implements IMultiSelectDropdown, IMultiSelect
 	/** @inheritdoc */
 	@Prop({ reflect: true }) shortcuts?: boolean = false;
 	/** @inheritdoc */
+	@Prop({ reflect: true }) showShortcuts?: boolean = false;
+	/** @inheritdoc */
 	@Prop({ reflect: true }) clickOutsideClose?: boolean = true;
 	/** @inheritdoc */
 	@Prop({ reflect: false }) actionElement?: HTMLElement | null = null;
@@ -299,6 +301,7 @@ export class KvMultiSelectDropdown implements IMultiSelectDropdown, IMultiSelect
 							minWidth={this.getMinWidth()}
 							counter={this.counter}
 							shortcuts={this._isOpen && this.shortcuts}
+							showShortcuts={this.showShortcuts}
 							maxSelectable={this.maxSelectable}
 							onSearchChange={this.onSearchChange}
 							onClearSelection={this.onClearSelection}

--- a/packages/ui-components/src/components/select-multi-options/readme.md
+++ b/packages/ui-components/src/components/select-multi-options/readme.md
@@ -30,6 +30,7 @@
 | `selectionAll`            | `selection-all`             | (optional) If `true` the list has an action to select all items                                                   | `boolean`                              | `undefined`                                     |
 | `selectionClearable`      | `selection-clearable`       | (optional) If `true` dropdown items can be cleared                                                                | `boolean`                              | `undefined`                                     |
 | `shortcuts`               | `shortcuts`                 | (optional) If `true` the keyboard shortcuts can be used to navigate between the dropdown results. Default `false` | `boolean`                              | `false`                                         |
+| `showShortcuts`           | `show-shortcuts`            |                                                                                                                   | `boolean`                              | `false`                                         |
 
 
 ## Events

--- a/packages/ui-components/src/components/select-multi-options/select-multi-options.tsx
+++ b/packages/ui-components/src/components/select-multi-options/select-multi-options.tsx
@@ -81,6 +81,8 @@ export class KvSelectMultiOptions implements ISelectMultiOptionsConfig, ISelectM
 	@Prop({ reflect: true }) createOptionPlaceholder?: string = DEFAULT_ADD_OPTION_PLACEHOLDER;
 	/** @inheritdoc */
 	@Prop({ reflect: true }) maxSelectable?: number;
+	/** @inheritdoc */
+	@Prop({ reflect: true }) showShortcuts?: boolean = false;
 
 	@Element() el: HTMLKvSelectMultiOptionsElement;
 
@@ -438,7 +440,7 @@ export class KvSelectMultiOptions implements ISelectMultiOptionsConfig, ISelectM
 					<div
 						class={{
 							'create-new-option-container': true,
-							'has-shortcuts': this.shortcuts
+							'has-shortcuts': this.shortcuts && this.showShortcuts
 						}}
 					>
 						<div class="create-new-option-form">
@@ -450,7 +452,7 @@ export class KvSelectMultiOptions implements ISelectMultiOptionsConfig, ISelectM
 						</div>
 					</div>
 				)}
-				{this.shortcuts && (
+				{this.shortcuts && this.showShortcuts && (
 					<slot name="select-footer" slot="select-footer">
 						<kv-select-shortcuts-label>
 							<div class="counter" slot="right-items">

--- a/packages/ui-components/src/components/single-select-dropdown/single-select-dropdown.tsx
+++ b/packages/ui-components/src/components/single-select-dropdown/single-select-dropdown.tsx
@@ -93,6 +93,8 @@ export class KvSingleSelectDropdown implements ISingleSelectDropdown, ISingleSel
 	/** @inheritdoc */
 	@Prop({ reflect: true }) shortcuts?: boolean = false;
 	/** @inheritdoc */
+	@Prop({ reflect: true }) showShortcuts?: boolean = false;
+	/** @inheritdoc */
 	@Prop({ reflect: false }) zIndex?: number = DEFAULT_DROPDOWN_Z_INDEX;
 	/** @inheritdoc */
 	@Prop({ reflect: true }) canAddItems?: boolean = false;
@@ -357,6 +359,7 @@ export class KvSingleSelectDropdown implements ISingleSelectDropdown, ISingleSel
 							minWidth={this.getMinWidth()}
 							counter={this.counter}
 							shortcuts={this.isOpen && this.shortcuts}
+							showShortcuts={this.showShortcuts}
 							onSearchChange={this.onSearchChange}
 							onClearSelection={this.onClearSelection}
 							onOptionSelected={this.onOptionSelected}


### PR DESCRIPTION
## Summary
- **select-multi-options**: Add `showShortcuts` prop to independently control the visibility of keyboard shortcuts label from the shortcuts functionality

## Test plan
- [ ] Verify `kv-select-multi-options` shortcuts still function when `showShortcuts` is `false` but label is hidden
- [ ] Run `pnpm build:packages` successfully
- [ ] Run `pnpm test` with no regressions