### PR TITLE
feat(inline-editable-field): add placeholder for empty values

### DIFF
--- a/apps/react-storybook/src/components/inputs/inline-editable-field/InlineEditableField.stories.tsx
+++ b/apps/react-storybook/src/components/inputs/inline-editable-field/InlineEditableField.stories.tsx
@@ -63,3 +63,10 @@ export const DisableEdit: Story = {
 		disabled: true
 	}
 };
+
+export const WithPlaceholder: Story = {
+	args: {
+		value: "",
+		placeholder: "-"
+	}
+};

--- a/packages/ui-components/src/components/inline-editable-field/inline-editable-field.scss
+++ b/packages/ui-components/src/components/inline-editable-field/inline-editable-field.scss
@@ -11,12 +11,16 @@
 	* @prop --inline-editable-field-background-color-hover: Background color of the editable field on hover.
 	* @prop --inline-editable-field-outline-color-hover: Outline color of the editable field on hover.
 	* @prop --inline-editable-field-outline-color-focus: Outline color of the editable field on focus.
+	* @prop --inline-editable-field-placeholder-color: Text color used to render the placeholder when the field is empty.
+	* @prop --inline-editable-field-min-width: Minimum width of the editable area so it stays clickable when empty.
 	*/
 	--margin-top-bottom: var(--spacing-xs);
 	--margin-left-right: var(--spacing-md);
 	--inline-editable-field-background-color-hover: var(--input-background-default);
 	--inline-editable-field-outline-color-hover: var(--input-border-color-default);
 	--inline-editable-field-outline-color-focus: var(--input-border-color-selected);
+	--inline-editable-field-placeholder-color: var(--input-text-text-input-default);
+	--inline-editable-field-min-width: unset;
 
 	&__hover .inline-editable-field-slot {
 		border-radius: var(--radius-md);
@@ -29,6 +33,7 @@
 	&[contenteditable] {
 		padding: var(--margin-top-bottom) var(--margin-left-right);
 		margin: calc(var(--margin-top-bottom) * -1) calc(var(--margin-left-right) * -1);
+		min-width: var(--inline-editable-field-min-width);
 		white-space: nowrap;
 		overflow: hidden;
 		outline: 1px solid transparent;
@@ -55,6 +60,12 @@
 		display: inline;
 		white-space: nowrap;
 	}
+}
+
+.inline-editable-field-container:not(.inline-editable-field-container__editing) .inline-editable-field-slot[contenteditable]:empty::before {
+	content: attr(data-placeholder);
+	color: var(--inline-editable-field-placeholder-color);
+	pointer-events: none;
 }
 
 .inline-editable-field-actions {

--- a/packages/ui-components/src/components/inline-editable-field/inline-editable-field.scss
+++ b/packages/ui-components/src/components/inline-editable-field/inline-editable-field.scss
@@ -12,7 +12,8 @@
 	* @prop --inline-editable-field-outline-color-hover: Outline color of the editable field on hover.
 	* @prop --inline-editable-field-outline-color-focus: Outline color of the editable field on focus.
 	* @prop --inline-editable-field-placeholder-color: Text color used to render the placeholder when the field is empty.
-	* @prop --inline-editable-field-min-width: Minimum width of the editable area so it stays clickable when empty.
+	* @prop --inline-editable-field-min-width: Minimum width applied to the field in visualization mode. Unset by default — consumers opt in for layout stability.
+	* @prop --inline-editable-field-editing-min-width: Minimum width applied while editing. Takes priority over `--inline-editable-field-min-width` in edit mode. Unset by default.
 	*/
 	--margin-top-bottom: var(--spacing-xs);
 	--margin-left-right: var(--spacing-md);
@@ -21,11 +22,22 @@
 	--inline-editable-field-outline-color-focus: var(--input-border-color-selected);
 	--inline-editable-field-placeholder-color: var(--input-text-text-input-default);
 	--inline-editable-field-min-width: unset;
+	--inline-editable-field-editing-min-width: unset;
 
 	&__hover .inline-editable-field-slot {
 		border-radius: var(--radius-md);
 		background: var(--inline-editable-field-background-color-hover);
 		outline-color: var(--inline-editable-field-outline-color-hover);
+	}
+
+	&:not(&__editing) .inline-editable-field-slot[contenteditable]:empty::before {
+		content: attr(data-placeholder);
+		color: var(--inline-editable-field-placeholder-color);
+		pointer-events: none;
+	}
+
+	&__editing .inline-editable-field-slot[contenteditable] {
+		min-width: var(--inline-editable-field-editing-min-width);
 	}
 }
 
