### PR TITLE
fix(tab-item): suppress tabSelected emit when disabled

### DIFF
--- a/apps/react-storybook/src/components/navigation/tabs/tab-item/TabItem.stories.tsx
+++ b/apps/react-storybook/src/components/navigation/tabs/tab-item/TabItem.stories.tsx
@@ -20,7 +20,8 @@ const meta = {
 		type: {
 			control: "radio",
 			options: Object.values(ETabItemType)
-		}
+		},
+		onTabSelected: { action: "tabSelected" }
 	}
 } satisfies Meta<typeof KvTabItem>;
 
@@ -68,6 +69,7 @@ export const SecondaryWithBadge: Story = {
 				label={args.label}
 				disabled={args.disabled}
 				selected={args.selected}
+				onTabSelected={args.onTabSelected}
 			>
 				<KvBadge slot="right-slot" type={EBadgeType.Secondary}>
 					+3
@@ -91,6 +93,7 @@ export const SecondaryWithTagStatus: Story = {
 				label={args.label}
 				disabled={args.disabled}
 				selected={args.selected}
+				onTabSelected={args.onTabSelected}
 			>
 				<KvTagStatus
 					slot="right-slot"

--- a/apps/react-storybook/src/components/navigation/tabs/tab-navigation/TabNavigation.stories.tsx
+++ b/apps/react-storybook/src/components/navigation/tabs/tab-navigation/TabNavigation.stories.tsx
@@ -15,6 +15,7 @@ const meta = {
 		const [, updateArgs] = useArgs();
 
 		const handleTabChange = (event: CustomEvent<string>) => {
+			args.onTabChange?.(event);
 			updateArgs({ selectedTabKey: event.detail });
 		};
 
@@ -34,7 +35,8 @@ const meta = {
 		type: {
 			control: "radio",
 			options: Object.values(ETabItemType)
-		}
+		},
+		onTabChange: { action: "tabChange" }
 	}
 } satisfies Meta<typeof KvTabNavigation>;
 
@@ -131,6 +133,7 @@ export const SecondaryTypeOnlyIconVertical: Story = {
 		const [, updateArgs] = useArgs();
 
 		const handleTabChange = (event: CustomEvent<string>) => {
+			args.onTabChange?.(event);
 			updateArgs({ selectedTabKey: event.detail });
 		};
 

--- a/packages/ui-components/src/components/tab-item/tab-item.scss
+++ b/packages/ui-components/src/components/tab-item/tab-item.scss
@@ -79,6 +79,7 @@
 
 			&.disabled {
 				cursor: not-allowed;
+				pointer-events: none;
 				user-select: none;
 				background: var(--tab-secondary-background-disabled);
 				border-color: var(--tab-secondary-border-color-disabled);

--- a/packages/ui-components/src/components/tab-item/tab-item.tsx
+++ b/packages/ui-components/src/components/tab-item/tab-item.tsx
@@ -41,6 +41,7 @@ export class KvTabItem implements ICustomCss {
 	}
 
 	private tabClick = () => {
+		if (this.disabled) return;
 		this.tabSelected.emit(this.tabKey);
 	};
 

--- a/packages/ui-components/src/components/tab-item/test/tab-item.e2e.ts
+++ b/packages/ui-components/src/components/tab-item/test/tab-item.e2e.ts
@@ -59,4 +59,30 @@ describe('Tab Item (end-to-end)', () => {
 			});
 		});
 	});
+
+	describe('when rendering with disabled attribute on a secondary tab', () => {
+		beforeEach(async () => {
+			page = await newE2EPage();
+			await page.setContent('<kv-tab-item tab-key="dashboard" label="Dashboard" type="secondary" disabled></kv-tab-item>');
+		});
+
+		describe('and the user clicks on the tab', () => {
+			let tabClickSpy: EventSpy;
+			let tabEl: E2EElement;
+
+			beforeEach(async () => {
+				tabEl = await page.find('kv-tab-item');
+				tabClickSpy = await tabEl.spyOnEvent('tabSelected');
+
+				const tabContainerEl = await page.find('kv-tab-item >>> .tab-item-container');
+				await tabContainerEl.click();
+
+				await new Promise(r => setTimeout(r, 300));
+			});
+
+			it(`should not emit the tab's key (tabKey)`, () => {
+				expect(tabClickSpy).not.toHaveReceivedEvent();
+			});
+		});
+	});
 });

