### PR TITLE
Add GitHub Release creation and pre-release tag cleanup

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -89,7 +89,7 @@ graph TD
     E --> F[build:packages]
     F --> G[lerna publish → NPM + push vX.Y.Z tag]
     G --> H[Create GitHub Release for vX.Y.Z]
-    H --> I[Remove pre-release tags: *-alpha.* / *-beta.*]
+    H --> I["Remove pre-release tags &le; vX.Y.Z (*-alpha.* / *-beta.*)"]
     I --> J[Build master storybook → ./gp]
     J --> K[Build dev storybook → ./gp/alpha]
     K --> L[Deploy combined output to gh-pages]
@@ -173,7 +173,11 @@ Jobs:
 After `lerna publish` pushes the production `vX.Y.Z` tag, the workflow:
 
 1. **Creates a GitHub Release** for `vX.Y.Z` with `gh release create` — auto-generated notes (`--generate-notes`), marked as `--latest`, and tag-verified (`--verify-tag`). The step is idempotent: if a release for the tag already exists it is skipped rather than failing the run.
-2. **Removes all pre-release tags** matching `*-alpha.*` or `*-beta.*` from both the remote and the local checkout. Once a production version ships, the alpha/beta tags that led up to it are no longer needed, so the tag list stays limited to shipped production releases. The cleanup deletes each tag individually so an already-removed tag does not abort the run, and logs when there is nothing to remove.
+2. **Removes the pre-release tags** matching `*-alpha.*` or `*-beta.*` **whose base version (`X.Y.Z`) is `<=` the version just released**, from both the remote and the local checkout. Once a production version ships, the alpha/beta tags that led up to it are no longer needed, so the tag list stays limited to shipped production releases. The cleanup deletes each tag individually so an already-removed tag does not abort the run, and logs when there is nothing to remove.
+
+   **The `<=` bound is deliberate — it avoids a race.** A concurrent `alpha`/`beta` run can push a fresh pre-release tag while this workflow is in flight, and the cleanup's `git fetch --tags --force` would pull it in. If that tag targets a *future* version (e.g. `v1.4.0-alpha.0` pushed while master releases `v1.3.0`), an unbounded delete would wrongly remove it. Bounding the delete to base versions `<= X.Y.Z` leaves any future-version pre-release untouched, whether it already existed or was pushed mid-release.
+
+   > ⚠️ Base versions are compared with `sort -V`, which is **not** semver-aware for pre-release suffixes (it orders `1.3.0-alpha.0` *after* `1.3.0`). The workflow therefore strips the `-alpha.N` / `-beta.N` suffix and compares only the plain `X.Y.Z` base versions, which `sort -V` orders correctly (including `1.10.0 > 1.3.0`).
 
 **Why this approach?**
 - **Atomic release**: Versioning, building, publishing, GitHub release creation, tag cleanup, and docs deployment live in one job; a failure in any step halts the release.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -175,7 +175,7 @@ After `lerna publish` pushes the production `vX.Y.Z` tag, the workflow:
 1. **Creates a GitHub Release** for `vX.Y.Z` with `gh release create` — auto-generated notes (`--generate-notes`), marked as `--latest`, and tag-verified (`--verify-tag`). The step is idempotent: if a release for the tag already exists it is skipped rather than failing the run.
 2. **Removes the pre-release tags** matching `*-alpha.*` or `*-beta.*` **whose base version (`X.Y.Z`) is `<=` the version just released**, from both the remote and the local checkout. Once a production version ships, the alpha/beta tags that led up to it are no longer needed, so the tag list stays limited to shipped production releases. The cleanup deletes each tag individually so an already-removed tag does not abort the run, and logs when there is nothing to remove.
 
