### PR TITLE
feat(deps): upgrade to React 19

### DIFF
--- a/apps/react-storybook/package.json
+++ b/apps/react-storybook/package.json
@@ -24,8 +24,8 @@
 		"@rjsf/core": "^5.24.8",
 		"@rjsf/utils": "^5.24.8",
 		"lodash-es": "^4.17.21",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"react": "^19.2.0",
+		"react-dom": "^19.2.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.11.1",
@@ -46,8 +46,8 @@
 		"@storybook/react-webpack5": "^8.6.12",
 		"@storybook/storybook-deployer": "^2.8.16",
 		"@storybook/theming": "^8.6.12",
-		"@types/react": "^18.3.10",
-		"@types/react-dom": "^18.3.1",
+		"@types/react": "^19.2.0",
+		"@types/react-dom": "^19.2.0",
 		"css-loader": "^7.1.2",
 		"eslint": "^9.11.1",
 		"eslint-plugin-react-hooks": "^5.1.0-rc.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,16 @@
 	"pnpm": {
 		"patchedDependencies": {
 			"@pxtrn/storybook-addon-docs-stencil@8.0.0": "patches/@pxtrn__storybook-addon-docs-stencil@8.0.0.patch"
+		},
+		"overrides": {
+			"@types/react": "^19.2.0",
+			"@types/react-dom": "^19.2.0"
+		},
+		"peerDependencyRules": {
+			"allowedVersions": {
+				"@storybook/icons>react": "19",
+				"@storybook/icons>react-dom": "19"
+			}
 		}
 	}
 }

--- a/packages/react-ui-components/package.json
+++ b/packages/react-ui-components/package.json
@@ -81,7 +81,7 @@
 	},
 	"dependencies": {
 		"@kelvininc/ui-components": "workspace:*",
-		"@monaco-editor/react": "^4.4.6",
+		"@monaco-editor/react": "^4.7.0",
 		"@rjsf/core": "^5.24.8",
 		"@rjsf/utils": "^5.24.8",
 		"@rjsf/validator-ajv8": "^5.24.8",
@@ -97,8 +97,8 @@
 		"@types/json-schema": "^7.0.12",
 		"@types/lodash": "^4.17.5",
 		"@types/node": "^22.7.2",
-		"@types/react": "^18.3.10",
-		"@types/react-dom": "^18.3.1",
+		"@types/react": "^19.2.0",
+		"@types/react-dom": "^19.2.0",
 		"@typescript-eslint/parser": "^5.12.1",
 		"dayjs": "^1.11.13",
 		"eslint": "^8.9.0",
@@ -108,8 +108,8 @@
 		"lodash": "^4.17.21",
 		"postcss": "^8.4.47",
 		"prettier": "^2.5.1",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1",
+		"react": "^19.2.0",
+		"react-dom": "^19.2.0",
 		"rollup": "^4.21.3",
 		"rollup-plugin-copy": "^3.5.0",
 		"rollup-plugin-peer-deps-external": "^2.2.4",
@@ -128,7 +128,7 @@
 		"@stencil/react-output-target": "^0.5.3",
 		"dayjs": "^1.11.13",
 		"lodash-es": "^4.17.21",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	}
 }

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/FileWidget/FileWidget.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/FileWidget/FileWidget.tsx
@@ -133,7 +133,7 @@ function FileWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends 
 					id={`file_${name}`}
 					type="file"
 					value=""
-					onInput={handleChange}
+					onChange={handleChange}
 					required={value ? false : required}
 					readOnly={readonly}
 					accept={options.accept ? String(options.accept) : undefined}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   libnpmpublish: 4.0.2
+  '@types/react': ^19.2.0
+  '@types/react-dom': ^19.2.0
 
 patchedDependencies:
   '@pxtrn/storybook-addon-docs-stencil@8.0.0':
@@ -39,19 +41,19 @@ importers:
         version: link:../../packages/react-ui-components
       '@rjsf/core':
         specifier: ^5.24.8
-        version: 5.24.8(@rjsf/utils@5.24.8)(react@18.3.1)
+        version: 5.24.8(@rjsf/utils@5.24.8)(react@19.2.7)
       '@rjsf/utils':
         specifier: ^5.24.8
-        version: 5.24.8(react@18.3.1)
+        version: 5.24.8(react@19.2.7)
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
       react:
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.2.0
+        version: 19.2.7
       react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.0