--- a/packages/ui-components/src/components/tab-item/test/tab-item.spec.tsx
+++ b/packages/ui-components/src/components/tab-item/test/tab-item.spec.tsx
@@ -43,6 +43,14 @@ describe('Tab Item (unit tests)', () => {
 		it('should set the disabled prop value', () => {
 			expect(component.disabled).toBeTruthy();
 		});
+
+		it('should not emit tabSelected when the inner container is clicked', async () => {
+			const emitSpy = jest.spyOn(component.tabSelected, 'emit');
+			const container = page.root.shadowRoot.querySelector<HTMLElement>('.tab-item-container');
+			container.click();
+			await page.waitForChanges();
+			expect(emitSpy).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('when initialized with selected attribute', () => {


### PR DESCRIPTION
## Context

`KvTabItem` was firing `tabSelected` on every click, including when the `disabled` prop was true. `KvTabNavigation` re-emits that as `tabChange`, so downstream consumers (`@kelvininc/shared-ui` `Tabs`, used in core-ui-apps' `ApplicationRecommendationsCard`) reacted to clicks on zero-count / disabled tabs and switched `activeTab` to a disabled key.

Two compounding defects:
1. **JS guard missing** — `KvTabItem.tabClick` emitted `tabSelected` unconditionally.
2. **CSS inconsistency** — `pointer-events: none` was applied only on `.primary.disabled`. Secondary tabs (the variant used by shared-ui's `Tabs`) had the disabled visual styling but still let clicks reach the handler.

## Changes

- `tab-item.tsx` — added `if (this.disabled) return;` at the top of `tabClick`. This is the load-bearing fix; it stops the emit regardless of CSS.
- `tab-item.scss` — added `pointer-events: none` to `.secondary.disabled` (mirrors the existing `.primary.disabled` rule). Defense in depth.
- `tab-item.spec.tsx` — new unit case dispatches a real click on the inner `.tab-item-container` (shadow DOM) and asserts `tabSelected.emit` is not called. Exercises the full `onClick → tabClickThrottler → tabClick → guard` chain rather than calling the private method directly.
- `tab-item.e2e.ts` — new `type="secondary" disabled` case. Previously only the default primary variant was covered, which silently relied on the CSS pointer-events block.
- `TabItem.stories.tsx` / `TabNavigation.stories.tsx` — wired `onTabSelected` / `onTabChange` to Storybook's Actions panel via `argTypes` so the fix is visually verifiable (clicking the disabled `parts` tab in the existing `SecondaryType` story no longer logs `tabChange`).

## Testing

- `pnpm test:spec` and `pnpm test:e2e` on `packages/ui-components` — all tab-item tests green (9 unit, 3 e2e).
- Manually verified the existing `SecondaryType` `TabNavigation` story: clicking the disabled `parts` tab no longer fires `tabChange` in the Actions panel and the cursor shows `not-allowed`.

## Risk

Low. The guard is a single early-return on a private method; behavior on enabled tabs is unchanged. The SCSS rule only affects already-disabled tabs.

## References

Tracked: [KFE-2995](https://kelvininc.atlassian.net/browse/KFE-2995). Repro found in core-ui-apps' `ApplicationRecommendationsCard`; once a new `@kelvininc/react-ui-components` is published with this fix and bumped there, the recommendations card stops reacting to disabled-tab clicks (no change needed in core-ui-apps).

[KFE-2995]: https://kelvininc.atlassian.net/browse/KFE-2995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