@@ -60,12 +72,6 @@
 		display: inline;
 		white-space: nowrap;
 	}
-}
-
-.inline-editable-field-container:not(.inline-editable-field-container__editing) .inline-editable-field-slot[contenteditable]:empty::before {
-	content: attr(data-placeholder);
-	color: var(--inline-editable-field-placeholder-color);
-	pointer-events: none;
 }
 
 .inline-editable-field-actions {

--- a/packages/ui-components/src/components/inline-editable-field/inline-editable-field.tsx
+++ b/packages/ui-components/src/components/inline-editable-field/inline-editable-field.tsx
@@ -24,6 +24,12 @@ export class KvInlineEditableField {
 	 * The maximum length of the editable field.
 	 */
 	@Prop({ reflect: true }) maxLength: number = DEFAULT_MAX_LENGTH;
+	/**
+	 * Text displayed when the field has no value. Visible only when the slot is empty
+	 * and the field is not in edit mode. Empty saves are not allowed: clearing all
+	 * content and confirming reverts to the previous value.
+	 */
+	@Prop({ reflect: true }) placeholder?: string;
 
 	/**
 	 * Emitted when the content is edited.
@@ -92,6 +98,17 @@ export class KvInlineEditableField {
 		}
 	}
 
+	@Watch('placeholder')
+	handlePlaceholderChange(placeholder: string | undefined) {
+		if (!this.slotEl) return;
+
+		if (placeholder) {
+			this.slotEl.setAttribute('data-placeholder', placeholder);
+		} else {
+			this.slotEl.removeAttribute('data-placeholder');
+		}
+	}
+
 	private discardContent = () => {
 		this.slotEl.innerText = this.value;
 	};
@@ -144,6 +161,9 @@ export class KvInlineEditableField {
 	private initializeEditableContent() {
 		this.slotEl.classList.add('inline-editable-field-slot');
 		this.slotEl.setAttribute('contenteditable', 'true');
+		if (this.placeholder) {
+			this.slotEl.setAttribute('data-placeholder', this.placeholder);
+		}
 		this.slotEl.addEventListener('blur', this.handleBlur);
 		this.slotEl.addEventListener('focus', this.handleFocus);
 		this.slotEl.addEventListener('input', this.checkSaveBtnDisabled);
@@ -154,6 +174,7 @@ export class KvInlineEditableField {
 
 		this.slotEl.classList.remove('inline-editable-field-slot');
 		this.slotEl.removeAttribute('contenteditable');
+		this.slotEl.removeAttribute('data-placeholder');
 		this.slotEl.removeEventListener('blur', this.handleBlur);
 		this.slotEl.removeEventListener('focus', this.handleFocus);
 		this.slotEl.removeEventListener('input', this.checkSaveBtnDisabled);
@@ -195,7 +216,8 @@ export class KvInlineEditableField {
 			<Host
 				class={{
 					'inline-editable-field-container': true,
-					'inline-editable-field-container__hover': this.isHovering
+					'inline-editable-field-container__hover': this.isHovering,
+					'inline-editable-field-container__editing': this.isEditing
 				}}
 			>
 				<slot></slot>

--- a/packages/ui-components/src/components/inline-editable-field/readme.md
+++ b/packages/ui-components/src/components/inline-editable-field/readme.md
@@ -7,11 +7,12 @@
 
 ## Properties
 
-| Property    | Attribute    | Description                                       | Type      | Default              |
-| ----------- | ------------ | ------------------------------------------------- | --------- | -------------------- |
-| `disabled`  | `disabled`   | Indicates whether the editable field is disabled. | `boolean` | `undefined`          |
-| `maxLength` | `max-length` | The maximum length of the editable field.         | `number`  | `DEFAULT_MAX_LENGTH` |
-| `value`     | `value`      | The value of the field.                           | `string`  | `undefined`          |
+| Property      | Attribute     | Description                                                                                                                                                                                                        | Type      | Default              |
+| ------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- | -------------------- |
+| `disabled`    | `disabled`    | Indicates whether the editable field is disabled.                                                                                                                                                                  | `boolean` | `undefined`          |
+| `maxLength`   | `max-length`  | The maximum length of the editable field.                                                                                                                                                                          | `number`  | `DEFAULT_MAX_LENGTH` |
+| `placeholder` | `placeholder` | Text displayed when the field has no value. Visible only when the slot is empty and the field is not in edit mode. Empty saves are not allowed: clearing all content and confirming reverts to the previous value. | `string`  | `undefined`          |
+| `value`       | `value`       | The value of the field.                                                                                                                                                                                            | `string`  | `undefined`          |
 
 
 ## Events
@@ -38,13 +39,15 @@ Type: `Promise<void>`
 
 ## CSS Custom Properties
 
-| Name                                             | Description                                      |
-| ------------------------------------------------ | ------------------------------------------------ |
-| `--inline-editable-field-background-color-hover` | Background color of the editable field on hover. |
-| `--inline-editable-field-outline-color-focus`    | Outline color of the editable field on focus.    |
-| `--inline-editable-field-outline-color-hover`    | Outline color of the editable field on hover.    |
-| `--margin-left-right`                            | Margin left and right of the editable container. |
-| `--margin-top-bottom`                            | Margin top and bottom of the editable container. |
+| Name                                             | Description                                                          |
+| ------------------------------------------------ | -------------------------------------------------------------------- |
+| `--inline-editable-field-background-color-hover` | Background color of the editable field on hover.                     |
+| `--inline-editable-field-min-width`              | Minimum width of the editable area so it stays clickable when empty. |
+| `--inline-editable-field-outline-color-focus`    | Outline color of the editable field on focus.                        |
+| `--inline-editable-field-outline-color-hover`    | Outline color of the editable field on hover.                        |
+| `--inline-editable-field-placeholder-color`      | Text color used to render the placeholder when the field is empty.   |
+| `--margin-left-right`                            | Margin left and right of the editable container.                     |
+| `--margin-top-bottom`                            | Margin top and bottom of the editable container.                     |
 
 
 ## Dependencies

--- a/packages/ui-components/src/components/inline-editable-field/test/inline-editable-field.e2e.ts
+++ b/packages/ui-components/src/components/inline-editable-field/test/inline-editable-field.e2e.ts
@@ -50,4 +50,46 @@ describe('KvInlineEditableField (e2e tests)', () => {
 			});
 		});
 	});
+
+	describe('when a placeholder is set and the value is empty', () => {
+		let page: E2EPage;
+		let component: E2EElement;
+		let slot: E2EElement;
+
+		beforeEach(async () => {
+			page = await newE2EPage();
+			await page.setContent(`
+				<kv-inline-editable-field placeholder="-">
+					<div></div>
+				</kv-inline-editable-field>`);
+			await page.waitForChanges();
+
+			component = await page.find('kv-inline-editable-field');
+			slot = await component.find('div');
+		});
+
+		it('should set data-placeholder on the slotted element', async () => {
+			expect(slot.getAttribute('data-placeholder')).toBe('-');
+		});
+
+		it('should add the editing class to the host on focus', async () => {
+			await slot.click();
+			await page.waitForChanges();
+
+			expect(component.getAttribute('class')).toContain('inline-editable-field-container__editing');
+		});
+
+		it('should not emit contentEdited when saving an empty value', async () => {
+			const contentEdited = await component.spyOnEvent('contentEdited');
+
+			await slot.click();
+			await page.waitForChanges();
+
+			const saveBtn = await page.find('kv-inline-editable-field .inline-editable-field-actions kv-action-button-icon[icon="kv-done-all"]');
+			await saveBtn.click();
+			await page.waitForChanges();
+
+			expect(contentEdited).not.toHaveReceivedEvent();
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- Adds an optional `placeholder` prop to `kv-inline-editable-field` that renders a default display value (e.g. `-`) when the slot is empty and the field is not in edit mode.
- Implementation uses a `:empty::before { content: attr(data-placeholder); }` pseudo, gated on a new `inline-editable-field-container__editing` host class so the placeholder vanishes the moment focus enters and never leaks into `slotEl.innerText`.
- Empty-save behavior is intentionally unchanged — clearing and confirming falls back to the previous value via the existing `discardContent` path.
- New CSS custom properties: `--inline-editable-field-placeholder-color` (defaults to `--input-text-text-input-default`, matching `kv-text-field`) and `--inline-editable-field-min-width`.
- Storybook gets a new `WithPlaceholder` story.
- E2E coverage added for `data-placeholder` propagation, the editing host class, and the no-emit regression on empty save.

## Test plan
- [x] `pnpm build:packages` succeeds
- [x] `pnpm test -- inline-editable-field` passes (spec + e2e)
- [x] In `pnpm storybook`, `Inputs / Inline Editable Field / WithPlaceholder` renders `-`, click-to-edit empties the field without collapse, saved typed value persists, clearing + saving reverts to the previous value
- [x] Existing `Default` and `DisableEdit` stories unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)