### PR TITLE
fix(portal, schema-form): stop kv-portal tooltip autoUpdate leak and reuse the default AJV validator

### DIFF
--- a/packages/react-ui-components/src/utils/schema-form/config.ts
+++ b/packages/react-ui-components/src/utils/schema-form/config.ts
@@ -1,3 +1,4 @@
+import { customizeValidator, CustomValidatorOptionsType } from '@rjsf/validator-ajv8';
 import { EApplyDefaults } from '../../components/SchemaForm/types';
 import { ExperimentalAllOf, ExperimentalArrayMinItems, ExperimentalConstAsDefaults, ExperimentalEmptyObjectFields } from './types';
 
@@ -24,3 +25,20 @@ export const APPLY_DEFAULTS_TO_EXPERIMENTAL_DEFAULT_FORM_CONST_AS_DEFAULT: Recor
 	[EApplyDefaults.RequiredOnly]: 'skipOneOf',
 	[EApplyDefaults.Never]: 'never'
 };
+
+// Custom validator options.
+export const AJV_OPTIONS_OVERRIDES: CustomValidatorOptionsType['ajvOptionsOverrides'] = {
+	$data: true //Mandatory for use $data reference (https://ajv.js.org/guide/combining-schemas.html#data-reference)
+};
+
+export const AJV_FORMAT_OPTIONS: CustomValidatorOptionsType['ajvFormatOptions'] = {
+	keywords: true //Mandatory for use keywords to compare values like formatMinimum,... (https://ajv.js.org/packages/ajv-formats.html#keywords-to-compare-values-formatmaximum-formatminimum-and-formatexclusivemaximum-formatexclusiveminimum)
+};
+
+// A single shared validator instance. @rjsf/validator-ajv8 caches compiled schemas
+// per instance (keyed by hashForSchema); returning a fresh instance on every call
+// discarded that cache, so large/dynamic schemas were recompiled on every
+// getDefaultFormState/validate call (e.g. ~8-10x per table column reorder via the
+// view dirty-check). Sharing one instance compiles each unique schema once,
+// process-wide. Generics are erased at runtime, so one instance serves all callers.
+export const DEFAULT_VALIDATOR = customizeValidator({ ajvOptionsOverrides: AJV_OPTIONS_OVERRIDES, ajvFormatOptions: AJV_FORMAT_OPTIONS });

--- a/packages/react-ui-components/src/utils/schema-form/schema-form.ts
+++ b/packages/react-ui-components/src/utils/schema-form/schema-form.ts
@@ -6,7 +6,8 @@ import {
 	APPLY_DEFAULTS_TO_EXPERIMENTAL_DEFAULT_FORM_ALL_OFF,
 	APPLY_DEFAULTS_TO_EXPERIMENTAL_DEFAULT_FORM_ARRAY,
 	APPLY_DEFAULTS_TO_EXPERIMENTAL_DEFAULT_FORM_CONST_AS_DEFAULT,
-	APPLY_DEFAULTS_TO_EXPERIMENTAL_DEFAULT_FORM_OBJECT
+	APPLY_DEFAULTS_TO_EXPERIMENTAL_DEFAULT_FORM_OBJECT,
+	DEFAULT_VALIDATOR
 } from './config';
 import { JSONSchema7Definition } from 'json-schema';
 import { UiSchema } from '@rjsf/utils';
@@ -129,17 +130,8 @@ export const getInitialFormData = <T, S extends StrictRJSFSchema = RJSFSchema>(
 	return getDefaultFormState<T, S, SchemaFormContext>(validator, cleanedSchema, formDataProp, cleanedSchema, undefined, defaultFormStateBehavior);
 };
 