+        version: 19.2.7(react@19.2.7)
     devDependencies:
       '@eslint/js':
         specifier: ^9.11.1
@@ -67,16 +69,16 @@ importers:
         version: 8.6.12(storybook@8.6.12)
       '@storybook/addon-docs':
         specifier: ^8.6.12
-        version: 8.6.12(@types/react@18.3.12)(storybook@8.6.12)
+        version: 8.6.12(@types/react@19.2.17)(storybook@8.6.12)
       '@storybook/addon-essentials':
         specifier: ^8.6.12
-        version: 8.6.12(@types/react@18.3.12)(storybook@8.6.12)
+        version: 8.6.12(@types/react@19.2.17)(storybook@8.6.12)
       '@storybook/addon-interactions':
         specifier: ^8.6.12
         version: 8.6.12(storybook@8.6.12)
       '@storybook/addon-links':
         specifier: ^8.6.12
-        version: 8.6.12(react@18.3.1)(storybook@8.6.12)
+        version: 8.6.12(react@19.2.7)(storybook@8.6.12)
       '@storybook/addon-styling-webpack':
         specifier: ^1.0.1
         version: 1.0.1(storybook@8.6.12)(webpack@5.95.0)
@@ -88,7 +90,7 @@ importers:
         version: 3.0.0(webpack@5.95.0)
       '@storybook/blocks':
         specifier: ^8.6.12
-        version: 8.6.12(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.12)
+        version: 8.6.12(react-dom@19.2.7)(react@19.2.7)(storybook@8.6.12)
       '@storybook/manager-api':
         specifier: ^8.6.12
         version: 8.6.12(storybook@8.6.12)
@@ -97,10 +99,10 @@ importers:
         version: 8.6.12(storybook@8.6.12)
       '@storybook/react':
         specifier: ^8.6.12
-        version: 8.6.12(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.12)(typescript@5.6.2)
+        version: 8.6.12(react-dom@19.2.7)(react@19.2.7)(storybook@8.6.12)(typescript@5.6.2)
       '@storybook/react-webpack5':
         specifier: ^8.6.12
-        version: 8.6.12(@swc/core@1.11.20)(esbuild@0.23.1)(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.12)(typescript@5.6.2)
+        version: 8.6.12(@swc/core@1.11.20)(esbuild@0.23.1)(react-dom@19.2.7)(react@19.2.7)(storybook@8.6.12)(typescript@5.6.2)
       '@storybook/storybook-deployer':
         specifier: ^2.8.16
         version: 2.8.16
@@ -108,11 +110,11 @@ importers:
         specifier: ^8.6.12
         version: 8.6.12(storybook@8.6.12)
       '@types/react':
-        specifier: ^18.3.10
-        version: 18.3.12
+        specifier: ^19.2.0
+        version: 19.2.17
       '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.17)
       css-loader:
         specifier: ^7.1.2
         version: 7.1.2(webpack@5.95.0)
@@ -159,14 +161,14 @@ importers:
         specifier: workspace:*
         version: link:../ui-components
       '@monaco-editor/react':
-        specifier: ^4.4.6
-        version: 4.6.0(monaco-editor@0.34.1)(react-dom@18.3.1)(react@18.3.1)
+        specifier: ^4.7.0
+        version: 4.7.0(monaco-editor@0.34.1)(react-dom@19.2.7)(react@19.2.7)
       '@rjsf/core':
         specifier: ^5.24.8
-        version: 5.24.8(@rjsf/utils@5.24.8)(react@18.3.1)
+        version: 5.24.8(@rjsf/utils@5.24.8)(react@19.2.7)
       '@rjsf/utils':
         specifier: ^5.24.8
-        version: 5.24.8(react@18.3.1)
+        version: 5.24.8(react@19.2.7)
       '@rjsf/validator-ajv8':
         specifier: ^5.24.8
         version: 5.24.8(@rjsf/utils@5.24.8)
@@ -205,11 +207,11 @@ importers:
         specifier: ^22.7.2
         version: 22.7.4
       '@types/react':
-        specifier: ^18.3.10
-        version: 18.3.12
+        specifier: ^19.2.0
+        version: 19.2.17
       '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.2.0
+        version: 19.2.3(@types/react@19.2.17)
       '@typescript-eslint/parser':
         specifier: ^5.12.1
         version: 5.62.0(eslint@8.57.1)(typescript@5.6.2)