-   **The `<=` bound is deliberate — it avoids a race.** A concurrent `alpha`/`beta` run can push a fresh pre-release tag while this workflow is in flight, and the cleanup's `git fetch --tags --force` would pull it in. If that tag targets a *future* version (e.g. `v1.4.0-alpha.0` pushed while master releases `v1.3.0`), an unbounded delete would wrongly remove it. Bounding the delete to base versions `<= X.Y.Z` leaves any future-version pre-release untouched, whether it already existed or was pushed mid-release.
+   **The `<=` bound is deliberate.** It keeps the cleanup correct even when `dev`/`alpha` is ahead of `master`: pre-release tags for a *future* version (e.g. `v1.4.0-alpha.*` still in active use while master ships `v1.3.1`) have a higher base version and are left untouched. It is also a second line of defense against a mid-release tag push — the [concurrency serialization](#-concurrency--release-serialization) below is the primary guard for that.
 
    > ⚠️ Base versions are compared with `sort -V`, which is **not** semver-aware for pre-release suffixes (it orders `1.3.0-alpha.0` *after* `1.3.0`). The workflow therefore strips the `-alpha.N` / `-beta.N` suffix and compares only the plain `X.Y.Z` base versions, which `sort -V` orders correctly (including `1.10.0 > 1.3.0`).
 
@@ -205,6 +205,22 @@ Jobs:
 - **Resync guard**: When `lerna.json` drifts from the latest tag, the workflow re-aligns it before versioning so `lerna` computes the next prerelease from a clean baseline.
 - **Canary publish**: `lerna publish from-git --canary` publishes exactly the tagged versions to Nexus, keeping pre-releases clearly separated from production NPM.
 - **Summary with channel context**: The `summary` job reports the resolved pre-release channel (`alpha` / `beta`) and the exact version published to Nexus.
+
+## 🔒 Concurrency / Release Serialization
+
+`publish-master.yml` and `publish-prerelease.yml` share a single top-level concurrency group so the release workflows are **never in flight at the same time**:
+
+```yaml
+concurrency:
+    group: release-pipeline
+    cancel-in-progress: false
+```
+
+- **Same group name** across both workflows means GitHub treats their runs as one serialized queue: while a `master` release runs, an `alpha`/`beta` push is held as *pending* and only starts once the release finishes (and vice versa).
+- **`cancel-in-progress: false`** ensures a running release is never cancelled by a newly queued run — releases always complete.
+- **Why it matters**: the master release pushes the `vX.Y.Z` tag and then prunes pre-release tags. Serializing guarantees no concurrent `alpha`/`beta` run pushes a tag during that window, so the cleanup can't race a fresh tag. (The pre-release cleanup is *also* version-bounded as a second line of defense — see [Publish Master Workflow](#3-publish-master-workflow-publish-masteryml).)
+
+> ℹ️ **Queue depth**: A concurrency group keeps at most one running and one pending run. If several release runs pile up behind an in-flight one, only the newest pending run is retained; older pending runs are cancelled. In practice releases don't stack this quickly, but be aware a rapid burst of `alpha`/`beta` pushes during a long master release may collapse to the latest one. `publish-dev.yml` (storybook only) is intentionally left out of the group so docs previews are never blocked by a release.
 
 ## 🧾 Summary Jobs
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -87,12 +87,14 @@ graph TD
     C --> D[test]
     D --> E[lerna version → outputs new-version]
     E --> F[build:packages]
-    F --> G[lerna publish → NPM]
-    G --> H[Build master storybook → ./gp]
-    H --> I[Build dev storybook → ./gp/alpha]
-    I --> J[Deploy combined output to gh-pages]
-    J --> K[summary]
-    K --> L[End]
+    F --> G[lerna publish → NPM + push vX.Y.Z tag]
+    G --> H[Create GitHub Release for vX.Y.Z]
+    H --> I[Remove pre-release tags: *-alpha.* / *-beta.*]
+    I --> J[Build master storybook → ./gp]
+    J --> K[Build dev storybook → ./gp/alpha]
+    K --> L[Deploy combined output to gh-pages]
+    L --> M[summary]
+    M --> N[End]
 ```
 
 #### Publish Pre-Release Workflow
@@ -156,18 +158,28 @@ Jobs:
 
 ```yaml
 Jobs:
-├── publish    # Lint + Test + lerna version + build + lerna publish + storybook deploy
+├── publish    # Lint + Test + lerna version + build + lerna publish
+│              # + GitHub Release + pre-release tag cleanup + storybook deploy
 │              # Exposes outputs: new-version, release-tag (read from lerna.json after version)
 └── summary    # Writes Release Summary (including version/tag) to $GITHUB_STEP_SUMMARY (if: always())
 ```
 
 **Permissions**:
-- `contents: write` — required to create tags and push version commits.
+- `contents: write` — required to create tags, push version commits, **create the GitHub Release**, and **delete pre-release tags**.
 - `id-token: write` — required for **NPM provenance** via OIDC (`NPM_CONFIG_PROVENANCE: true`).
 
+**Release & pre-release tag cleanup**:
+
+After `lerna publish` pushes the production `vX.Y.Z` tag, the workflow:
+
+1. **Creates a GitHub Release** for `vX.Y.Z` with `gh release create` — auto-generated notes (`--generate-notes`), marked as `--latest`, and tag-verified (`--verify-tag`). The step is idempotent: if a release for the tag already exists it is skipped rather than failing the run.
+2. **Removes all pre-release tags** matching `*-alpha.*` or `*-beta.*` from both the remote and the local checkout. Once a production version ships, the alpha/beta tags that led up to it are no longer needed, so the tag list stays limited to shipped production releases. The cleanup deletes each tag individually so an already-removed tag does not abort the run, and logs when there is nothing to remove.
+
 **Why this approach?**
-- **Atomic release**: Versioning, building, publishing, and docs deployment live in one job; a failure in any step halts the release.
+- **Atomic release**: Versioning, building, publishing, GitHub release creation, tag cleanup, and docs deployment live in one job; a failure in any step halts the release.
 - **Provenance**: Production packages are published with NPM provenance for supply-chain traceability.
+- **Discoverable releases**: Every production version gets a corresponding GitHub Release with generated notes, so the Releases page mirrors what is on NPM.
+- **Clean tag history**: Pre-release (`*-alpha.*` / `*-beta.*`) tags are pruned on each production release, keeping the tag list focused on shipped versions.
 - **Consistent docs**: Storybook for `master` and `dev` is refreshed together so GitHub Pages always reflects the latest released and in-flight docs.
 - **Summary with version context**: The `summary` job consumes `needs.publish.outputs.new-version` / `release-tag` so the report shows exactly what was (or would have been) released.
 

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -65,6 +65,44 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_CONFIG_PROVENANCE: true
 
+            - name: Create GitHub Release
+              run: |
+                  # The `v$NEW_VERSION` tag was created and pushed by `lerna publish`.
+                  # Make sure it is available locally before creating the release.
+                  git fetch origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG" --force || true
+                  if gh release view "$RELEASE_TAG" > /dev/null 2>&1; then
+                    echo "Release $RELEASE_TAG already exists — skipping creation."
+                  else
+                    gh release create "$RELEASE_TAG" \
+                      --title "$RELEASE_TAG" \
+                      --generate-notes \
+                      --latest \
+                      --verify-tag
+                  fi
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  RELEASE_TAG: ${{ steps.version.outputs.release-tag }}
+
+            - name: Remove Pre-Release Tags
+              run: |
+                  # Refresh the local tag list from the remote so we operate on the
+                  # complete set of tags (and prune any that were already deleted).
+                  git fetch origin --tags --prune --prune-tags --force
+                  PRERELEASE_TAGS=$(git tag -l '*-alpha.*' '*-beta.*')
+                  if [ -z "$PRERELEASE_TAGS" ]; then
+                    echo "No pre-release tags found to remove."
+                  else
+                    echo "Removing the following pre-release tags:"
+                    echo "$PRERELEASE_TAGS"
+                    # Delete the tags on the remote (one at a time so a single
+                    # already-deleted tag does not abort the whole cleanup).
+                    echo "$PRERELEASE_TAGS" | xargs -r -n 1 -I {} git push origin ":refs/tags/{}"
+                    # Delete the tags locally.
+                    echo "$PRERELEASE_TAGS" | xargs -r git tag -d
+                  fi
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Publish Alpha & Master Storybook to GitHub Pages
               run: |
                   pnpm storybook:deploy -- -- -- --out='./gp' --dry-run
@@ -98,10 +136,12 @@ jobs:
 
                   | Component | Status |
                   |-----------|---------|
-                  | Publish (Lint + Test + Version + Build + NPM + Storybook) | ${{ needs.publish.result == 'success' && '✅ Success' || needs.publish.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }} |
+                  | Publish (Lint + Test + Version + Build + NPM + GitHub Release + Tag Cleanup + Storybook) | ${{ needs.publish.result == 'success' && '✅ Success' || needs.publish.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }} |
 
                   ## Release Summary
                   - **Package Release**: ${{ needs.publish.result == 'success' && '📦 Published to NPM (with provenance)' || needs.publish.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}
+                  - **GitHub Release**: `${{ needs.publish.outputs.release-tag || 'N/A' }}` ${{ needs.publish.result == 'success' && '🏷️ Created' || needs.publish.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}
+                  - **Pre-Release Tags**: ${{ needs.publish.result == 'success' && '🧹 `*-alpha.*` / `*-beta.*` removed' || needs.publish.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}
                   - **Master Storybook**: ${{ needs.publish.result == 'success' && '💅 Deployed to /' || needs.publish.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}
                   - **Alpha (Dev) Storybook**: ${{ needs.publish.result == 'success' && '💅 Deployed to /alpha' || needs.publish.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}
 

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -4,6 +4,14 @@ on:
         branches:
             - master
 
+# Serialize all release workflows (master + alpha/beta pre-releases) so they
+# never run at the same time. A pre-release push while a master release is in
+# flight is queued (cancel-in-progress: false) rather than run in parallel,
+# which prevents a concurrent alpha/beta run from pushing a tag mid-release.
+concurrency:
+    group: release-pipeline
+    cancel-in-progress: false
+
 permissions:
     contents: write # for checkout and tag
     id-token: write # Required for OIDC

--- a/.github/workflows/publish-master.yml
+++ b/.github/workflows/publish-master.yml
@@ -88,20 +88,51 @@ jobs:
                   # Refresh the local tag list from the remote so we operate on the
                   # complete set of tags (and prune any that were already deleted).
                   git fetch origin --tags --prune --prune-tags --force
-                  PRERELEASE_TAGS=$(git tag -l '*-alpha.*' '*-beta.*')
-                  if [ -z "$PRERELEASE_TAGS" ]; then
-                    echo "No pre-release tags found to remove."
+
+                  # Only remove pre-release tags whose base version (the X.Y.Z before
+                  # the `-alpha`/`-beta` suffix) is <= the version we just released.
+                  #
+                  # This bounds the cleanup to the pre-releases that actually led up to
+                  # this release. Pre-release tags for a *future* version have a higher
+                  # base version and are left untouched — including any pushed by a
+                  # concurrent alpha/beta run while this workflow is in flight (e.g. a
+                  # v1.4.0-alpha.0 pushed while master is releasing v1.3.0), which the
+                  # earlier `--force` fetch would otherwise have pulled in and deleted.
+                  #
+                  # NOTE: we compare *base* versions (plain X.Y.Z) with `sort -V`.
+                  # `sort -V` is not semver-aware for pre-release suffixes — it orders
+                  # "1.3.0-alpha.0" *after* "1.3.0" — so it must never see the suffix.
+                  RELEASED_VERSION="${NEW_VERSION#v}"
+                  if [ -z "$RELEASED_VERSION" ]; then
+                    echo "No released version resolved — skipping pre-release tag cleanup."
+                    exit 0
+                  fi
+
+                  REMOVED=0
+                  for tag in $(git tag -l '*-alpha.*' '*-beta.*'); do
+                    base="${tag#v}"     # strip a leading "v"
+                    base="${base%%-*}"  # strip the -alpha.N / -beta.N suffix -> X.Y.Z
+                    # Keep the tag if its base version is newer than the released one.
+                    highest=$(printf '%s\n%s\n' "$base" "$RELEASED_VERSION" | sort -V | tail -n 1)
+                    if [ "$highest" != "$RELEASED_VERSION" ]; then
+                      echo "Keeping $tag (base $base is newer than released $RELEASED_VERSION)"
+                      continue
+                    fi
+                    echo "Removing $tag"
+                    # `|| true` so a single already-deleted tag never aborts the cleanup.
+                    git push origin ":refs/tags/$tag" || true
+                    git tag -d "$tag" || true
+                    REMOVED=$((REMOVED + 1))
+                  done
+
+                  if [ "$REMOVED" -eq 0 ]; then
+                    echo "No pre-release tags eligible for removal."
                   else
-                    echo "Removing the following pre-release tags:"
-                    echo "$PRERELEASE_TAGS"
-                    # Delete the tags on the remote (one at a time so a single
-                    # already-deleted tag does not abort the whole cleanup).
-                    echo "$PRERELEASE_TAGS" | xargs -r -n 1 -I {} git push origin ":refs/tags/{}"
-                    # Delete the tags locally.
-                    echo "$PRERELEASE_TAGS" | xargs -r git tag -d
+                    echo "Removed $REMOVED pre-release tag(s) up to v$RELEASED_VERSION."
                   fi
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  NEW_VERSION: ${{ steps.version.outputs.new-version }}
 
             - name: Publish Alpha & Master Storybook to GitHub Pages
               run: |
@@ -141,7 +172,7 @@ jobs:
                   ## Release Summary
                   - **Package Release**: ${{ needs.publish.result == 'success' && '📦 Published to NPM (with provenance)' || needs.publish.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}
                   - **GitHub Release**: `${{ needs.publish.outputs.release-tag || 'N/A' }}` ${{ needs.publish.result == 'success' && '🏷️ Created' || needs.publish.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}
-                  - **Pre-Release Tags**: ${{ needs.publish.result == 'success' && '🧹 `*-alpha.*` / `*-beta.*` removed' || needs.publish.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}
+                  - **Pre-Release Tags**: ${{ needs.publish.result == 'success' && '🧹 `*-alpha.*` / `*-beta.*` up to the released version removed' || needs.publish.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}
                   - **Master Storybook**: ${{ needs.publish.result == 'success' && '💅 Deployed to /' || needs.publish.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}
                   - **Alpha (Dev) Storybook**: ${{ needs.publish.result == 'success' && '💅 Deployed to /alpha' || needs.publish.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}
 

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -9,6 +9,14 @@ on:
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
 
+# Serialize all release workflows (master + alpha/beta pre-releases) so they
+# never run at the same time. Shares the group with publish-master so a
+# pre-release queues behind an in-flight master release instead of pushing a
+# tag while master's pre-release tag cleanup is running.
+concurrency:
+    group: release-pipeline
+    cancel-in-progress: false
+
 permissions:
     contents: write # for checkout and tag
 


### PR DESCRIPTION
## Summary

Enhance the publish workflow to automatically create GitHub Releases for production versions and clean up pre-release tags, improving release discoverability and tag hygiene.

## Key Changes

- **Create GitHub Release**: Added a new workflow step that uses `gh release create` to automatically generate a GitHub Release for each production version (`vX.Y.Z`). The release includes auto-generated notes, is marked as latest, and verifies the tag. The step is idempotent—if a release already exists, it skips creation rather than failing.

- **Remove Pre-Release Tags**: Added a cleanup step that removes all pre-release tags matching `*-alpha.*` or `*-beta.*` patterns from both remote and local repositories after a production release. Tags are deleted individually to prevent a single already-deleted tag from aborting the entire cleanup. The step logs when no pre-release tags are found.

- **Updated Workflow Documentation**: 
  - Updated the publish job flowchart to show the new GitHub Release and tag cleanup steps in sequence
  - Updated the job description to reflect the additional responsibilities
  - Added detailed explanation of the release and cleanup process, including rationale
  - Updated permissions documentation to note `contents: write` is required for release creation and tag deletion
  - Updated the summary report to include GitHub Release and pre-release tag cleanup status

## Implementation Details

- Both new steps use environment variables (`RELEASE_TAG`, `GH_TOKEN`) to access the release tag output from the version step and GitHub API credentials
- The GitHub Release creation includes error handling via `|| true` for the git fetch to gracefully handle cases where the tag may already be available
- Pre-release tag cleanup uses `git fetch --prune-tags` to ensure the local tag list is current before filtering
- The workflow summary now reports on all three release components: NPM package publication, GitHub Release creation, and pre-release tag cleanup

https://claude.ai/code/session_01BHj1u6HAw63zX1BtR3LjLV