### PR TITLE
fix(schema-form): keep select dropdowns visible with a partial dropdownConfig

### DIFF
--- a/packages/react-ui-components/src/components/SchemaForm/Templates/FieldTemplate/FieldTemplate.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/FieldTemplate/FieldTemplate.tsx
@@ -1,10 +1,10 @@
 import { EValidationState } from '@kelvininc/ui-components';
 import { FieldTemplateProps, FormContextType, RJSFSchema, StrictRJSFSchema, getTemplate, getUiOptions } from '@rjsf/utils';
-import { get, isEmpty, merge } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import React, { useMemo } from 'react';
 import { KvFormHelpText } from '../../../../stencil-generated';
 import styles from './FieldTemplate.module.scss';
-import buildDefaultHelperText from './utils';
+import buildDefaultHelperText, { buildHelperOptions } from './utils';
 import { EDescriptionPosition } from '../../types';
 import classNames from 'classnames';
 import { useFormState } from '../../contexts';
@@ -31,7 +31,7 @@ const FieldTemplate = <T, S extends StrictRJSFSchema = RJSFSchema, F extends For
 	const uiOptions = getUiOptions<T, S, F>(uiSchema);
 	const TitleFieldTemplate = getTemplate<'TitleFieldTemplate', T, S, F>('TitleFieldTemplate', registry, uiOptions);
 	const WrapIfAdditionalTemplate = getTemplate<'WrapIfAdditionalTemplate', T, S, F>('WrapIfAdditionalTemplate', registry, uiOptions);
-	const defaultHelperOptions = useMemo(() => merge(formContext, uiOptions), [formContext, uiOptions]);
+	const defaultHelperOptions = useMemo(() => buildHelperOptions(formContext, uiOptions), [formContext, uiOptions]);
 	const displayedHelper = useMemo(() => buildDefaultHelperText(defaultHelperOptions, schema.default), [defaultHelperOptions, schema.default]);
 	const descriptionPosition = useMemo(
 		() => (uiOptions.descriptionPosition as EDescriptionPosition) ?? (schema.type === 'object' ? EDescriptionPosition.Top : EDescriptionPosition.Bottom),

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/FieldTemplate/utils.test.ts
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/FieldTemplate/utils.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import buildDefaultHelperText, { buildHelperOptions } from './utils';
+
+describe('buildHelperOptions', () => {
+	// `formContext` is a single object RJSF hands to every field and widget in the
+	// form. `merge(formContext, uiOptions)` (no `{}` target) wrote each field's
+	// `ui:*` options straight into it, so one field carrying `ui:dropdownConfig`
+	// leaked that config into every other widget and silently broke them.
+	describe('when merging a field ui options into the shared form context', () => {
+		it('should not mutate the form context', () => {
+			const formContext = { componentSize: 'large' };
+			const snapshot = structuredClone(formContext);
+
+			buildHelperOptions(formContext, { dropdownConfig: { minWidth: '240px' } });
+
+			expect(formContext).toEqual(snapshot);
+		});
+
+		it('should leave the form context object identity untouched', () => {
+			const formContext = { componentSize: 'large' };
+
+			const result = buildHelperOptions(formContext, { dropdownConfig: { minWidth: '240px' } });
+
+			expect(result).not.toBe(formContext);
+		});
+
+		it('should not add keys to the form context', () => {
+			const formContext = { componentSize: 'large' };
+
+			buildHelperOptions(formContext, { dropdownConfig: { minWidth: '240px' }, showDefaultValueHelper: true });
+
+			expect(Object.keys(formContext)).toEqual(['componentSize']);
+		});
+
+		it('should not mutate nested form context values', () => {
+			const formContext = { dropdownConfig: { zIndex: 9004, maxHeight: '400px' } };
+
+			buildHelperOptions(formContext, { dropdownConfig: { minWidth: '240px' } });
+
+			expect(formContext.dropdownConfig).toEqual({ zIndex: 9004, maxHeight: '400px' });
+		});
+
+		it('should keep every field isolated from the previously rendered field', () => {
+			const formContext = { componentSize: 'large' };
+
+			buildHelperOptions(formContext, { dropdownConfig: { minWidth: '240px' } });
+			const nextField = buildHelperOptions(formContext, { showDefaultValueHelper: true });
+
+			expect(nextField).not.toHaveProperty('dropdownConfig');
+		});
+	});
+
+	describe('when resolving the returned options', () => {
+		it('should merge the form context with the ui options', () => {
+			expect(buildHelperOptions({ componentSize: 'large' }, { showDefaultValueHelper: true })).toEqual({
+				componentSize: 'large',
+				showDefaultValueHelper: true
+			});
+		});
+
+		it('should let the field ui options win over the form context', () => {
+			expect(buildHelperOptions({ showDefaultValueHelper: false }, { showDefaultValueHelper: true })).toEqual({ showDefaultValueHelper: true });
+		});
+
+		it('should still drive the default helper text', () => {
+			const options = buildHelperOptions({ showDefaultValueHelper: true }, {});
+
+			expect(buildDefaultHelperText(options, 'a')).toBe('Default value is: a');
+		});
+	});
+});

--- a/packages/react-ui-components/src/components/SchemaForm/Templates/FieldTemplate/utils.ts
+++ b/packages/react-ui-components/src/components/SchemaForm/Templates/FieldTemplate/utils.ts
@@ -1,6 +1,6 @@
 import { JSONSchema7Type } from 'json-schema';
 import { FormContextType, RJSFSchema, StrictRJSFSchema, UIOptionsType } from '@rjsf/utils';
-import { get, isNil } from 'lodash';
+import { get, isNil, merge } from 'lodash';
 import { DEFAULT_VALUE_HELPER_PREFIX } from '../../config';
 
 export default function buildDefaultHelperText<T, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
@@ -16,3 +16,18 @@ export default function buildDefaultHelperText<T, S extends StrictRJSFSchema = R
 
 	return undefined;
 }