@@ -238,11 +240,11 @@ importers:
         specifier: ^2.5.1
         version: 2.8.8
       react:
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.2.0
+        version: 19.2.7
       react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.0
+        version: 19.2.7(react@19.2.7)
       rollup:
         specifier: ^4.21.3
         version: 4.27.3
@@ -2409,37 +2411,34 @@ packages:
       - typescript
     dev: true
 
-  /@mdx-js/react@3.1.0(@types/react@18.3.12)(react@18.3.1):
+  /@mdx-js/react@3.1.0(@types/react@19.2.17)(react@19.2.7):
     resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
     peerDependencies:
-      '@types/react': '>=16'
+      '@types/react': ^19.2.0
       react: '>=16'
     dependencies:
       '@types/mdx': 2.0.13
-      '@types/react': 18.3.12
-      react: 18.3.1
+      '@types/react': 19.2.17
+      react: 19.2.7
     dev: true
 
-  /@monaco-editor/loader@1.4.0(monaco-editor@0.34.1):
-    resolution: {integrity: sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==}
-    peerDependencies:
-      monaco-editor: '>= 0.21.0 < 1'
+  /@monaco-editor/loader@1.7.0:
+    resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
     dependencies:
-      monaco-editor: 0.34.1
       state-local: 1.0.7
     dev: false
 
-  /@monaco-editor/react@4.6.0(monaco-editor@0.34.1)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==}
+  /@monaco-editor/react@4.7.0(monaco-editor@0.34.1)(react-dom@19.2.7)(react@19.2.7):
+    resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
     peerDependencies:
       monaco-editor: '>= 0.25.0 < 1'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     dependencies:
-      '@monaco-editor/loader': 1.4.0(monaco-editor@0.34.1)
+      '@monaco-editor/loader': 1.7.0
       monaco-editor: 0.34.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     dev: false
 
   /@napi-rs/wasm-runtime@0.2.4:
@@ -2952,23 +2951,23 @@ packages:
     dev: true
     patched: true
 
-  /@rjsf/core@5.24.8(@rjsf/utils@5.24.8)(react@18.3.1):
+  /@rjsf/core@5.24.8(@rjsf/utils@5.24.8)(react@19.2.7):
     resolution: {integrity: sha512-7YdOMl0UylldYR75rnKoQF5etibSwPQHA3rY8LEo28xyYek81ESGuqPTs37P14doBpGRL+SobggR76tYhDYO7A==}
     engines: {node: '>=14'}
     peerDependencies:
       '@rjsf/utils': ^5.24.x
       react: ^16.14.0 || >=17
     dependencies:
-      '@rjsf/utils': 5.24.8(react@18.3.1)
+      '@rjsf/utils': 5.24.8(react@19.2.7)
       lodash: 4.17.21
       lodash-es: 4.17.21
-      markdown-to-jsx: 7.5.0(react@18.3.1)
+      markdown-to-jsx: 7.5.0(react@19.2.7)
       nanoid: 3.3.7
       prop-types: 15.8.1
-      react: 18.3.1
+      react: 19.2.7
     dev: false
 
