### PR TITLE
fix(dropdown-base): prevent layout shift from un-projected list slot before hydration

### DIFF
--- a/packages/ui-components/src/assets/styles/index.scss
+++ b/packages/ui-components/src/assets/styles/index.scss
@@ -20,3 +20,5 @@
 //New Design Tokens
 //Styles tokens (typography and effects)
 @forward 'style-dictionary/styles-mixins.scss';
+
+@forward 'kv-pre-hydration';

--- a/packages/ui-components/src/assets/styles/kv-pre-hydration.scss
+++ b/packages/ui-components/src/assets/styles/kv-pre-hydration.scss
@@ -1,0 +1,21 @@
+// Pre-hydration fixes for Kelvin web components.
+//
+// Forwarded by `index.scss`, so it ships through any consumer that `@use`s the styles index
+// (e.g. core-ui's app.scss, loaded in <head>) — present from first paint, before components upgrade.
+//
+// kv-dropdown-base (shadow:false) renders its `slot="list"` panel inside a portal that is only
+// shown when the dropdown is open. Before the component hydrates there is no portal yet, so the
+// un-projected panel renders INLINE — visible and full-size — inflating its container (e.g. a table
+// header). On hydration the panel is moved into its (closed) portal and the container collapses,
+// producing a layout shift (CLS). Hiding the un-projected panel pre-hydration keeps layout stable
+// from first paint; once `.hydrated` is added the rule stops matching and the closed portal keeps
+// the panel hidden.
+//
+// NOTE: this also hides an initially-open (`is-open`) dropdown's list until hydration. Do NOT scope
+// with `:not([is-open])` — closed dropdowns also carry an `is-open` attribute pre-hydration, so that
+// would exempt them too and re-introduce the CLS. A correct scope must key off the attribute value;
+// deferred as a follow-up since the only observed CLS is from closed dropdowns.
+
+kv-dropdown-base:not(.hydrated) > [slot='list'] {
+	display: none;
+}


### PR DESCRIPTION
## Summary

Fixes a layout shift (CLS) on initial page load caused by `kv-dropdown-base`.

`kv-dropdown-base` (`shadow: false`) renders its `slot="list"` panel inside a `<kv-portal show={isOpen}>` that is closed by default. **Before the component hydrates there is no portal**, so the un-projected `slot="list"` panel renders **inline at full size**, inflating its container (e.g. a table header / filter row). On hydration the panel is moved into its closed portal and the container collapses → visible layout jump.

## Fix

Ship a global, light-DOM rule that hides the un-projected list panel until the component hydrates:

```css
kv-dropdown-base:not(.hydrated) > [slot='list'] {
    display: none;
}
```

- New partial `src/assets/styles/kv-pre-hydration.scss`, `@forward`ed from `src/assets/styles/index.scss` — so any consumer that already `@use`s the styles index gets it in their `<head>` bundle **from first paint**, with no per-consumer import.
- `:not(.hydrated)` scopes it to the pre-hydration window only; once Stencil adds `.hydrated` the rule stops matching and the (closed) portal keeps the panel hidden.
- Direct-child combinator (`> [slot='list']`) so it only affects a dropdown's own list slot, never a nested one.

## Testing

- Reproduced and fixed on the core-ui Assets page: the Advanced Filter panel no longer inflates the table header on load.
- Verified via a Sass compile that `@forward`-ing a partial containing a top-level rule emits that rule into consumers' compiled CSS.
