### PR TITLE
refactor(mixins): extend rotate-border-animation with third color stop

### DIFF
--- a/packages/ui-components/src/assets/styles/kv-mixins.scss
+++ b/packages/ui-components/src/assets/styles/kv-mixins.scss
@@ -101,7 +101,14 @@
 	@include custom-scrollbar(var(--scrollbar-thumb-default));
 }
 
-@mixin rotate-border-animation($border-radius: var(--radius-md), $border-width: 2px, $color1: var(--color-teal-500), $color2: var(--color-teal-600), $inset: 0) {
+@mixin rotate-border-animation(
+	$border-radius: var(--radius-md),
+	$border-width: 2px,
+	$color1: var(--color-teal-400),
+	$color2: var(--color-brand-800),
+	$color3: var(--color-teal-400),
+	$inset: 0
+) {
 	position: relative;
 
 	&::before {
@@ -113,7 +120,7 @@
 		z-index: 99;
 		border: $border-width solid transparent;
 		border-radius: $border-radius;
-		background-image: conic-gradient(from var(--rotation), $color1, $color2, $color1);
+		background-image: conic-gradient(from var(--rotation), $color1, $color2, $color3);
 		background-origin: border-box;
 		mask: linear-gradient(#000, #000), linear-gradient(#000, #000);
 		mask-clip: content-box, border-box;


### PR DESCRIPTION
## Summary
- Extend \`rotate-border-animation\` mixin signature with a third color parameter so the conic gradient can transition through three distinct stops
- Refresh default colors to \`--color-teal-400\` and \`--color-brand-800\` for better contrast in the rotating border effect
- Reformat the mixin signature onto multiple lines for readability

## Test plan
- [ ] Verify rotating border animation renders correctly in components consuming the mixin
- [ ] Confirm default color palette matches design expectations in light and dark themes
- [ ] Check that existing callers passing fewer arguments still work with the new defaults