+
+/**
+ * Layers a field's own `ui:*` options over the form-wide context to produce the
+ * options a field resolves its helper text from.
+ *
+ * The `{}` target is load-bearing. This was `merge(formContext, uiOptions)`, which
+ * wrote straight into `formContext` — the single object RJSF shares with every
+ * field and widget in the form. One field carrying `ui:dropdownConfig` therefore
+ * leaked that config into every other widget, and whichever field happened to
+ * render first decided what the rest of the form saw.
+ */
+export const buildHelperOptions = <T, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+	formContext: F,
+	uiOptions: UIOptionsType<T, S, F>
+): UIOptionsType<T, S, F> => merge({}, formContext, uiOptions);

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/SelectWidget.tsx
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/SelectWidget.tsx
@@ -4,8 +4,8 @@ import { isEmpty } from 'lodash';
 import React, { useCallback, useMemo, useState } from 'react';
 import { KvMultiSelectDropdown, KvSingleSelectDropdown } from '../../../../stencil-generated';
 import styles from './SelectWidget.module.scss';
-import { buildDropdownOptions, buildSelectedOptions, getSelectedOptions, processValue, searchDropdownOptions } from './utils';
-import { DEFAULT_DROPDOWN_CONFIG, DEFAULT_MINIMUM_SEARCHABLE_OPTIONS } from './config';
+import { buildDropdownOptions, buildSelectedOptions, getSelectedOptions, processValue, resolveDropdownConfig, searchDropdownOptions } from './utils';
+import { DEFAULT_MINIMUM_SEARCHABLE_OPTIONS } from './config';
 import { useFormState } from '../../contexts';
 
 const SelectWidget = <T, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>({
@@ -44,7 +44,8 @@ const SelectWidget = <T, S extends StrictRJSFSchema = RJSFSchema, F extends Form
 		selectAllLabel,
 		maxSelectable
 	} = uiSchema;
-	const { componentSize = EComponentSize.Large, dropdownConfig = DEFAULT_DROPDOWN_CONFIG, allowClearInputs } = formContext as F;
+	const { componentSize = EComponentSize.Large, dropdownConfig: contextDropdownConfig, allowClearInputs } = formContext as F;
+	const dropdownConfig = resolveDropdownConfig(contextDropdownConfig);
 	const [searchTerm, setSearchTerm] = useState<string | null>(null);
 
 	const defaultDropdownOptions = useMemo(

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/config.ts
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/config.ts
@@ -1,5 +1,21 @@
+import type { EIconName } from '@kelvininc/ui-components';
+
 export const DEFAULT_MINIMUM_SEARCHABLE_OPTIONS = 15;
-export const DEFAULT_DROPDOWN_CONFIG = {
+
+export interface IDropdownConfig {
+	zIndex: number;
+	maxHeight: string;
+	minHeight: string;
+	maxWidth: string;
+	minWidth: string;
+	icon?: EIconName;
+}
+
+export const DEFAULT_DROPDOWN_CONFIG: IDropdownConfig = {
+	// Kept in step with `DEFAULT_DROPDOWN_Z_INDEX` from `@kelvininc/ui-components`,
+	// which is re-exported from this package so consumers never hardcode it. It is
+	// duplicated rather than imported so this module stays free of a runtime
+	// dependency on the built web components, which keeps these unit tests hermetic.
 	zIndex: 9004,
 	maxHeight: '400px',
 	minHeight: 'auto',

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/utils.test.ts
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/utils.test.ts
@@ -1,6 +1,8 @@
 import { JSONSchema7 } from 'json-schema';
 import { describe, expect, it } from 'vitest';
-import { buildDropdownOptions, buildSelectedOptions, getSelectedOptions, processValue } from './utils';
+import { buildDropdownOptions, buildSelectedOptions, getSelectedOptions, processValue, resolveDropdownConfig } from './utils';
+import { DEFAULT_DROPDOWN_CONFIG, IDropdownConfig } from './config';
+import { buildHelperOptions } from '../../Templates/FieldTemplate/utils';
 
 describe('buildSelectedOptions', () => {
 	describe('when given an array of selected values', () => {
@@ -156,6 +158,93 @@ describe('buildDropdownOptions', () => {
 			['an object', { a: 1 }]
 		])('should return no options for %s', (_, options) => {
 			expect(buildDropdownOptions({ schema, options })).toEqual({});
+		});
+	});
+});
+
+describe('resolveDropdownConfig', () => {
+	// `const { dropdownConfig = DEFAULT_DROPDOWN_CONFIG } = formContext` only falls
+	// back when the whole config is `undefined`, so any partial config replaced the
+	// defaults wholesale and left `zIndex` undefined. `kv-portal` then wrote the
+	// literal string "undefined" to `style.zIndex`, which the browser discards, and
+	// the dropdown stayed stuck behind the page at the `-1` it was created with.
+	describe('when no config is provided', () => {
+		it('should return every default', () => {
+			expect(resolveDropdownConfig(undefined)).toEqual(DEFAULT_DROPDOWN_CONFIG);
+		});
+
+		it('should return every default for an empty config', () => {
+			expect(resolveDropdownConfig({})).toEqual(DEFAULT_DROPDOWN_CONFIG);
+		});
+	});
+
+	describe('when a partial config is provided', () => {
+		it('should keep the default z-index', () => {
+			expect(resolveDropdownConfig({ minWidth: '240px' }).zIndex).toBe(DEFAULT_DROPDOWN_CONFIG.zIndex);
+		});
+
+		it('should retain all the other defaults', () => {
+			expect(resolveDropdownConfig({ minWidth: '240px' })).toEqual({
+				...DEFAULT_DROPDOWN_CONFIG,
+				minWidth: '240px'
+			});
+		});
+
+		it('should apply the provided override', () => {
+			expect(resolveDropdownConfig({ minWidth: '240px' }).minWidth).toBe('240px');
+		});
+
+		it.each<[keyof IDropdownConfig, string]>([
+			['maxHeight', '400px'],
+			['minHeight', 'auto'],
+			['maxWidth', 'auto'],
+			['minWidth', 'max-content']
+		])('should keep the default %s when only zIndex is overridden', (key, value) => {
+			expect(resolveDropdownConfig({ zIndex: 10 })[key]).toBe(value);
+		});
+	});
+
+	describe('when a config explicitly holds undefined values', () => {
+		it('should not let an undefined override erase a default', () => {
+			expect(resolveDropdownConfig({ zIndex: undefined, minWidth: '240px' }).zIndex).toBe(DEFAULT_DROPDOWN_CONFIG.zIndex);
+		});
+	});
+
+	describe('when the config is fully specified', () => {
+		it('should use every provided value', () => {
+			const config = { zIndex: 10, maxHeight: '10px', minHeight: '1px', maxWidth: '20px', minWidth: '2px' };
+
+			expect(resolveDropdownConfig(config)).toEqual(config);
+		});
+	});
+
+	describe('when it does not mutate its inputs', () => {
+		it('should leave the defaults untouched', () => {
+			resolveDropdownConfig({ zIndex: 10 });
+
+			expect(DEFAULT_DROPDOWN_CONFIG.zIndex).toBe(9004);
+		});
+
+		it('should leave the provided config untouched', () => {
+			const config = { minWidth: '240px' };
+
+			resolveDropdownConfig(config);
+
+			expect(config).toEqual({ minWidth: '240px' });
+		});
+	});
+
+	// The reported failure: one field carries `ui:dropdownConfig: { minWidth: '240px' }`
+	// and a *different* field is a select. FieldTemplate leaked the first field's
+	// options into the shared form context, and the select then resolved its config
+	// from that polluted context.
+	describe('when another field in the same form carries a partial ui:dropdownConfig', () => {
+		it('should still resolve a usable z-index for the select', () => {
+			const formContext: { dropdownConfig?: Record<string, unknown> } = { componentSize: 'large' } as never;
+
+			buildHelperOptions(formContext, { dropdownConfig: { minWidth: '240px' } });
+
+			expect(resolveDropdownConfig(formContext.dropdownConfig).zIndex).toBe(DEFAULT_DROPDOWN_CONFIG.zIndex);
 		});
 	});
 });

--- a/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/utils.ts
+++ b/packages/react-ui-components/src/components/SchemaForm/Widgets/SelectWidget/utils.ts
@@ -1,7 +1,8 @@
 import { asNumber, guessType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
 import { JSONSchema7 } from 'json-schema';
-import { get, isEmpty, isNil, isString } from 'lodash';
+import { get, isEmpty, isNil, isString, merge } from 'lodash';
 import { EnumOptions, IUIDropdownOptions } from './types';
+import { DEFAULT_DROPDOWN_CONFIG, IDropdownConfig } from './config';
 
 const numericTypes = ['number', 'integer'];
 
@@ -102,3 +103,16 @@ export const searchDropdownOptions = (term: string, options: IUIDropdownOptions)
 		return accumulator;
 	}, {});
 };
+
+/**
+ * Layers a form's `dropdownConfig` over the defaults.
+ *
+ * This used to be a destructuring default — `const { dropdownConfig = DEFAULT_DROPDOWN_CONFIG } = formContext`
+ * — which only fires when the whole config is `undefined`. A consumer passing a
+ * partial config such as `{ minWidth: '240px' }` therefore replaced every default
+ * wholesale, leaving `zIndex` undefined; `kv-portal` wrote the string "undefined"
+ * to `style.zIndex`, the browser discarded it, and the dropdown opened invisible
+ * behind the page. Merging keeps a partial config partial. `merge` also ignores
+ * `undefined` source values, so an explicitly-undefined key cannot erase a default.
+ */
+export const resolveDropdownConfig = (dropdownConfig?: Partial<IDropdownConfig>): IDropdownConfig => merge({}, DEFAULT_DROPDOWN_CONFIG, dropdownConfig);

--- a/packages/react-ui-components/src/ui-components.ts
+++ b/packages/react-ui-components/src/ui-components.ts
@@ -31,6 +31,10 @@ export {
 	EToasterType
 } from '@kelvininc/ui-components';
 
+// Export z-index constants, so consumers can layer their own overlays against the
+// library's stacking order instead of hardcoding the values.
+export { DEFAULT_PORTAL_Z_INDEX, DEFAULT_DROPDOWN_Z_INDEX, TOGGLE_TIP_Z_INDEX, TOOLTIP_Z_INDEX } from '@kelvininc/ui-components';
+
 // Export initialize function
 export { initialize } from '@kelvininc/ui-components';
 

--- a/packages/ui-components/src/components/dropdown/dropdown.tsx
+++ b/packages/ui-components/src/components/dropdown/dropdown.tsx
@@ -55,7 +55,15 @@ export class KvDropdown implements IDropdown, IDropdownEvents {
 	};
 
 	componentDidRender() {
-		this._actionElement = this.actionElement ?? this.el.querySelector('#dropdown-input').shadowRoot.querySelector('#dropdown-input');
+		// Only the `actionElement` prop can name an action element here. This used to
+		// fall back to `this.el.querySelector('#dropdown-input').shadowRoot.querySelector('#dropdown-input')`,
+		// which could never match: `kv-text-field` gives its inner `<input>` only a
+		// `name` and `part="input-text"`, never `id="dropdown-input"`. The lookup
+		// always produced `null` and `kv-dropdown-base` silently fell back to its own
+		// `div#dropdown-action` — and when a consumer filled the `dropdown-action`
+		// slot the fallback `kv-text-field` was gone, so the unguarded `.shadowRoot`
+		// threw a `TypeError` on every render.
+		this._actionElement = this.actionElement ?? null;
 	}
 
 	render() {

--- a/packages/ui-components/src/components/portal/portal.tsx
+++ b/packages/ui-components/src/components/portal/portal.tsx
@@ -94,6 +94,23 @@ export class KvPortal implements IPortal, IPortalEvents {
 		this.elementAppend.emit(this.element);
 	}
 
+	/**
+	 * Resolves the z-index to write to the portal element.
+	 *
+	 * `zIndex` is not guaranteed to hold a number by the time it reaches the DOM:
+	 * the React wrapper assigns every prop with `node[name] = newProps[name]`, so a
+	 * consumer passing `undefined` overwrites this component's `@Prop` default. The
+	 * old code wrote `${this.zIndex}` straight through, and `${undefined}` is the
+	 * string "undefined" — invalid CSS, silently discarded by the browser. The
+	 * portal then kept the `-1` that `createPortal()` sets, leaving its content
+	 * correctly positioned but rendered behind the whole page with nothing logged.
+	 */
+	private getZIndex = (): number => {
+		const zIndex = typeof this.zIndex === 'number' ? this.zIndex : Number.parseFloat(this.zIndex);
+
+		return Number.isFinite(zIndex) ? zIndex : PORTAL_Z_INDEX.show;
+	};
+
 	private getPortalArrowElement = (): HTMLElement | null => {
 		return this.element.shadowRoot.querySelector('#portal-arrow') as HTMLElement | null;
 	};
@@ -121,7 +138,7 @@ export class KvPortal implements IPortal, IPortalEvents {
 				const { referenceHidden } = middlewareData.hide;
 				if (this.show) {
 					this.visible = !referenceHidden;
-					this.portal.style.zIndex = referenceHidden ? `${PORTAL_Z_INDEX.hidden}` : `${this.zIndex}`;
+					this.portal.style.zIndex = referenceHidden ? `${PORTAL_Z_INDEX.hidden}` : `${this.getZIndex()}`;
 				}
 			}
 
@@ -154,7 +171,7 @@ export class KvPortal implements IPortal, IPortalEvents {
 	private showPortalContent() {
 		if (!this.portal) return;
 
-		this.portal.style.zIndex = `${this.zIndex}`;
+		this.portal.style.zIndex = `${this.getZIndex()}`;
 		if (this.delay) {
 			this.timeoutId = window.setTimeout(() => {
 				this.visible = true;

--- a/packages/ui-components/src/components/portal/test/portal.spec.tsx
+++ b/packages/ui-components/src/components/portal/test/portal.spec.tsx
@@ -1,0 +1,72 @@
+import { SpecPage } from '@stencil/core/internal';
+import { newSpecPage } from '@stencil/core/testing';
+import { KvPortal } from '../portal';
+import { PORTAL_Z_INDEX } from '../portal.config';
+
+const getPortalElement = (page: SpecPage): HTMLElement => page.doc.getElementById('kv-portal');
+
+describe('Portal (unit tests)', () => {
+	let page: SpecPage;
+
+	const openPortal = async (zIndex: unknown) => {
+		page = await newSpecPage({ components: [KvPortal], html: `<kv-portal></kv-portal>` });
+		// Mirrors what the React wrapper's `attachProps` does: it assigns every prop
+		// with `node[name] = newProps[name]`, so an undefined `zIndex` clobbers the
+		// `@Prop` default instead of leaving it in place.
+		(page.root as unknown as Record<string, unknown>).zIndex = zIndex;
+		(page.root as HTMLKvPortalElement).show = true;
+		await page.waitForChanges();
+	};
+
+	describe('when opened with a valid z-index', () => {
+		beforeEach(() => openPortal(4000));
+
+		it('should apply it to the portal element', () => {
+			expect(getPortalElement(page).style.zIndex).toBe('4000');
+		});
+	});
+
+	describe('when opened with no z-index', () => {
+		beforeEach(() => openPortal(undefined));
+
+		// Writing `${undefined}` produces the string "undefined", which is invalid CSS
+		// and is silently dropped by the browser. The portal then keeps the `-1` that
+		// `createPortal()` set, so the content renders correctly positioned but behind
+		// the whole page, with no error to point at.
+		it('should never write the literal string "undefined"', () => {
+			expect(getPortalElement(page).style.zIndex).not.toBe('undefined');
+		});
+
+		it('should fall back to the default z-index', () => {
+			expect(getPortalElement(page).style.zIndex).toBe(`${PORTAL_Z_INDEX.show}`);
+		});
+
+		it('should not leave the portal behind the page', () => {
+			expect(Number(getPortalElement(page).style.zIndex)).toBeGreaterThan(0);
+		});
+	});
+
+	describe.each([
+		['null', null],
+		['a non numeric string', 'auto'],
+		['NaN', NaN]
+	])('when opened with %s as z-index', (_label, zIndex) => {
+		beforeEach(() => openPortal(zIndex));
+
+		it('should fall back to the default z-index', () => {
+			expect(getPortalElement(page).style.zIndex).toBe(`${PORTAL_Z_INDEX.show}`);
+		});
+	});
+
+	describe('when closed', () => {
+		beforeEach(async () => {
+			await openPortal(undefined);
+			(page.root as HTMLKvPortalElement).show = false;
+			await page.waitForChanges();
+		});
+
+		it('should hide the portal behind the page', () => {
+			expect(getPortalElement(page).style.zIndex).toBe(`${PORTAL_Z_INDEX.hidden}`);
+		});
+	});
+});

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -2,4 +2,5 @@ export type { Components, JSX } from './components';
 export * from './components';
 export * from './types';
 export * from './globals/globals';
+export { DEFAULT_PORTAL_Z_INDEX, DEFAULT_DROPDOWN_Z_INDEX, TOGGLE_TIP_Z_INDEX, TOOLTIP_Z_INDEX } from './globals/config';
 export * from './utils';


### PR DESCRIPTION
## Summary

A `KvSchemaForm` where any single field set `ui:dropdownConfig` opened its select dropdowns **invisible** — correctly positioned and sized, but stuck behind the page at `z-index: -1`.

### Problem

With a dropdown open, its portal `div#kv-portal` sat at `z-index: -1` while `left`/`top`/`width` were all correct, and `zIndex` read `undefined` on `kv-single-select-dropdown`, `kv-dropdown`, `kv-dropdown-base` and `kv-portal` alike. It reproduced intermittently — more often on a cold page load than on a client-side re-render.

### Root cause

Three defects in a chain, each harmless alone:

1. **`FieldTemplate` mutated shared state.** `merge(formContext, uiOptions)` had no `{}` target, so lodash wrote each field's `ui:*` options into `formContext` in place. That object is shared by every field and widget in the form, so one field carrying `ui:dropdownConfig` leaked it into all the others — and whichever field rendered first decided what the rest saw. That render-order dependence is what made the symptom intermittent.
2. **`SelectWidget` replaced instead of merging.** A destructuring default only fires on `undefined`, so once the context was polluted a partial config such as `{ minWidth: '240px' }` replaced every default wholesale and left `zIndex` undefined.
3. **`kv-portal` wrote the value unvalidated.** Writing `undefined` into `style.zIndex` assigns the literal string `"undefined"` — invalid CSS, silently discarded by the browser. The element kept the `-1` that `createPortal()` sets, so the dropdown rendered perfectly but behind the whole page, with no error and nothing logged.

### Fix

Every link is fixed independently, so no single one can reproduce the bug on its own.

## Changes

- **`fix(portal)`** — `showPortalContent()` and `updatePosition()` resolve the value through a new `getZIndex()`, which falls back to the portal default for `undefined`, `null`, `NaN` and non-numeric strings. This also absorbs the React wrapper's `attachProps`, which assigns every prop with `node[name] = newProps[name]` and so clobbers the Stencil `@Prop` default with `undefined`.
- **`fix(schema-form)`** — `FieldTemplate` merges into a fresh `{}` via a new `buildHelperOptions`, leaving `formContext` untouched. `SelectWidget` resolves its config through a new `resolveDropdownConfig`, layering the form's config over the defaults. `merge` is used over a spread so an explicitly-undefined key cannot erase a default either.
- **`feat(globals)`** — exports `DEFAULT_PORTAL_Z_INDEX`, `DEFAULT_DROPDOWN_Z_INDEX`, `TOGGLE_TIP_Z_INDEX` and `TOOLTIP_Z_INDEX` from both packages. They existed in `globals/config` but `index.ts` only re-exported `globals/globals`, so consumers had to hardcode the raw numbers to layer their own overlays.
- **`fix(dropdown)`** — removes an unreachable action-element lookup found while investigating. `this.el.querySelector('#dropdown-input').shadowRoot.querySelector('#dropdown-input')` could never match, because `kv-text-field` gives its inner `<input>` only a `name` and `part="input-text"`. It always returned `null` and `kv-dropdown-base` silently fell back to its own `div#dropdown-action`. The `.shadowRoot` access was also unguarded, so a consumer filling the `dropdown-action` slot made it throw a `TypeError` on every render. Behaviour is unchanged.

An audit for other non-target merges found none: `SchemaForm.tsx` already used `merge({}, …)`, and nothing calls `Object.assign` on `formContext` or `registry`.

## Test Plan

- [x] `pnpm test` — 61 suites, 348 tests, 123 snapshots pass (8 new; no snapshot churn)
- [x] React unit tests — 82 pass, up from 60 (22 new)
- [x] `pnpm lint` — clean across all 3 projects
- [x] `pnpm build:packages` — succeeds; fixes verified present in `dist`

New tests fail against the previous implementation:

- `kv-portal` falls back to the default z-index and never writes the literal string `"undefined"`.
- `buildHelperOptions` leaves `formContext` untouched — object identity, deep equality, key set, nested values, and isolation between consecutive fields.
- `resolveDropdownConfig` keeps every other default when given a partial config, and an explicitly-undefined key cannot erase one.
- A cross-field regression case reproducing the report: one field carries a partial `ui:dropdownConfig`, another is a select, and the select still resolves a usable `zIndex`.

**Manual:** open a `KvSchemaForm` with one field set to `"ui:dropdownConfig": { "minWidth": "240px" }` (no `zIndex`) and a second field of type select. Hard-reload the page and open the select. It should render in front of the form, with `div#kv-portal` at `z-index: 9004`. Before this change it opened at `-1` — correctly positioned but invisible.

## Notes

- The two acceptance criteria phrased around a full form render are covered at the unit level, against the exact functions the render calls, rather than by mounting a real `KvSchemaForm`. `@kelvininc/react-ui-components` has no DOM test environment (no jsdom/happy-dom or testing-library) and its suite is pure-function tests; adding a render harness would mean new devDependencies, so it is left as a follow-up.
- `DEFAULT_DROPDOWN_CONFIG.zIndex` still holds the literal `9004`, now commented and pointing at the newly exported constant, rather than importing it — that keeps those unit tests hermetic instead of requiring a built `dist`.
- Unrelated: root `pnpm test` is scoped to `@kelvininc/ui-components` only, so the React suite — including these new regression tests — never runs in CI.
