### PR TITLE
fix(schema-form): stop a non-array select value from crashing the form

### DIFF
--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/utils.test.ts
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/utils.test.ts
@@ -1,0 +1,161 @@
+import { JSONSchema7 } from 'json-schema';
+import { describe, expect, it } from 'vitest';
+import { buildDropdownOptions, buildSelectedOptions, getSelectedOptions, processValue } from './utils';
+
+describe('buildSelectedOptions', () => {
+	describe('when given an array of selected values', () => {
+		it('should map every value to true', () => {
+			expect(buildSelectedOptions(['a', 'b'])).toEqual({ a: true, b: true });
+		});
+
+		it('should return an empty map for an empty array', () => {
+			expect(buildSelectedOptions([])).toEqual({});
+		});
+
+		it('should collapse duplicates onto one key', () => {
+			expect(buildSelectedOptions(['a', 'a'])).toEqual({ a: true });
+		});
+	});
+
+	// A multiple select receives whatever the host form holds for the field, so the
+	// value is not guaranteed to match a `type: 'array'` schema. Every one of these
+	// used to throw `TypeError: … .reduce is not a function` and take the form down.
+	describe('when the value is not an array', () => {
+		it.each([
+			['undefined', undefined],
+			['null', null],
+			['a string', 'a'],
+			['a number', 4],
+			['a boolean', true],
+			['an object', { a: true }]
+		])('should select nothing for %s', (_, value) => {
+			expect(buildSelectedOptions(value as unknown as string[])).toEqual({});
+		});
+	});
+
+	it('should round-trip through getSelectedOptions', () => {
+		expect(getSelectedOptions(buildSelectedOptions(['a', 'b']))).toEqual(['a', 'b']);
+	});
+});
+
+describe('processValue', () => {
+	const numberArraySchema: JSONSchema7 = { type: 'array', items: { type: 'number' } };
+
+	describe('when the value is empty', () => {
+		it.each([
+			['an empty string', ''],
+			['undefined', undefined],
+			['null', null]
+		])('should return undefined for %s', (_, value) => {
+			expect(processValue({ type: 'string' }, value)).toBeUndefined();
+		});
+	});
+
+	describe('when the schema is an array of numbers', () => {
+		it('should coerce every item to a number', () => {
+			expect(processValue(numberArraySchema, ['1', '2'])).toEqual([1, 2]);
+		});
+
+		it('should coerce an integer item type too', () => {
+			expect(processValue({ type: 'array', items: { type: 'integer' } }, ['3'])).toEqual([3]);
+		});
+
+		// Used to throw `TypeError: … .map is not a function`.
+		it.each([
+			['a string', 'a'],
+			['a number', 4],
+			['an object', { a: 1 }]
+		])('should return %s untouched rather than coercing it', (_, value) => {
+			expect(processValue(numberArraySchema, value)).toBe(value);
+		});
+	});
+
+	describe('when the schema is an array of strings', () => {
+		it('should return the value untouched', () => {
+			const value = ['a', 'b'];
+
+			expect(processValue({ type: 'array', items: { type: 'string' } }, value)).toBe(value);
+		});
+	});
+
+	describe('when the schema is a boolean', () => {
+		it.each([
+			['true', true],
+			['the string "true"', 'true']
+		])('should return true for %s', (_, value) => {
+			expect(processValue({ type: 'boolean' }, value)).toBe(true);
+		});
+
+		it('should return false for the string "false"', () => {
+			expect(processValue({ type: 'boolean' }, 'false')).toBe(false);
+		});
+	});
+
+	describe('when the schema is numeric', () => {
+		it('should coerce a numeric string', () => {
+			expect(processValue({ type: 'number' }, '1.5')).toBe(1.5);
+		});
+
+		it('should coerce for an integer schema', () => {
+			expect(processValue({ type: 'integer' }, '2')).toBe(2);
+		});
+	});
+
+	describe('when the schema has no type but an enum', () => {
+		it('should infer a number from an all-number enum', () => {
+			expect(processValue({ enum: [1, 2] }, '2')).toBe(2);
+		});
+
+		it('should infer a boolean from an all-boolean enum', () => {
+			expect(processValue({ enum: [true, false] }, 'true')).toBe(true);
+		});
+
+		it('should return the value untouched for a mixed enum', () => {
+			expect(processValue({ enum: [1, 'a'] }, 'a')).toBe('a');
+		});
+	});
+});
+
+describe('buildDropdownOptions', () => {
+	const schema: JSONSchema7 = { type: 'string' };
+
+	it('should key each option by its value', () => {
+		const options = [
+			{ label: 'A', value: 'a' },
+			{ label: 'B', value: 'b' }
+		];
+
+		expect(buildDropdownOptions({ schema, options })).toEqual({
+			a: { value: 'a', label: 'A', description: undefined, disabled: false },
+			b: { value: 'b', label: 'B', description: undefined, disabled: false }
+		});
+	});
+
+	it('should mark only the options listed as disabled', () => {
+		const options = [
+			{ label: 'A', value: 'a' },
+			{ label: 'B', value: 'b' }
+		];
+
+		const result = buildDropdownOptions({ schema, options, disabledOptions: ['b'] });
+
+		expect(result.a.disabled).toBe(false);
+		expect(result.b.disabled).toBe(true);
+	});
+
+	it('should prefer multiSubOptions when they are not empty', () => {
+		const multiSubOptions = { a: { value: 'a', label: 'A' } };
+
+		expect(buildDropdownOptions({ schema, options: [{ label: 'B', value: 'b' }], multiSubOptions })).toBe(multiSubOptions);
+	});
+
+	describe('when options is not an array', () => {
+		it.each([
+			['undefined', undefined],
+			['null', null],
+			['an object', { a: 1 }]
+		])('should return no options for %s', (_, options) => {
+			expect(buildDropdownOptions({ schema, options })).toEqual({});
+		});
+	});
+});

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/utils.ts
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/utils.ts
@@ -8,6 +8,11 @@ const numericTypes = ['number', 'integer'];
 /**
  * This is a silly limitation in the DOM where option change event values are
  * always retrieved as strings.
+ *
+ * Each coercion is guarded by the shape it needs rather than trusting `value` to
+ * match `schema`: the value is host data, so an array-typed field can hold a scalar
+ * left over from a schema that typed it differently. A value the branch cannot
+ * coerce falls through and is returned as-is instead of throwing.
  */
 export const processValue = (schema: JSONSchema7, value: any) => {
 	// "enum" is a reserved word, so only "type" and "items" can be destructured
@@ -15,7 +20,7 @@ export const processValue = (schema: JSONSchema7, value: any) => {
 	const itemsType = get(items, 'type');
 	if (value === '' || isNil(value)) {
 		return undefined;
-	} else if (type === 'array' && items && isString(itemsType) && numericTypes.includes(itemsType)) {
+	} else if (type === 'array' && Array.isArray(value) && items && isString(itemsType) && numericTypes.includes(itemsType)) {
 		return value.map(asNumber);
 	} else if (type === 'boolean') {
 		return value === true || value === 'true';
@@ -38,12 +43,25 @@ export const processValue = (schema: JSONSchema7, value: any) => {
 
 export const getSelectedOptions = (selectedOptionsMap: Record<string, boolean>): string[] => Object.keys(selectedOptionsMap);
 
-export const buildSelectedOptions = (selectedOptions: string[]): Record<string, boolean> =>
-	selectedOptions.reduce<Record<string, boolean>>((accumulator, selectOptionKey) => {
-		accumulator[selectOptionKey] = true;
+/**
+ * Maps the selected values onto the map `KvMultiSelectDropdown` expects.
+ *
+ * Anything that is not an array selects nothing, rather than throwing. The value
+ * reaching a multiple select is host data — it can be a scalar left over from a
+ * schema that typed the field differently, or restored from a URL — and
+ * `processValue` maps `''` and nil to `undefined`. Reducing over any of those threw
+ * `TypeError: … .reduce is not a function` and took the whole form down with it.
+ * This mirrors what `buildDropdownOptions` below already does for a non-array
+ * `options`.
+ */
+export const buildSelectedOptions = (selectedOptions?: string[] | null): Record<string, boolean> =>
+	Array.isArray(selectedOptions)
+		? selectedOptions.reduce<Record<string, boolean>>((accumulator, selectOptionKey) => {
+				accumulator[selectOptionKey] = true;
 
-		return accumulator;
-	}, {});
+				return accumulator;
+		  }, {})
+		: {};
 
 export const buildDropdownOptions = <S extends StrictRJSFSchema = RJSFSchema>({
 	schema,


### PR DESCRIPTION
## Problem

Two lines in the `SelectWidget` assume the form value matches its schema, and throw when it doesn't:

| Site | Throws |
| --- | --- |
| `SelectWidget/utils.ts` — `buildSelectedOptions(selectedOptions)` | `TypeError: … .reduce is not a function` |
| `SelectWidget/utils.ts` — `processValue`'s array-of-numbers branch, `value.map(asNumber)` | `TypeError: … .map is not a function` |

`buildSelectedOptions` is called on every render of a `multiple` select — `selectedOptions={buildSelectedOptions(processedValue)}` — so it receives the **form value**, which is host data. It is not guaranteed to be an array:

- a value persisted against a schema that typed the field differently (an option list that used to be a single select), or restored from a URL, arrives as a **scalar**;
- `processValue` maps `''` and nil to `undefined`, so a nil value reaches it as `undefined` too.

Reducing over either takes the whole form into its error boundary — the field renders nothing, and so does everything around it.

This is showing up in production in `kelvin-core-ui` as **KELVIN-CORE-UI-158** (31 events) and **KELVIN-CORE-UI-16T** (8 events), on the assets pages' filter dropdowns.

## Change

Both call sites now check the shape they need:

- `buildSelectedOptions` selects nothing for a non-array, and its signature widens to `(selectedOptions?: string[] | null)` to say so.
- `processValue`'s numeric-array branch only applies when the value really is an array; anything else falls through and is returned as-is rather than coerced.

Neither invents data. `buildDropdownOptions`, a few lines below in the same file, has always done exactly this for a non-array `options` (`Array.isArray(options) ? … : {}`) — guarding the options but not the value was an oversight rather than a decision, and `SelectWidget` already computes the right fallback (`emptyValue = multiple ? [] : undefined`) but only uses it for `displayValue`.

## Tests

Adds `SelectWidget/utils.test.ts` — the widget had none. It covers both crashes plus the surrounding coercions (empty values, boolean/numeric schemas, enum type inference, and `buildDropdownOptions`' own non-array handling): 33 tests.

Checked out against the previous implementation, **9 of them fail** with exactly the two errors above, so they pin the regression rather than just describing the new behaviour.

## Verification

- `vitest run` in `packages/react-ui-components` — 60 passed (3 files)
- `eslint src --quiet` — clean; `prettier --check` — clean
- `tsc --noEmit` — this package has 8 pre-existing errors on `dev`; the set is **byte-identical** before and after this change (diffed against a stashed baseline), so it introduces none

## Downstream

This makes the widget resilient; it is deliberately **not** the whole fix. Coercing to "nothing selected" would render a user's saved filter as empty while the datasource still queried with the scalar — a wrong-data bug wearing a working UI. Getting the value *correct* is the host's job, and that half is a separate `kv-ui-apps` change (KFE-3223) which normalizes filter values against the schema on every inbound path.

Worth landing both: this one also protects every other `KvSchemaForm` consumer that builds a `type: 'array'` field, none of which the host-side change audits.