-export const getDefaultValidator = <T, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>() => {
-	// Custom validator
-	const ajvOptionsOverrides: CustomValidatorOptionsType['ajvOptionsOverrides'] = {
-		$data: true //Mandatory for use $data reference (https://ajv.js.org/guide/combining-schemas.html#data-reference)
-	};
-	const ajvFormatOptions: CustomValidatorOptionsType['ajvFormatOptions'] = {
-		keywords: true //Mandatory for use keywords to compare values like formatMinimum,... (https://ajv.js.org/packages/ajv-formats.html#keywords-to-compare-values-formatmaximum-formatminimum-and-formatexclusivemaximum-formatexclusiveminimum)
-	};
-
-	return customizeValidator<T, S, F>({ ajvOptionsOverrides, ajvFormatOptions });
-};
+export const getDefaultValidator = <T, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(): ValidatorType<T, S, F> =>
+	DEFAULT_VALIDATOR as unknown as ValidatorType<T, S, F>;
 
 export const buildDefaultFormStateBehavior = (applyDefaults: EApplyDefaults): Experimental_DefaultFormStateBehavior => {
 	const emptyObjectFields = APPLY_DEFAULTS_TO_EXPERIMENTAL_DEFAULT_FORM_OBJECT[applyDefaults];

--- a/packages/ui-components/src/components/portal/portal.tsx
+++ b/packages/ui-components/src/components/portal/portal.tsx
@@ -191,7 +191,26 @@ export class KvPortal implements IPortal, IPortalEvents {
 	}
 
 	disconnectedCallback() {
-		this.moved ? this.portal?.remove() : (this.moved = true);
+		if (this.moved) {
+			// The portal is being removed for good (the first disconnect is the element
+			// being moved into the portal, guarded by `moved`). Tear down the floating-ui
+			// autoUpdate loop and any pending delay timeout here too — otherwise a portal
+			// that is unmounted directly, e.g. a conditionally-rendered kv-tooltip that
+			// removes <kv-portal> instead of toggling `show` to false, never runs
+			// hidePortalContent() and leaks autoUpdate's scroll/resize listeners +
+			// observers, which retain the detached reference/portal nodes.
+			if (this.timeoutId) {
+				window.clearTimeout(this.timeoutId);
+				this.timeoutId = undefined;
+			}
+			if (!isNil(this.closeAutoUpdate)) {
+				this.closeAutoUpdate();
+				this.closeAutoUpdate = undefined;
+			}
+			this.portal?.remove();
+		} else {
+			this.moved = true;
+		}
 	}
 
 	render() {


### PR DESCRIPTION
## Summary

Two performance fixes in the design system, both surfaced while profiling drag/reorder jank in a data-grid (column-management side panel) in a consuming app:

1. **`kv-portal` — stop leaking the floating-ui `autoUpdate` loop on unmount** (detached-DOM / listener / memory leak)
2. **`schema-form` — reuse a single AJV validator** so RJSF's compiled-schema cache is preserved (stops repeated schema recompilation)

## 1. `kv-portal` autoUpdate leak (`fix(portal)`)

`kv-portal` starts a `@floating-ui/dom` `autoUpdate` loop in `calculatePosition()`, but its cleanup (`closeAutoUpdate()` + clearing the delay timeout) only ran from `hidePortalContent()`, which fires on a `show: true → false` transition. `disconnectedCallback()` removed the portal `<div>` but never ran that cleanup.

`kv-tooltip` renders `<kv-portal show={true}>` **conditionally** and, on hide, just unmounts it (never toggling `show` to `false`). So **every tooltip open→close orphaned an `autoUpdate` loop** — `scroll`/`resize` listeners on overflow ancestors + a `ResizeObserver` + an `IntersectionObserver`, each retaining the detached reference/portal nodes. This is app-wide (any tooltip) and severe in tables where effectively every cell/header is a tooltip.

**Fix:** in `disconnectedCallback()`, when the portal is being removed for good, also call `closeAutoUpdate()` and clear the pending `delay` timeout. (Contrast: `kv-dropdown-base` binds `show={isOpen}` and does not leak — this restores the same guarantee for the conditional-mount pattern.)

## 2. Shared AJV validator (`perf(schema-form)`)

`getDefaultValidator()` returned a fresh `customizeValidator()` on **every** call. `@rjsf/validator-ajv8` caches compiled schemas **per instance** (keyed by `hashForSchema`), so returning a new instance each time discarded that cache and recompiled the schema on every `getDefaultFormState`/validate call. For large, dynamically-built schemas this dominated CPU (in a trace, ~8–10 recompiles per grid column reorder ≈ 27% of the main thread).

**Fix:** a single module-level `DEFAULT_VALIDATOR` (in `config.ts`) shared by all callers, so each unique schema compiles once, process-wide. Generics are erased at runtime, so one instance safely serves all callers.

## Testing

- `pnpm --filter @kelvininc/ui-components eslint:check` — clean
- `pnpm --filter @kelvininc/react-ui-components eslint:check` — clean
- `tsc --noEmit` for `react-ui-components` — no new errors in `schema-form.ts` (only pre-existing, unrelated `JSONSchema7Definition` narrowing errors in `schema-form.test.ts`)
- **Leak verification (recommended in review/QA):** with a tooltip-heavy view, `getEventListeners(window)` before/after repeated hover/open→close should no longer show a growing pile of `scroll`/`resize` entries; a heap snapshot filtered by "Detached" should no longer accumulate `kv-portal`-retained nodes across cycles.

_Note: local runs show a pnpm engine warning (repo wants Node >=22, ran on v20.20.0); lint/typecheck were unaffected._