-  /@rjsf/utils@5.24.8(react@18.3.1):
+  /@rjsf/utils@5.24.8(react@19.2.7):
     resolution: {integrity: sha512-Y/D1orNsTnIswp23QtWKq7QEme07/nSdnSJoK4gSsm2cDBkSCW+9KUsWSvmE7poqHwCn3zpbIaa3ZWEAQUJEEg==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -2978,7 +2977,7 @@ packages:
       jsonpointer: 5.0.1
       lodash: 4.17.21
       lodash-es: 4.17.21
-      react: 18.3.1
+      react: 19.2.7
       react-is: 18.3.1
     dev: false
 
@@ -2988,7 +2987,7 @@ packages:
     peerDependencies:
       '@rjsf/utils': ^5.24.x
     dependencies:
-      '@rjsf/utils': 5.24.8(react@18.3.1)
+      '@rjsf/utils': 5.24.8(react@19.2.7)
       ajv: 8.17.1
       ajv-formats: 2.1.1(ajv@8.17.1)
       lodash: 4.17.21
@@ -3603,24 +3602,24 @@ packages:
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/addon-docs@8.6.12(@types/react@18.3.12)(storybook@8.6.12):
+  /@storybook/addon-docs@8.6.12(@types/react@19.2.17)(storybook@8.6.12):
     resolution: {integrity: sha512-kEezQjAf/p3SpDzLABgg4fbT48B6dkT2LiZCKTRmCrJVtuReaAr4R9MMM6Jsph6XjbIj/SvOWf3CMeOPXOs9sg==}
     peerDependencies:
       storybook: ^8.6.12
     dependencies:
-      '@mdx-js/react': 3.1.0(@types/react@18.3.12)(react@18.3.1)
-      '@storybook/blocks': 8.6.12(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.12)
+      '@mdx-js/react': 3.1.0(@types/react@19.2.17)(react@19.2.7)
+      '@storybook/blocks': 8.6.12(react-dom@19.2.7)(react@19.2.7)(storybook@8.6.12)
       '@storybook/csf-plugin': 8.6.12(storybook@8.6.12)
-      '@storybook/react-dom-shim': 8.6.12(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.12)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      '@storybook/react-dom-shim': 8.6.12(react-dom@19.2.7)(react@19.2.7)(storybook@8.6.12)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       storybook: 8.6.12
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
     dev: true
 
-  /@storybook/addon-essentials@8.6.12(@types/react@18.3.12)(storybook@8.6.12):
+  /@storybook/addon-essentials@8.6.12(@types/react@19.2.17)(storybook@8.6.12):
     resolution: {integrity: sha512-Y/7e8KFlttaNfv7q2zoHMPdX6hPXHdsuQMAjYl5NG9HOAJREu4XBy4KZpbcozRe4ApZ78rYsN/MO1EuA+bNMIA==}
     peerDependencies:
       storybook: ^8.6.12
@@ -3628,7 +3627,7 @@ packages:
       '@storybook/addon-actions': 8.6.12(storybook@8.6.12)
       '@storybook/addon-backgrounds': 8.6.12(storybook@8.6.12)
       '@storybook/addon-controls': 8.6.12(storybook@8.6.12)
-      '@storybook/addon-docs': 8.6.12(@types/react@18.3.12)(storybook@8.6.12)
+      '@storybook/addon-docs': 8.6.12(@types/react@19.2.17)(storybook@8.6.12)
       '@storybook/addon-highlight': 8.6.12(storybook@8.6.12)
       '@storybook/addon-measure': 8.6.12(storybook@8.6.12)
       '@storybook/addon-outline': 8.6.12(storybook@8.6.12)
@@ -3662,7 +3661,7 @@ packages:
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/addon-links@8.6.12(react@18.3.1)(storybook@8.6.12):
+  /@storybook/addon-links@8.6.12(react@19.2.7)(storybook@8.6.12):
     resolution: {integrity: sha512-AfKujFHoAxhxq4yu+6NwylltS9lf5MPs1eLLXvOlwo3l7Y/c68OdxJ7j68vLQhs9H173WVYjKyjbjFxJWf/YYg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
@@ -3672,7 +3671,7 @@ packages:
         optional: true
     dependencies:
       '@storybook/global': 5.0.0
-      react: 18.3.1
+      react: 19.2.7
       storybook: 8.6.12
       ts-dedent: 2.2.0
     dev: true
@@ -3745,7 +3744,7 @@ packages:
       - webpack
     dev: true
 
-  /@storybook/blocks@8.6.12(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.12):
+  /@storybook/blocks@8.6.12(react-dom@19.2.7)(react@19.2.7)(storybook@8.6.12):
     resolution: {integrity: sha512-DohlTq6HM1jDbHYiXL4ZvZ00VkhpUp5uftzj/CZDLY1fYHRjqtaTwWm2/OpceivMA8zDitLcq5atEZN+f+siTg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3757,9 +3756,9 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@storybook/icons': 1.2.12(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      '@storybook/icons': 1.2.12(react-dom@19.2.7)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       storybook: 8.6.12
       ts-dedent: 2.2.0
     dev: true
@@ -3877,15 +3876,15 @@ packages:
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
     dev: true
 
-  /@storybook/icons@1.2.12(react-dom@18.3.1)(react@18.3.1):
+  /@storybook/icons@1.2.12(react-dom@19.2.7)(react@19.2.7):
     resolution: {integrity: sha512-UxgyK5W3/UV4VrI3dl6ajGfHM4aOqMAkFLWe2KibeQudLf6NJpDrDMSHwZj+3iKC4jFU7dkKbbtH2h/al4sW3Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     dev: true
 
   /@storybook/instrumenter@8.6.12(storybook@8.6.12):
@@ -3914,7 +3913,7 @@ packages:
       storybook: 8.6.12
     dev: true
 
-  /@storybook/preset-react-webpack@8.6.12(@swc/core@1.11.20)(esbuild@0.23.1)(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.12)(typescript@5.6.2):
+  /@storybook/preset-react-webpack@8.6.12(@swc/core@1.11.20)(esbuild@0.23.1)(react-dom@19.2.7)(react@19.2.7)(storybook@8.6.12)(typescript@5.6.2):
     resolution: {integrity: sha512-aCCHjR/jsVPVThRH7nK70wS0Od44M6hqkkakg3xr7LETZZGj99heen6t4VHvz8gcQYT9l6R/oZwCl7f/PQ3ZBQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -3927,14 +3926,14 @@ packages:
         optional: true
     dependencies:
       '@storybook/core-webpack': 8.6.12(storybook@8.6.12)
-      '@storybook/react': 8.6.12(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.12)(typescript@5.6.2)
+      '@storybook/react': 8.6.12(react-dom@19.2.7)(react@19.2.7)(storybook@8.6.12)(typescript@5.6.2)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.6.2)(webpack@5.95.0)
       '@types/semver': 7.5.8
       find-up: 5.0.0
       magic-string: 0.30.11
-      react: 18.3.1
+      react: 19.2.7
       react-docgen: 7.1.0
-      react-dom: 18.3.1(react@18.3.1)
+      react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.8
       semver: 7.6.3
       storybook: 8.6.12
@@ -3977,19 +3976,19 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/react-dom-shim@8.6.12(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.12):
+  /@storybook/react-dom-shim@8.6.12(react-dom@19.2.7)(react@19.2.7)(storybook@8.6.12):
     resolution: {integrity: sha512-51QvoimkBzYs8s3rCYnY5h0cFqLz/Mh0vRcughwYaXckWzDBV8l67WBO5Xf5nBsukCbWyqBVPpEQLww8s7mrLA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^8.6.12
     dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       storybook: 8.6.12
     dev: true
 
-  /@storybook/react-webpack5@8.6.12(@swc/core@1.11.20)(esbuild@0.23.1)(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.12)(typescript@5.6.2):
+  /@storybook/react-webpack5@8.6.12(@swc/core@1.11.20)(esbuild@0.23.1)(react-dom@19.2.7)(react@19.2.7)(storybook@8.6.12)(typescript@5.6.2):
     resolution: {integrity: sha512-wZOjPQ00gu85iQoKgwz5uvM3+bhXrQDVR0ppVAj7vVy6cvLEsJXmqNLHbXPCZuKPmvwzYr1QkslMLCIkF8OGdA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -4002,10 +4001,10 @@ packages:
         optional: true
     dependencies:
       '@storybook/builder-webpack5': 8.6.12(@swc/core@1.11.20)(esbuild@0.23.1)(storybook@8.6.12)(typescript@5.6.2)
-      '@storybook/preset-react-webpack': 8.6.12(@swc/core@1.11.20)(esbuild@0.23.1)(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.12)(typescript@5.6.2)
-      '@storybook/react': 8.6.12(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.12)(typescript@5.6.2)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      '@storybook/preset-react-webpack': 8.6.12(@swc/core@1.11.20)(esbuild@0.23.1)(react-dom@19.2.7)(react@19.2.7)(storybook@8.6.12)(typescript@5.6.2)
+      '@storybook/react': 8.6.12(react-dom@19.2.7)(react@19.2.7)(storybook@8.6.12)(typescript@5.6.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       storybook: 8.6.12
       typescript: 5.6.2
     transitivePeerDependencies:
@@ -4018,7 +4017,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@storybook/react@8.6.12(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.12)(typescript@5.6.2):
+  /@storybook/react@8.6.12(react-dom@19.2.7)(react@19.2.7)(storybook@8.6.12)(typescript@5.6.2):
     resolution: {integrity: sha512-NzxlHLA5DkDgZM/dMwTYinuzRs6rsUPmlqP+NIv6YaciQ4NGnTYyOC7R/SqI6HHFm8ZZ5eMYvpfiFmhZ9rU+rQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -4037,10 +4036,10 @@ packages:
       '@storybook/global': 5.0.0
       '@storybook/manager-api': 8.6.12(storybook@8.6.12)
       '@storybook/preview-api': 8.6.12(storybook@8.6.12)
-      '@storybook/react-dom-shim': 8.6.12(react-dom@18.3.1)(react@18.3.1)(storybook@8.6.12)
+      '@storybook/react-dom-shim': 8.6.12(react-dom@19.2.7)(react@19.2.7)(storybook@8.6.12)
       '@storybook/theming': 8.6.12(storybook@8.6.12)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       storybook: 8.6.12
       typescript: 5.6.2
     dev: true
@@ -4452,21 +4451,18 @@ packages:
     resolution: {integrity: sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==}
     dev: true
 
-  /@types/prop-types@15.7.13:
-    resolution: {integrity: sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==}
+  /@types/react-dom@19.2.3(@types/react@19.2.17):
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+    dependencies:
+      '@types/react': 19.2.17
     dev: true
 
-  /@types/react-dom@18.3.1:
-    resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
+  /@types/react@19.2.17:
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
     dependencies:
-      '@types/react': 18.3.12
-    dev: true
-
-  /@types/react@18.3.12:
-    resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
-    dependencies:
-      '@types/prop-types': 15.7.13
-      csstype: 3.1.3
+      csstype: 3.2.3
     dev: true
 
   /@types/resolve@1.20.2:
@@ -6588,8 +6584,8 @@ packages:
       rrweb-cssom: 0.8.0
     dev: true
 
-  /csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+  /csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
     dev: true
 
   /dargs@7.0.0:
@@ -10276,13 +10272,13 @@ packages:
     resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
     dev: true
 
-  /markdown-to-jsx@7.5.0(react@18.3.1):
+  /markdown-to-jsx@7.5.0(react@19.2.7):
     resolution: {integrity: sha512-RrBNcMHiFPcz/iqIj0n3wclzHXjwS7mzjBNWecKKVhNTIxQepIix6Il/wZCn2Cg5Y1ow2Qi84+eJrryFRWBEWw==}
     engines: {node: '>= 10'}
     peerDependencies:
       react: '>= 0.14.0'
     dependencies:
-      react: 18.3.1
+      react: 19.2.7
     dev: false
 
   /math-intrinsics@1.1.0:
@@ -12242,14 +12238,13 @@ packages:
       - supports-color
     dev: true
 
-  /react-dom@18.3.1(react@18.3.1):
-    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+  /react-dom@19.2.7(react@19.2.7):
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
-      react: ^18.3.1
+      react: ^19.2.7
     dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
+      react: 19.2.7
+      scheduler: 0.27.0
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -12261,11 +12256,9 @@ packages:
   /react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  /react@18.3.1:
-    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+  /react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
-    dependencies:
-      loose-envify: 1.4.0
 
   /read-cmd-shim@4.0.0:
     resolution: {integrity: sha512-yILWifhaSEEytfXI76kB9xEEiG1AiozaCJZ83A87ytjRiN+jVibXjedjCRNjoZviinhG+4UkalO3mWTd8u5O0Q==}
@@ -12996,10 +12989,8 @@ packages:
       xmlchars: 2.2.0
     dev: true
 
-  /scheduler@0.23.2:
-    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
-    dependencies:
-      loose-envify: 1.4.0
+  /scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   /schema-utils@3.3.0:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}


### PR DESCRIPTION
Add React 19 support across the React packages and the Storybook app.

react-ui-components:
- peerDependencies react/react-dom -> ^19.0.0
- react/react-dom/@types/react/@types/react-dom devDeps -> 19
- @monaco-editor/react -> ^4.7.0 (first release supporting React 19)
- FileWidget: file input onInput -> onChange (React 19 types onInput as InputEventHandler, incompatible with the existing ChangeEvent handler; onChange is idiomatic and fires identically with value="")

react-storybook:
- react/react-dom -> 19, @types/react(-dom) -> 19 (Storybook stays on 8.6)

root:
- pnpm.overrides: pin @types/react(-dom) to 19 to dedupe the duplicate @types/react copies that collided via @rjsf/core typings
- pnpm.peerDependencyRules: allow React 19 for @storybook/icons