### PR TITLE
feat(time-picker): apply relative options on click

### DIFF
--- a/packages/ui-components/src/components/relative-time-picker/readme.md
+++ b/packages/ui-components/src/components/relative-time-picker/readme.md
@@ -47,13 +47,14 @@ export const KvRelativeTimePickerExample: React.FC = () => (
 
 ## Events
 
-| Event                         | Description                                                       | Type                                                      |
-| ----------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------- |
-| `customizeIntervalClicked`    | Emitted when customize interval is clicked                        | `CustomEvent<string>`                                     |
-| `selectedRelativeTimeChange`  | Emitted when the selected time key changes                        | `CustomEvent<{ key: string; range: SelectedTimestamp; }>` |
-| `timezoneChange`              | Emitted when selected timezone changes                            | `CustomEvent<{ name: string; offset: number; }>`          |
-| `timezoneDropdownStateChange` | Emitted when the timezone dropdown open state changes             | `CustomEvent<boolean>`                                    |
-| `timezoneInputClicked`        | Emitted when the input wrapper containing the timezone is clicked | `CustomEvent<boolean>`                                    |
+| Event                         | Description                                                                                                                                                                                                                    | Type                                                      |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| `customizeIntervalClicked`    | Emitted when customize interval is clicked                                                                                                                                                                                     | `CustomEvent<string>`                                     |
+| `relativeTimeOptionClicked`   | Emitted when the user clicks a relative time option. Unlike `selectedRelativeTimeChange`, this fires only on a real click — never from the periodic range refresh — and fires even when the clicked option is already selected | `CustomEvent<{ key: string; range: SelectedTimestamp; }>` |
+| `selectedRelativeTimeChange`  | Emitted when the selected time key changes                                                                                                                                                                                     | `CustomEvent<{ key: string; range: SelectedTimestamp; }>` |
+| `timezoneChange`              | Emitted when selected timezone changes                                                                                                                                                                                         | `CustomEvent<{ name: string; offset: number; }>`          |
+| `timezoneDropdownStateChange` | Emitted when the timezone dropdown open state changes                                                                                                                                                                          | `CustomEvent<boolean>`                                    |
+| `timezoneInputClicked`        | Emitted when the input wrapper containing the timezone is clicked                                                                                                                                                              | `CustomEvent<boolean>`                                    |
 
 
 ## CSS Custom Properties

--- a/packages/ui-components/src/components/relative-time-picker/relative-time-picker.tsx
+++ b/packages/ui-components/src/components/relative-time-picker/relative-time-picker.tsx
@@ -68,6 +68,8 @@ export class KvRelativeTimePicker implements IRelativeTimePicker, IRelativeTimeP
 	/** @inheritdoc */
 	@Event() selectedRelativeTimeChange: EventEmitter<ITimePickerRelativeTime>;
 	/** @inheritdoc */
+	@Event({ bubbles: false }) relativeTimeOptionClicked: EventEmitter<ITimePickerRelativeTime>;
+	/** @inheritdoc */
 	@Event() customizeIntervalClicked: EventEmitter<string>;
 	/** @inheritdoc */
 	@Event() timezoneChange: EventEmitter<ITimePickerTimezone>;
@@ -134,6 +136,9 @@ export class KvRelativeTimePicker implements IRelativeTimePicker, IRelativeTimeP
 
 	private onSelectRelativeOption = ({ detail: newOption }: CustomEvent<string>, range: SelectedTimestamp): void => {
 		this.hasSelectedKeyRangeChanged(range, newOption);
+		// Emitted unconditionally: `hasSelectedKeyRangeChanged` stays silent when neither the key nor the
+		// range moved, but re-clicking the selected option is still a deliberate confirmation.
+		this.relativeTimeOptionClicked.emit({ key: newOption, range });
 	};
 
 	private hasSelectedKeyRangeChanged = (newRange: SelectedTimestamp, optionSelected: string): void => {

--- a/packages/ui-components/src/components/relative-time-picker/relative-time-picker.types.ts
+++ b/packages/ui-components/src/components/relative-time-picker/relative-time-picker.types.ts
@@ -31,6 +31,11 @@ export interface IRelativeTimePicker extends ICustomCss {
 export interface IRelativeTimePickerEvents {
 	/** Emitted when the selected time key changes */
 	selectedRelativeTimeChange: EventEmitter<ITimePickerRelativeTime>;
+	/** Emitted when the user clicks a relative time option. Unlike `selectedRelativeTimeChange`, this fires
+	 * only on a real click — never from the periodic range refresh — and fires even when the clicked option
+	 * is already selected
+	 */
+	relativeTimeOptionClicked: EventEmitter<ITimePickerRelativeTime>;
 	/** Emitted when customize interval is clicked */
 	customizeIntervalClicked: EventEmitter<string>;
 	/** Emitted when selected timezone changes */

--- a/packages/ui-components/src/components/time-picker/test/time-picker.spec.tsx
+++ b/packages/ui-components/src/components/time-picker/test/time-picker.spec.tsx
@@ -7,11 +7,22 @@ import { EAbsoluteTimePickerMode } from '../../absolute-time-picker/absolute-tim
 import { MOCK_RELATIVE_TIME_OPTIONS_GROUPS } from '../../relative-time-picker/test/relative-time-picker.mock';
 import { BOTTOM_OPTIONS_HEIGHT, MAX_HEIGHT, PADDING_SIZE, SELECT_OPTION_HEIGHT } from '../../relative-time-picker/relative-time-picker.config';
 import { CUSTOM_TIME_RANGE_KEY, DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS } from '../../../utils/relative-time';
-import { ITimePickerTimezone } from '../../relative-time-picker/relative-time-picker.types';
+import { ITimePickerRelativeTime, ITimePickerTimezone } from '../../relative-time-picker/relative-time-picker.types';
+import { ETimePickerView, SelectedTimestamp } from '../time-picker.types';
 
 const TIMEZONE: ITimePickerTimezone = { name: 'UTC', offset: 0 };
+const TOKYO_TIMEZONE: ITimePickerTimezone = { name: 'Asia/Tokyo', offset: 540 };
 const FROM = 1681319856833;
 const TO = 1681406272018;
+
+/**
+ * Dispatches the click-intent event on the relative picker. `kv-relative-time-picker` is not registered
+ * in these spec pages, so the event is dispatched directly on its element — a non-bubbling event still
+ * reaches the listener the vdom attached there.
+ */
+const clickRelativeOption = (page: SpecPage, key: string, range: SelectedTimestamp): void => {
+	page.root.querySelector('kv-relative-time-picker').dispatchEvent(new CustomEvent<ITimePickerRelativeTime>('relativeTimeOptionClicked', { detail: { key, range } }));
+};
 
 describe('KvTimePicker (unit tests)', () => {
 	let page: SpecPage;
@@ -43,6 +54,10 @@ describe('KvTimePicker (unit tests)', () => {
 		it('should disable apply for a single date while in range mode', () => {
 			component.selectedTimeState = { key: CUSTOM_TIME_RANGE_KEY, range: [FROM], timezone: TIMEZONE };
 			expect(component['isApplyButtonDisabled']()).toBe(true);
+		});
+
+		it('should not display the apply and cancel actions', () => {
+			expect(page.root.querySelector('.actions')).toBeNull();
 		});
 	});
 
@@ -84,6 +99,10 @@ describe('KvTimePicker (unit tests)', () => {
 			expect(page.root.querySelector('.show-calendar-toggle')).toBeNull();
 		});
 
+		it('should not render the footer at all', () => {
+			expect(page.root.querySelector('.footer')).toBeNull();
+		});
+
 		it('should enable apply for a single custom date', () => {
 			component.selectedTimeState = { key: CUSTOM_TIME_RANGE_KEY, range: [FROM], timezone: TIMEZONE };
 			expect(component['isApplyButtonDisabled']()).toBe(false);
@@ -100,6 +119,112 @@ describe('KvTimePicker (unit tests)', () => {
 			component.selectedTimeState = { key: DEFAULT_SELECTED_TIME_KEY, range: [FROM, TO], timezone: TIMEZONE };
 			expect(component['isApplyButtonDisabled']()).toBe(false);
 		});
+	});
+});
+
+describe('KvTimePicker (option list commits on click)', () => {
+	let page: SpecPage;
+	let component: KvTimePicker;
+	let timeRangeChange: jest.Mock;
+
+	beforeEach(async () => {
+		page = await newSpecPage({
+			components: [KvTimePicker],
+			template: () => <kv-time-picker isOpen={true} />
+		});
+		component = page.rootInstance;
+		timeRangeChange = jest.fn();
+		page.root.addEventListener('timeRangeChange', timeRangeChange);
+	});
+
+	it('should commit the clicked option and close the panel', async () => {
+		clickRelativeOption(page, 'today', [FROM, TO]);
+		await page.waitForChanges();
+
+		expect(timeRangeChange).toHaveBeenCalledTimes(1);
+		expect(timeRangeChange.mock.calls[0][0].detail).toEqual(expect.objectContaining({ key: 'today', range: [FROM, TO] }));
+		expect(component.isOpen).toBe(false);
+	});
+
+	it('should commit again when the already selected option is clicked', async () => {
+		const { key, range } = component.selectedTimeState;
+
+		clickRelativeOption(page, key, range);
+		await page.waitForChanges();
+
+		expect(timeRangeChange).toHaveBeenCalledTimes(1);
+		expect(component.isOpen).toBe(false);
+	});
+
+	// The periodic refresh in kv-relative-time-picker re-emits `selectedRelativeTimeChange` as a
+	// "now"-relative range moves. Committing from it would make an open panel close itself unprompted.
+	it('should not commit from the periodic range refresh', async () => {
+		component['onSelectedRelativeTimeChange']({ detail: { key: DEFAULT_SELECTED_TIME_KEY, range: [FROM, TO] } } as CustomEvent<ITimePickerRelativeTime>);
+		await page.waitForChanges();
+
+		expect(timeRangeChange).not.toHaveBeenCalled();
+		expect(component.isOpen).toBe(true);
+	});
+
+	it('should commit a timezone change without closing the panel', async () => {
+		component['onSelectedTimezoneChange']({ detail: TOKYO_TIMEZONE } as CustomEvent<ITimePickerTimezone>);
+		await page.waitForChanges();
+
+		expect(timeRangeChange).toHaveBeenCalledTimes(1);
+		expect(timeRangeChange.mock.calls[0][0].detail.timezone).toEqual(TOKYO_TIMEZONE);
+		expect(component.isOpen).toBe(true);
+	});
+
+	it('should display the apply and cancel actions once the custom interval is picked', async () => {
+		component['onClickSeeCustomInterval']({ detail: CUSTOM_TIME_RANGE_KEY } as CustomEvent<string>);
+		await page.waitForChanges();
+
+		expect(component.timePickerView).toEqual(ETimePickerView.AbsoluteTimePicker);
+		expect(page.root.querySelector('.actions')).not.toBeNull();
+	});
+});
+
+describe('KvTimePicker (calendar confirms with apply)', () => {
+	let page: SpecPage;
+	let component: KvTimePicker;
+	let timeRangeChange: jest.Mock;
+
+	beforeEach(async () => {
+		page = await newSpecPage({
+			components: [KvTimePicker],
+			template: () => <kv-time-picker isOpen={true} showCalendar={true} />
+		});
+		component = page.rootInstance;
+		timeRangeChange = jest.fn();
+		page.root.addEventListener('timeRangeChange', timeRangeChange);
+	});
+
+	it('should display the apply and cancel actions', () => {
+		expect(component.timePickerView).toEqual(ETimePickerView.FullView);
+		expect(page.root.querySelector('.actions')).not.toBeNull();
+	});
+
+	it('should not commit on option click', async () => {
+		clickRelativeOption(page, 'today', [FROM, TO]);
+		await page.waitForChanges();
+
+		expect(timeRangeChange).not.toHaveBeenCalled();
+		expect(component.isOpen).toBe(true);
+		expect(component.selectedTimeState.key).toEqual(DEFAULT_SELECTED_TIME_KEY);
+	});
+
+	it('should drop a pending calendar range when the calendar is hidden', async () => {
+		component.selectedTimeState = { key: CUSTOM_TIME_RANGE_KEY, range: [FROM, TO], timezone: TIMEZONE };
+		component.calendarViewLocked = true;
+
+		// Driven from the host element so it takes the same path as a consumer updating the prop
+		(page.root as HTMLKvTimePickerElement).showCalendar = false;
+		await page.waitForChanges();
+
+		expect(component.timePickerView).toEqual(ETimePickerView.RelativeTimePicker);
+		expect(component.selectedTimeState.key).toEqual(DEFAULT_SELECTED_TIME_KEY);
+		expect(component.calendarViewLocked).toBe(false);
+		expect(page.root.querySelector('.actions')).toBeNull();
 	});
 });
 

--- a/packages/ui-components/src/components/time-picker/test/time-picker.spec.tsx
+++ b/packages/ui-components/src/components/time-picker/test/time-picker.spec.tsx
@@ -16,12 +16,21 @@ const FROM = 1681319856833;
 const TO = 1681406272018;
 
 /**
- * Dispatches the click-intent event on the relative picker. `kv-relative-time-picker` is not registered
- * in these spec pages, so the event is dispatched directly on its element — a non-bubbling event still
- * reaches the listener the vdom attached there.
+ * Simulates a click on a relative option, mirroring `kv-relative-time-picker.onSelectRelativeOption`:
+ * `selectedRelativeTimeChange` fires only when the key or range actually moved, `relativeTimeOptionClicked`
+ * always does. Pass `changed: false` for a re-click on the option that is already selected.
+ *
+ * `kv-relative-time-picker` is not registered in these spec pages, so the events are dispatched directly
+ * on its element — a non-bubbling event still reaches the listener the vdom attached there.
  */
-const clickRelativeOption = (page: SpecPage, key: string, range: SelectedTimestamp): void => {
-	page.root.querySelector('kv-relative-time-picker').dispatchEvent(new CustomEvent<ITimePickerRelativeTime>('relativeTimeOptionClicked', { detail: { key, range } }));
+const clickRelativeOption = (page: SpecPage, key: string, range: SelectedTimestamp, { changed = true }: { changed?: boolean } = {}): void => {
+	const relativePicker = page.root.querySelector('kv-relative-time-picker');
+
+	if (changed) {
+		relativePicker.dispatchEvent(new CustomEvent<ITimePickerRelativeTime>('selectedRelativeTimeChange', { detail: { key, range } }));
+	}
+
+	relativePicker.dispatchEvent(new CustomEvent<ITimePickerRelativeTime>('relativeTimeOptionClicked', { detail: { key, range } }));
 };
 
 describe('KvTimePicker (unit tests)', () => {
@@ -149,7 +158,7 @@ describe('KvTimePicker (option list commits on click)', () => {
 	it('should commit again when the already selected option is clicked', async () => {
 		const { key, range } = component.selectedTimeState;
 
-		clickRelativeOption(page, key, range);
+		clickRelativeOption(page, key, range, { changed: false });
 		await page.waitForChanges();
 
 		expect(timeRangeChange).toHaveBeenCalledTimes(1);
@@ -184,6 +193,47 @@ describe('KvTimePicker (option list commits on click)', () => {
 	});
 });
 
+describe('KvTimePicker (no option preselected)', () => {
+	let page: SpecPage;
+	let component: KvTimePicker;
+	let timeRangeChange: jest.Mock;
+
+	beforeEach(async () => {
+		// Options omitting the default key leave nothing selected, and the timezone dropdown stays on
+		page = await newSpecPage({
+			components: [KvTimePicker],
+			template: () => <kv-time-picker isOpen={true} relativeTimePickerOptions={MOCK_RELATIVE_TIME_OPTIONS_GROUPS} />
+		});
+		component = page.rootInstance;
+		timeRangeChange = jest.fn();
+		page.root.addEventListener('timeRangeChange', timeRangeChange);
+	});
+
+	// An empty range breaks `ITimePickerTime` and would hand a consumer an unusable range
+	it('should not commit a timezone change while no option is selected', async () => {
+		component['onSelectedTimezoneChange']({ detail: TOKYO_TIMEZONE } as CustomEvent<ITimePickerTimezone>);
+		await page.waitForChanges();
+
+		expect(timeRangeChange).not.toHaveBeenCalled();
+		expect(component.isOpen).toBe(true);
+	});
+
+	it('should keep the timezone as draft so the next option click carries it', async () => {
+		component['onSelectedTimezoneChange']({ detail: TOKYO_TIMEZONE } as CustomEvent<ITimePickerTimezone>);
+		await page.waitForChanges();
+
+		expect(component.selectedTimeState.timezone).toEqual(TOKYO_TIMEZONE);
+
+		const [{ value: key }] = MOCK_RELATIVE_TIME_OPTIONS_GROUPS[0];
+		clickRelativeOption(page, key, [FROM, TO]);
+		await page.waitForChanges();
+
+		expect(timeRangeChange).toHaveBeenCalledTimes(1);
+		expect(timeRangeChange.mock.calls[0][0].detail).toEqual({ key, range: [FROM, TO], timezone: TOKYO_TIMEZONE });
+		expect(component.isOpen).toBe(false);
+	});
+});
+
 describe('KvTimePicker (calendar confirms with apply)', () => {
 	let page: SpecPage;
 	let component: KvTimePicker;
@@ -204,13 +254,15 @@ describe('KvTimePicker (calendar confirms with apply)', () => {
 		expect(page.root.querySelector('.actions')).not.toBeNull();
 	});
 
-	it('should not commit on option click', async () => {
+	it('should not commit on option click, leaving apply to confirm the draft', async () => {
 		clickRelativeOption(page, 'today', [FROM, TO]);
 		await page.waitForChanges();
 
 		expect(timeRangeChange).not.toHaveBeenCalled();
 		expect(component.isOpen).toBe(true);
-		expect(component.selectedTimeState.key).toEqual(DEFAULT_SELECTED_TIME_KEY);
+		// the draft still advances, so apply has something valid to confirm
+		expect(component.selectedTimeState.key).toEqual('today');
+		expect(component['isApplyButtonDisabled']()).toBe(false);
 	});
 
 	it('should drop a pending calendar range when the calendar is hidden', async () => {

--- a/packages/ui-components/src/components/time-picker/time-picker.tsx
+++ b/packages/ui-components/src/components/time-picker/time-picker.tsx
@@ -250,14 +250,17 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 			timezone
 		};
 
-		if (this.isCalendarVisible()) {
-			this.selectedTimeState = timeState;
+		// Committing needs a calendar-free view — there is no Apply button to confirm with — and a
+		// complete selection. When the given options omit the default key nothing is preselected, so the
+		// range can still be empty here, and emitting that would break `ITimePickerTime` and hand a
+		// consumer an unusable range. Either way the panel stays open: the timezone modifies the current
+		// selection rather than being the selection, and is kept as draft until an option makes it valid.
+		if (!this.isCalendarVisible() && validateNewRange(timeState.range, this.getExpectedRangeSize())) {
+			this.emitTimeRangeChange(timeState);
 			return;
 		}
 
-		// There is no Apply button here to confirm with, so commit it — but leave the panel open: the
-		// timezone modifies the current selection rather than being the selection.
-		this.emitTimeRangeChange(timeState);
+		this.selectedTimeState = timeState;
 	};
 
 	/**

--- a/packages/ui-components/src/components/time-picker/time-picker.tsx
+++ b/packages/ui-components/src/components/time-picker/time-picker.tsx
@@ -35,7 +35,7 @@ import {
 import { CALENDAR_DATE_TIME_MASK, DATETIME_INPUT_MASK, DEFAULT_HEADER_TITLE } from '../absolute-time-picker/absolute-time-picker.config';
 import { IRelativeTimeInput, IAbsoluteSelectedRangeDates } from '../absolute-time-picker/absolute-time-picker.types';
 import dayjs from 'dayjs';
-import { CUSTOM_TIME_RANGE_KEY, DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS, getRelativeTimeOption } from '../../utils/relative-time';
+import { CUSTOM_TIME_RANGE_KEY, DEFAULT_RELATIVE_TIME_OPTIONS_GROUPS, buildOptionRange, buildTimestampRange, getRelativeTimeOption } from '../../utils/relative-time';
 
 @Component({
 	tag: 'kv-time-picker',
@@ -109,6 +109,13 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 	@Watch('showCalendar')
 	handleShowCalendarChange(value: boolean) {
 		this.syncShowCalendarViewState(value);
+
+		// Hiding the calendar also hides Apply, so a pending range would be left with no way to confirm it
+		// — and `calendarViewLocked` would stay set, disabling the toggle. Fall back to the committed value.
+		// Order matters: the view is reset first so `undoLastChanges` takes its non-full-view branch.
+		if (!value) {
+			this.undoLastChanges();
+		}
 	}
 
 	componentWillLoad() {
@@ -190,6 +197,10 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 		this.timezoneSelectionContentVisible = false;
 	};
 
+	/**
+	 * Syncs the draft selection. Also fires from `kv-relative-time-picker`'s periodic refresh as a
+	 * "now"-relative range moves, so it must never commit — see `onRelativeTimeOptionClicked`.
+	 */
 	private onSelectedRelativeTimeChange = ({ detail: timeOption }: CustomEvent<ITimePickerRelativeTime>) => {
 		this.selectedTimeState = {
 			key: timeOption.key,
@@ -197,6 +208,23 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 			timezone: this.getSelectedTimezone()
 		};
 		this.calendarViewLocked = false;
+	};
+
+	/**
+	 * A click on a relative option is the confirmation, so it commits and closes — unless a calendar is
+	 * on screen, where Apply confirms instead.
+	 */
+	private onRelativeTimeOptionClicked = ({ detail: timeOption }: CustomEvent<ITimePickerRelativeTime>) => {
+		if (this.isCalendarVisible()) {
+			return;
+		}
+
+		this.calendarViewLocked = false;
+		this.commitTimeState({
+			key: timeOption.key,
+			range: timeOption.range,
+			timezone: this.getSelectedTimezone()
+		});
 	};
 
 	private onClickSeeCustomInterval = ({ detail: key }: CustomEvent<string>) => {
@@ -216,22 +244,51 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 	};
 
 	private onSelectedTimezoneChange = ({ detail: timezone }: CustomEvent<ITimePickerTimezone>) => {
-		const previousTimezone = this.getSelectedTimezone().name;
-		const range =
-			this.selectedTimeState.key === CUSTOM_TIME_RANGE_KEY && this.selectedTimeState?.range?.length > 0
-				? getTimestampFromDateRange(this.selectedTimeState.range, previousTimezone, timezone.name)
-				: this.selectedTimeState.range;
-
-		this.selectedTimeState = {
+		const timeState: ITimePickerTimeState = {
 			...this.selectedTimeState,
-			range,
+			range: this.getRangeInTimezone(timezone),
 			timezone
 		};
+
+		if (this.isCalendarVisible()) {
+			this.selectedTimeState = timeState;
+			return;
+		}
+
+		// There is no Apply button here to confirm with, so commit it — but leave the panel open: the
+		// timezone modifies the current selection rather than being the selection.
+		this.emitTimeRangeChange(timeState);
+	};
+
+	/**
+	 * Re-anchors the selected range to a newly picked timezone. A custom interval keeps its wall-clock
+	 * dates; a relative option is recomputed from its definition so its boundaries land in the new zone.
+	 */
+	private getRangeInTimezone = (timezone: ITimePickerTimezone): SelectedTimestamp => {
+		const { key, range } = this.selectedTimeState;
+
+		if (key === CUSTOM_TIME_RANGE_KEY) {
+			return range?.length > 0 ? getTimestampFromDateRange(range, this.getSelectedTimezone().name, timezone.name) : range;
+		}
+
+		const option = getRelativeTimeOption(key, this.relativeTimePickerOptions);
+		return option !== undefined ? buildTimestampRange(buildOptionRange(option, timezone.name)) : range;
 	};
 
 	private onClickApply = () => {
-		const eventPayload = getTimePickerEventPayload(this.selectedTimeState, this.getSelectedTimezone());
-		this.timeRangeChange.emit(eventPayload);
+		this.commitTimeState(this.selectedTimeState);
+	};
+
+	/** Publishes a selection without dismissing the panel */
+	private emitTimeRangeChange = (timeState: ITimePickerTimeState) => {
+		// Assigned first so `getSelectedTimezone` resolves against the state being emitted
+		this.selectedTimeState = timeState;
+		this.timeRangeChange.emit(getTimePickerEventPayload(timeState, this.getSelectedTimezone()));
+	};
+
+	/** Publishes a selection and dismisses the panel */
+	private commitTimeState = (timeState: ITimePickerTimeState) => {
+		this.emitTimeRangeChange(timeState);
 		this.dropdownStateChange.emit(false);
 		this.isOpen = false;
 		this.timezoneSelectionContentVisible = false;
@@ -321,6 +378,23 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 	};
 
 	// Components config methods
+
+	/**
+	 * Apply/Cancel exist to confirm a calendar selection, where a half-picked range is not yet a valid
+	 * choice. In the plain option list the click is itself the confirmation, so they are dropped.
+	 */
+	private isCalendarVisible = (): boolean => {
+		return this.timePickerView !== ETimePickerView.RelativeTimePicker;
+	};
+
+	private isCalendarToggleVisible = (): boolean => {
+		return this.displayCalendarToggle && this.timePickerView !== ETimePickerView.AbsoluteTimePicker;
+	};
+
+	private isFooterVisible = (): boolean => {
+		return this.isCalendarToggleVisible() || this.isCalendarVisible();
+	};
+
 	private isSingleCustomInterval = (): boolean => {
 		return this.calendarMode === EAbsoluteTimePickerMode.Single && this.selectedTimeState?.key === CUSTOM_TIME_RANGE_KEY;
 	};
@@ -465,6 +539,7 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 									disableTimezoneSelection={this.disableTimezoneSelection}
 									onCustomizeIntervalClicked={this.onClickSeeCustomInterval}
 									onSelectedRelativeTimeChange={this.onSelectedRelativeTimeChange}
+									onRelativeTimeOptionClicked={this.onRelativeTimeOptionClicked}
 									onTimezoneChange={this.onSelectedTimezoneChange}
 									onTimezoneInputClicked={this.displayInputWrapperContent}
 									onTimezoneDropdownStateChange={this.onInternalDropdownsStateChange}
@@ -492,33 +567,38 @@ export class KvTimePicker implements ITimePicker, ITimePickerEvents {
 								/>
 							</div>
 						</div>
-						<div class="footer">
-							<div class="toggle-wrapper">
-								{this.displayCalendarToggle && this.timePickerView !== ETimePickerView.AbsoluteTimePicker && (
-									<div class="show-calendar-toggle">
-										<kv-switch-button
-											checked={this.showCalendar}
-											size={EComponentSize.Small}
-											onClick={this.onShowCalendarClick}
-											disabled={this.calendarViewLocked}
-										/>
-										<div class="toggle-text">Show Calendar</div>
+						{this.isFooterVisible() && (
+							<div class="footer">
+								{/* Always rendered so `space-between` keeps the actions right-aligned when the toggle is hidden */}
+								<div class="toggle-wrapper">
+									{this.isCalendarToggleVisible() && (
+										<div class="show-calendar-toggle">
+											<kv-switch-button
+												checked={this.showCalendar}
+												size={EComponentSize.Small}
+												onClick={this.onShowCalendarClick}
+												disabled={this.calendarViewLocked}
+											/>
+											<div class="toggle-text">Show Calendar</div>
+										</div>
+									)}
+								</div>
+								{this.isCalendarVisible() && (
+									<div class="actions">
+										<kv-action-button-text type={EActionButtonType.Secondary} size={EComponentSize.Small} text="Cancel" onClickButton={this.onClickCancel} />
+										<kv-tooltip text={this.getApplyButtonTooltipText()} position={ETooltipPosition.TopStart}>
+											<kv-action-button-text
+												type={EActionButtonType.Primary}
+												size={EComponentSize.Small}
+												text="Apply"
+												disabled={this.isApplyButtonDisabled()}
+												onClickButton={this.onClickApply}
+											/>
+										</kv-tooltip>
 									</div>
 								)}
 							</div>
-							<div class="actions">
-								<kv-action-button-text type={EActionButtonType.Secondary} size={EComponentSize.Small} text="Cancel" onClickButton={this.onClickCancel} />
-								<kv-tooltip text={this.getApplyButtonTooltipText()} position={ETooltipPosition.TopStart}>
-									<kv-action-button-text
-										type={EActionButtonType.Primary}
-										size={EComponentSize.Small}
-										text="Apply"
-										disabled={this.isApplyButtonDisabled()}
-										onClickButton={this.onClickApply}
-									/>
-								</kv-tooltip>
-							</div>
-						</div>
+						)}
 					</div>
 				</kv-dropdown>
 			</Host>


### PR DESCRIPTION
## Summary

`kv-time-picker` required a second press on **Apply** to commit a selection picked from the dropdown list. That confirmation earns its keep in the calendar, where a half-picked range is not yet a valid selection, but it is pure friction in the plain option list where the click is itself the decision.

Apply and Cancel now render only while a calendar is on screen — `showCalendar` on, or **Custom Interval** picked. In the option list a click commits and closes, matching `kv-single-select-dropdown` and every other dropdown in the library.

> [!NOTE]
> **Behaviour change, not an API change.** `timeRangeChange` keeps its name and its `ITimePickerTime` payload, and still fires once per selection — only earlier, on the click instead of on Apply. Consumers need no code change, so this is a minor, not a major.
>
> What does change downstream is anything driving the old two-step flow: automation or e2e tests that press **Apply** in the option list will no longer find the button, and `cancelClicked` is no longer reachable from that view (dismissal still reports `dropdownStateChange(false)`). Nothing in this repo consumes `kv-time-picker` internally.

## Changes

- **`feat(time-picker)`** — Apply/Cancel visibility is derived from the view rather than always rendered: `isCalendarVisible()` is `timePickerView !== RelativeTimePicker`, which covers exactly the two calendar cases (`showCalendar` → `FullView`, Custom Interval → `AbsoluteTimePicker`). No new prop.
- **`feat(time-picker)`** — `onClickApply` is split into `emitTimeRangeChange` (publish) and `commitTimeState` (publish + dismiss), so the new click path reuses the existing Apply behaviour instead of duplicating it. The Apply payload is unchanged.
- **`feat(relative-time-picker)`** — new `relativeTimeOptionClicked` event, emitted only from the click handler. This is the crux: `selectedRelativeTimeChange` is *also* re-emitted from the component's 10-second `setInterval` as a "now"-relative range moves (`hasRangeChanged` compares with seconds zeroed), so committing from it would have made an open panel commit and close itself roughly once a minute. The new event mirrors the existing `customizeIntervalClicked` intent-event pattern, and fires even when the clicked option is already selected so a re-click still confirms.
- **`feat(time-picker)`** — a timezone change in the option list commits without closing the panel, since no Apply is left to confirm it. The range is re-anchored to the new timezone by reusing `getRelativeTimeOption` + `buildOptionRange`/`buildTimestampRange`, so a boundary-based option like **Today** shifts correctly.
- **`fix(time-picker)`** — hiding the calendar now discards a pending range via `undoLastChanges`, which would otherwise be stranded with no Apply to commit it and would leave `calendarViewLocked` set, disabling the toggle.
- **`fix(time-picker)`** — the footer is dropped entirely when it would hold neither the toggle nor the actions (`displayCalendarToggle={false}` in the option list), instead of leaving an empty bordered, padded bar.
- **`test(time-picker)`** — 14 new specs, including a regression guard asserting that `onSelectedRelativeTimeChange` alone (the periodic-refresh path) emits nothing and leaves the panel open.

`packages/ui-components/src/components/relative-time-picker/readme.md` is regenerated by the build. No enum was added, so `packages/react-ui-components/src/ui-components.ts` needs no change, and the React binding picks the event up through the generated JSX types.

## Test Plan

- [x] `pnpm build:packages` — exit 0, no errors
- [x] `pnpm test` — 421 specs pass, 123 snapshots pass
- [x] `pnpm lint` — clean
- [x] Manual verification in Storybook (Chromium, no console errors)

**Manual steps** — `pnpm storybook`, then **Time Picker → Time Picker**, watching the Actions panel:

1. **DefaultState** — the footer shows only *Show Calendar*, no Apply/Cancel. Click *Last 7 days*: exactly one `timeRangeChange` (`key: last-7-d`), then `dropdownStateChange(false)`, panel closed, input reads "Last 7 days". Re-open and click the **already selected** option — it still commits and closes.
2. **Leave the panel open for ~2 minutes without touching it.** It must not emit or close itself. The periodic refresh is observably alive during this (the *Today* row's description advances with the clock), which is exactly the regression the new intent event prevents.
3. Toggle **Show Calendar** on — Apply/Cancel appear and option clicks stop auto-committing (Apply becomes enabled); Apply still commits and closes. Toggle it back off — the buttons disappear and the toggle stays enabled.
4. Click **Custom Interval** (calendar off) — the calendar slides in with Cancel and a correctly-disabled Apply, and no toggle. **Back** returns to the option list with the buttons gone.
5. Change the **timezone** in the option list — `timeRangeChange` fires and the panel *stays open*. Switching between two zones on **Today** shows the range re-anchor (e.g. `Pacific/Honolulu` → `2026-09-08T10:00Z`, `Europe/Lisbon` → `2026-09-07T23:00Z`).
6. **FutureDurations** (`displayCalendarToggle: false`, `displayTimezoneDropdown: false`) — no footer bar at all; clicking a duration commits and closes.

> Run the suite with `pnpm test` rather than a bare `stencil test`: the package script sets `TZ=UTC`, without which 9 pre-existing timezone-sensitive specs in `date.spec` / `relative-time.spec` fail independently of this change.
